### PR TITLE
Fix: PA missing S2 center lat/long on weather hook

### DIFF
--- a/utils/webhookHelper.py
+++ b/utils/webhookHelper.py
@@ -58,7 +58,9 @@ weather_webhook_payload = """[{{
                 "alert_severity": {3},
                 "warn": {4},
                 "day": {5},
-                "time_changed": {6}
+                "time_changed": {6},
+                "latitude": {7},
+                "longitude": {8}
         }},
       "type": "weather"
    }} ]"""
@@ -366,13 +368,17 @@ class WebhookHelper(object):
         if self.__application_args.weather_webhook:
             log.debug("Send Weather Webhook")
 
+            ll = CellId(s2cellId).to_lat_lng()
+            latitude = ll.lat().degrees
+            longitude = ll.lng().degrees
+
             cell = Cell(CellId(s2cellId))
             coords = []
             for v in range(0, 4):
                 vertex = LatLng.from_point(cell.get_vertex(v))
                 coords.append([vertex.lat().degrees, vertex.lng().degrees])
 
-            data = weather_webhook_payload.format(s2cellId, coords, weatherId, severe, warn, day, time)
+            data = weather_webhook_payload.format(s2cellId, coords, weatherId, severe, warn, day, time, latitude, longitude)
 
             log.debug(data)
             payload = json.loads(data)


### PR DESCRIPTION
PokeAlarm is expecting to receive the “latitude” and “longitude” of the center of the S2 cell when receiving weather updates

MAD with webhook plus weather enabled does not send that information and instead sends "coord" containing the 4 corners of the S2 cell which isn’t treated by PokeAlarm resulting in the following error:

```2018-12-18 17:26:55,437 [ERROR][  external][    Events] Encountered error while converting webhook data(KeyError: 'latitude')
2018-12-18 17:26:55,438 [DEBUG][  external][    Events] Stack trace: 
 Traceback (most recent call last):
  File "/home/PokeAlarm/PokeAlarm/Events/__init__.py", line 33, in event_factory
    return WeatherEvent(message)
  File "/home/PokeAlarm/PokeAlarm/Events/WeatherEvent.py", line 21, in __init__
    self.lat = float(data['latitude'])  # To the center of the cell
KeyError: 'latitude'
```
This commit simply adds the latitude and longitude as required by PokeAlarm to function properly.

NOTE: Although unused by PokeAlarm, I left "coords" untouched since I have no idea if another webhook app makes use of it and I don't want to break compatibility.