### PR TITLE
Dynamically reload settings from mappings.json

### DIFF
--- a/start.py
+++ b/start.py
@@ -235,6 +235,10 @@ if __name__ == "__main__":
             except KeyError as e:
                 log.fatal("Could not parse mappings. Please check those. Description: %s" % str(e))
                 sys.exit(1)
+            except RuntimeError as e:
+                log.fatal("There is something wrong with your mappings. Description: %s" % str(e))
+                sys.exit(1)
+
 
             mitm_mapper = MitmMapper(device_mappings)
             ocr_enabled = False

--- a/utils/mappingParser.py
+++ b/utils/mappingParser.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import sys
 from pathlib import Path
 
 from geofence.geofenceHelper import GeofenceHelper
@@ -58,15 +57,13 @@ class MappingParser(object):
 
             geofence_included = Path(area["geofence_included"])
             if not geofence_included.is_file():
-                log.error("Geofence included file configured does not exist")
-                sys.exit(1)
+                raise RuntimeError("Geofence included file configured does not exist")
 
             geofence_excluded_raw_path = area.get("geofence_excluded", None)
             if geofence_excluded_raw_path is not None:
                 geofence_excluded = Path(geofence_excluded_raw_path)
                 if not geofence_excluded.is_file():
-                    log.error("Geofence excluded specified but does not exist")
-                    sys.exit(1)
+                    raise RuntimeError("Geofence excluded file is specified but does not exist")
 
             area_dict = {"mode": area["mode"],
                          "geofence_included": area["geofence_included"],
@@ -116,8 +113,7 @@ class MappingParser(object):
                                                 settings=area.get("settings", None)
                                                 )
             else:
-                log.error("Invalid mode found in mapping parser.")
-                sys.exit(1)
+                raise RuntimeError("Invalid mode found in mapping parser.")
 
             if not mode == "iv_mitm":
                 if mode == "raids_ocr" or area.get("init", False) is False:

--- a/websocket/WebsocketServer.py
+++ b/websocket/WebsocketServer.py
@@ -11,8 +11,6 @@ from threading import Lock, Event, Thread
 
 from utils.authHelper import check_auth
 from utils.madGlobals import WebsocketWorkerRemovedException, WebsocketWorkerTimeoutException
-from utils.mappingParser import MappingParser
-from mitm_receiver.MitmMapper import MitmMapper
 from worker.WorkerMITM import WorkerMITM
 from worker.WorkerQuests import WorkerQuests
 from utils.timer import Timer
@@ -58,7 +56,6 @@ class WebsocketServer(object):
 
         log.info("Device mappings: %s" % str(self.__device_mappings))
         log.info("Allowed origins derived: %s" % str(allowed_origins))
-
         asyncio.set_event_loop(self.__loop)
         asyncio.get_event_loop().run_until_complete(
             websockets.serve(self.handler, self.__listen_address, self.__listen_port, max_size=2 ** 25,

--- a/websocket/WebsocketServer.py
+++ b/websocket/WebsocketServer.py
@@ -2,8 +2,6 @@ import math
 import queue
 import asyncio
 import sys
-import time
-import os
 
 import websockets
 import logging
@@ -60,11 +58,6 @@ class WebsocketServer(object):
 
         log.info("Device mappings: %s" % str(self.__device_mappings))
         log.info("Allowed origins derived: %s" % str(allowed_origins))
-
-        log.info("Starting file watcher for mappings.json changes.")
-        t_file_watcher = Thread(name='file_watcher', target=self.__file_watcher)
-        t_file_watcher.daemon = False
-        t_file_watcher.start()
 
         asyncio.set_event_loop(self.__loop)
         asyncio.get_event_loop().run_until_complete(
@@ -385,44 +378,10 @@ class WebsocketServer(object):
         self.__requests.pop(message_id)
         self.__requests_mutex.release()
 
-    def __file_watcher(self):
-        # We're on a 60-second timer.
-        refresh_time_sec = 60
-        filename = 'configs/mappings.json'
-
-        while True:
-            # Wait (x-1) seconds before refresh, min. 1s.
-            time.sleep(max(1, refresh_time_sec - 1))
-            try:
-                # Only refresh if the file has changed.
-                current_time_sec = time.time()
-                file_modified_time_sec = os.path.getmtime(filename)
-                time_diff_sec = current_time_sec - file_modified_time_sec
-
-                # File has changed in the last refresh_time_sec seconds.
-                if time_diff_sec < refresh_time_sec:
-                    log.info(
-                        'Change found in %s. Updating device mappings.', filename)
-                    self.__reload_mappings()
-                    log.info('Propagating new mappings to all clients.')
-                    self.__update_clients()
-                else:
-                    log.debug('No change found in %s.', filename)
-            except Exception as e:
-                log.exception('Exception occurred while updating device mappings: %s.', e)
-
-    def __reload_mappings(self):
-        mapping_parser = MappingParser(self.__db_wrapper)
-        device_mappings = mapping_parser.get_devicemappings()
-        routemanagers = mapping_parser.get_routemanagers()
-        auths = mapping_parser.get_auths()
-        mitm_mapper = MitmMapper(device_mappings)
+    def update_settings(self, routemanagers, device_mappings, auths):
         self.__device_mappings = device_mappings
         self.__routemanagers = routemanagers
         self.__auths = auths
-        self.__mitm_mapper = mitm_mapper
-
-    def __update_clients(self):
         for id, worker in self.__current_users.items():
             log.info('Stopping worker %s to apply new mappings.', id)
             worker[1].stop_worker()


### PR DESCRIPTION
This PR adds the functionality to dynamically update the settings for all workers on-the-fly when the mappings.json file has changed.

This enables easy editing of the settings and mappings in MADmin without the need for restarting the whole process to use the new ones.