### PR TITLE
Add only_routes mode

### DIFF
--- a/start.py
+++ b/start.py
@@ -243,7 +243,7 @@ if __name__ == "__main__":
                   "-oo     ---- start OCR analysis of screenshots\nExiting")
         sys.exit(1)
 
-    if args.only_scan:
+    if args.only_scan or args.only_routes:
         
         filename = os.path.join('configs', 'mappings.json')
         if not os.path.exists(filename):
@@ -264,6 +264,10 @@ if __name__ == "__main__":
             except RuntimeError as e:
                 log.fatal("There is something wrong with your mappings. Description: %s" % str(e))
                 sys.exit(1)
+
+            if args.only_routes:
+                log.info("Done calculating routes!")
+                sys.exit(0)
 
             pogoWindowManager = PogoWindows(args.temp_path)
             mitm_mapper = MitmMapper(device_mappings)

--- a/start.py
+++ b/start.py
@@ -236,11 +236,12 @@ if __name__ == "__main__":
         log.info('Raidscreen directory created')
         os.makedirs(args.raidscreen_path)
 
-    if not args.only_scan and not args.with_madmin and not args.only_ocr:
-        log.error("No runmode selected. \nAllowed modes: "
-                  " -wm    ---- start madmin (browserbased monitoring/configuration) "
-                  " -os    ---- start scanner/devicecontroller "
-                  "-oo     ---- start OCR analysis of screenshots\nExiting")
+    if not args.only_scan and not args.with_madmin and not args.only_ocr and not args.only_routes:
+        log.error("No runmode selected. \nAllowed modes:\n"
+                  " -wm    ---- start madmin (browserbased monitoring/configuration)\n"
+                  " -os    ---- start scanner/devicecontroller\n"
+                  " -oo    ---- start OCR analysis of screenshots\n"
+                  " -or    ---- only calculate routes\nExiting")
         sys.exit(1)
 
     if args.only_scan or args.only_routes:

--- a/utils/walkerArgs.py
+++ b/utils/walkerArgs.py
@@ -90,6 +90,8 @@ def parseArgs():
                         help='Amount of threads/processes to be used for screenshot-analysis.')
     parser.add_argument('-wm', '--with_madmin', action='store_true', default=False,
                         help='Start madmin as instance.')
+    parser.add_argument('-or', '--only_routes', action='store_true', default=False,
+                        help='Only calculate routes, then exit the program. No scanning.')
 
     # folder
     parser.add_argument('-tmp', '--temp_path', default='temp',


### PR DESCRIPTION
Quick implementation of `-or` / `--only_routes` mode, which will calculate missing route files while being able to keep your working instance running alongside it, as requested on Discord every couple of days.

Usually, calculating a complicated route at the beginning of the program causes a downtime. Running with -or separately will avoid this and shouldn't collide with the main instance in any way.

It's implemented as just a `sys.exit(0)` at the appropriate location in `start.py` when `-or` is set. 