### PR TITLE
Add missing info about what pokemon to evolve if the task requires it

### DIFF
--- a/locale/quest.pot
+++ b/locale/quest.pot
@@ -93,6 +93,9 @@ msgstr ""
 msgid "Evolve {0} Pokemon."
 msgstr ""
 
+msgid "Evolve {0} {poke}."
+msgstr ""
+
 msgid "Use an item to evolve a Pokemon."
 msgstr ""
 

--- a/utils/questGen.py
+++ b/utils/questGen.py
@@ -159,8 +159,26 @@ def questtask(typeid, condition, target):
         text = _('Power up Pokemon {0} times.')
     elif typeid == 15:
         text = _("Evolve {0} Pokemon.")
-        if re.search(r"'type': 11",condition) is not None:
+        if re.search(r"'type': 11", condition) is not None:
             text = _("Use an item to evolve a Pokemon.")
+        elif re.search(r"'type': 2", condition) is not None:
+            arr['wb'] = ""
+            arr['type'] = ""
+            arr['poke'] = ""
+
+            match_object = re.search(r"'pokemon_ids': \[([0-9, ]+)\]", condition)
+            if match_object is not None:
+                pt = match_object.group(1).split(', ')
+                last = len(pt)
+                cur = 1
+                if last == 1:
+                    arr['poke'] = i8ln(pokemonname(pt[0]))
+                else:
+                    for ty in pt:
+                        arr['poke'] += (_('or ') if last == cur else '') + i8ln(pokemonname(ty)) + (
+                            '' if last == cur else ', ')
+                        cur += 1
+                text = _('Evolve {0} {poke}.')
     elif typeid == 16:
         arr['inrow'] = ""
         arr['curve'] = ""


### PR DESCRIPTION
Event task "evolve a meowth" is interpreted as "evolve a pokemon" in MAD - fixed to add in "evolve {0} {poke}" if a research task is about evolving specific species. Hopefully not breaking anything with existing "evolve pokemon"/"us an item to evolve"