### PR TITLE
Gym Hook Fixes

### DIFF
--- a/utils/webhookHelper.py
+++ b/utils/webhookHelper.py
@@ -83,7 +83,9 @@ gym_webhook_payload = """[{{
   "message": {{
     "raid_active_until": {raid_active_until},
     "gym_id": "{gym_id}",
-    "gym_name": "{gym_name}",
+    "name": "{gym_name}",
+    "description": "{gym_description}",
+    "url": "{gym_url}",
     "team_id": {team_id},
     "slots_available": {slots_available},
     "guard_pokemon_id": {guard_pokemon_id},
@@ -209,14 +211,22 @@ class WebhookHelper(object):
     async def _send_gym_webhook(self, gym_id, raid_active_until, gym_name, team_id,
                                 slots_available, guard_pokemon_id, latitude, longitude):
         info_of_gym = self.gyminfo.get(gym_id, None)
+        gym_url = 'unknown'
+        gym_description = 'unknown'
         if info_of_gym is not None and gym_name == 'unknown':
             name = info_of_gym.get("name", "unknown")
             gym_name = name.replace("\\", r"\\").replace('"', '')
+            gym_description = info_of_gym.get('description', 'unknown')\
+                .replace('\\' r'\\').replace('"', '')
+            gym_url = info_of_gym.get('url', 'unknown')\
+                .replace('\\' r'\\').replace('"', '')
 
         payload_raw = gym_webhook_payload.format(
             raid_active_until=raid_active_until,
             gym_id=gym_id,
             gym_name=gym_name,
+            gym_description=gym_description,
+            gym_url=gym_url,
             team_id=team_id,
             slots_available=slots_available,
             guard_pokemon_id=guard_pokemon_id,


### PR DESCRIPTION
PA gym change hooks expects specific field names, so:
`gym_name` -> `name` so that it lines up with PA
Add description and url fields as well, both of which come from `gym_info.json`

***This needs tested***
I don't have a working version of MAD atm