### PR TITLE
Add dynamic rarity information for pokemon in webhook

### DIFF
--- a/configs/config.ini.example
+++ b/configs/config.ini.example
@@ -92,6 +92,12 @@ pogoasset:                   # Path to Pogo Assets: See: https://github.com/ZeCh
 #gym_webhook                 # Activate support for gym webhook (NOT required for raids!)
 #quest_webhook               # Activate support for quest webhook
 
+# Dynamic Rarity
+######################
+
+#rarity_hours:               # Set the number of hours for the calculation of pokemon rarity (Default: 72)
+#rarity_update_frequency:    # Update frequency for dynamic rarity in minutes (Default: 60)
+
 # Auto Hatch
 ######################
 #auto_hatch                  # Activate auto hatch of level 5 eggs

--- a/db/dbWrapperBase.py
+++ b/db/dbWrapperBase.py
@@ -320,6 +320,13 @@ class DbWrapperBase(ABC):
         pass
 
     @abstractmethod
+    def get_pokemon_spawns(self, hours):
+        """
+        Get Pokemon Spawns for dynamic rarity
+        """
+        pass
+
+    @abstractmethod
     def submit_weather_map_proto(self, origin, map_proto, received_timestamp):
         """
         Update/Insert weather from a map_proto dict

--- a/db/monocleWrapper.py
+++ b/db/monocleWrapper.py
@@ -6,7 +6,9 @@ import requests
 
 from db.dbWrapperBase import DbWrapperBase
 import logging
+import calendar
 from datetime import datetime, timedelta
+from functools import reduce
 
 from utils.collections import Location
 from utils.s2Helper import S2Helper
@@ -1177,3 +1179,21 @@ class MonocleWrapper(DbWrapperBase):
         now = datetime.utcfromtimestamp(time.time()).strftime("%Y-%m-%d %H:%M:%S")
 
         return name, image[0], now, stop_data['latitude'], stop_data['longitude'], stop_data['fort_id']
+
+    def get_pokemon_spawns(self, hours):
+        log.debug('Fetching pokemon spawns from db')
+        query_where = ''
+        if hours:
+            zero = datetime.datetime.now()
+            hours = calendar.timegm(zero.timetuple()) - hours*60*60
+            query_where = ' where expire_timestamp > %s ' % str(hours)
+
+        query = (
+            "SELECT pokemon_id, count(pokemon_id) from sightings %s group by pokemon_id" % str(query_where)
+        )
+
+        res = self.execute(query)
+
+        total = reduce(lambda x, y: x + y[1], res, 0)
+
+        return {'pokemon': res, 'total': total}

--- a/start.py
+++ b/start.py
@@ -273,7 +273,6 @@ if __name__ == "__main__":
                 log.fatal("There is something wrong with your mappings. Description: %s" % str(e))
                 sys.exit(1)
 
-
             if args.only_routes:
                 log.info("Done calculating routes!")
                 sys.exit(0)

--- a/start.py
+++ b/start.py
@@ -20,6 +20,7 @@ from utils.walkerArgs import parseArgs
 from utils.webhookHelper import WebhookHelper
 from utils.version import MADVersion
 from websocket.WebsocketServer import WebsocketServer
+from utils.rarity import Rarity
 
 from ocr.pogoWindows import PogoWindows
 
@@ -222,6 +223,9 @@ if __name__ == "__main__":
     db_wrapper.create_status_database_if_not_exists()
     version = MADVersion(args, db_wrapper)
     version.get_version()
+    rarity = Rarity(args, db_wrapper)
+    rarity.start_dynamic_rarity()
+    webhook_helper.set_rarity(rarity)
 
     if not db_wrapper.ensure_last_updated_column():
         log.fatal("Missing raids.last_updated column and couldn't create it")

--- a/utils/rarity.py
+++ b/utils/rarity.py
@@ -68,8 +68,7 @@ class Rarity(object):
             time.sleep(refresh_time_sec)
 
     def rarity_by_id(self, pokemonid):
-
-        if id in self._rarity:
+        if pokemonid in self._rarity:
             return self._rarity[pokemonid]
         else:
             return "New Spawn"

--- a/utils/rarity.py
+++ b/utils/rarity.py
@@ -1,0 +1,75 @@
+import logging
+import time
+from timeit import default_timer
+from threading import Thread
+
+log = logging.getLogger(__name__)
+
+
+class Rarity(object):
+    def __init__(self, args):
+        self.args = args
+        self._dbwrapper = None
+        self._rarity = {}
+
+    def get_pokemon_rarity(self, total_spawns_all, total_spawns_pokemon):
+        spawn_group = 'Common'
+
+        spawn_rate_pct = total_spawns_pokemon / float(total_spawns_all)
+        spawn_rate_pct = round(100 * spawn_rate_pct, 4)
+
+        if spawn_rate_pct == 0:
+            spawn_group = 'New Spawn'
+        elif spawn_rate_pct < 0.01:
+            spawn_group = 'Ultra Rare'
+        elif spawn_rate_pct < 0.03:
+            spawn_group = 'Very Rare'
+        elif spawn_rate_pct < 0.5:
+            spawn_group = 'Rare'
+        elif spawn_rate_pct < 1:
+            spawn_group = 'Uncommon'
+
+        return spawn_group
+
+    def start_dynamic_rarity(self, dbwrapper):
+        self._dbwrapper = dbwrapper
+        t = Thread(target=self.dynamic_rarity_refresher,
+                   name='dynamic_rarity')
+        t.daemon = False
+        t.start()
+
+    def dynamic_rarity_refresher(self):
+
+        hours = self.args.rarity_hours
+        update_frequency_mins = self.args.rarity_update_frequency
+        refresh_time_sec = update_frequency_mins * 60
+
+        while True:
+            log.info('Updating dynamic rarity...')
+
+            start = default_timer()
+            db_rarities = self._dbwrapper.get_pokemon_spawns(hours)
+            log.debug('Pokemon Rarity: %s' % (str(db_rarities)))
+            total = db_rarities['total']
+            pokemon = db_rarities['pokemon']
+
+            # Store as an easy lookup table for front-end.
+
+            for poke in pokemon:
+                self._rarity[poke[0]] = self.get_pokemon_rarity(total, int(poke[1]))
+
+            duration = default_timer() - start
+            log.info('Updated dynamic rarity. It took %.2fs for %d entries.',
+                     duration,
+                     total)
+
+            log.debug('Waiting %d minutes before next dynamic rarity update.',
+                      refresh_time_sec / 60)
+            time.sleep(refresh_time_sec)
+
+    def rarity_by_id(self, pokemonid):
+
+        if id in self._rarity:
+            return self._rarity[pokemonid]
+        else:
+            return "New Spawn"

--- a/utils/rarity.py
+++ b/utils/rarity.py
@@ -7,32 +7,32 @@ log = logging.getLogger(__name__)
 
 
 class Rarity(object):
-    def __init__(self, args):
+    def __init__(self, args, dbwrapper):
         self.args = args
-        self._dbwrapper = None
+        self._dbwrapper = dbwrapper
         self._rarity = {}
 
     def get_pokemon_rarity(self, total_spawns_all, total_spawns_pokemon):
-        spawn_group = 'Common'
+        spawn_group = 1
 
         spawn_rate_pct = total_spawns_pokemon / float(total_spawns_all)
         spawn_rate_pct = round(100 * spawn_rate_pct, 4)
 
         if spawn_rate_pct == 0:
-            spawn_group = 'New Spawn'
+            spawn_group = 0
         elif spawn_rate_pct < 0.01:
-            spawn_group = 'Ultra Rare'
+            spawn_group = 5
         elif spawn_rate_pct < 0.03:
-            spawn_group = 'Very Rare'
+            spawn_group = 4
         elif spawn_rate_pct < 0.5:
-            spawn_group = 'Rare'
+            spawn_group = 3
         elif spawn_rate_pct < 1:
-            spawn_group = 'Uncommon'
+            spawn_group = 2
 
         return spawn_group
 
-    def start_dynamic_rarity(self, dbwrapper):
-        self._dbwrapper = dbwrapper
+    def start_dynamic_rarity(self):
+
         t = Thread(target=self.dynamic_rarity_refresher,
                    name='dynamic_rarity')
         t.daemon = False
@@ -49,7 +49,7 @@ class Rarity(object):
 
             start = default_timer()
             db_rarities = self._dbwrapper.get_pokemon_spawns(hours)
-            log.debug('Pokemon Rarity: %s' % (str(db_rarities)))
+            log.info('Pokemon Rarity: %s' % (str(db_rarities)))
             total = db_rarities['total']
             pokemon = db_rarities['pokemon']
 
@@ -71,4 +71,4 @@ class Rarity(object):
         if pokemonid in self._rarity:
             return self._rarity[pokemonid]
         else:
-            return "New Spawn"
+            return 0

--- a/utils/walkerArgs.py
+++ b/utils/walkerArgs.py
@@ -148,6 +148,12 @@ def parseArgs():
     parser.add_argument('-chd', '--clean_hash_database', action='store_true', default=False,
                         help='Cleanup the hashing database.')
 
+    # rarity
+    parser.add_argument('-rh', '--rarity_hours', type=int, default=72,
+                        help='Set the number of hours for the calculation of pokemon rarity (Default: 72)')
+    parser.add_argument('-ruf', '--rarity_update_frequency', type=int, default=60,
+                        help='Update frequency for dynamic rarity in minutes (Default: 60)')
+
     # webhook
     parser.add_argument('-wh', '--webhook', action='store_true', default=False,
                         help='Activate webhook support')

--- a/utils/webhookHelper.py
+++ b/utils/webhookHelper.py
@@ -506,8 +506,8 @@ class WebhookHelper(object):
             mon_payload["boosted_weather"] = boosted_weather
 
         if pokemon_rarity_name is not None:
-            mon_payload["rarity"] = pokemon_rarity_name
-            mon_payload["rarity_id"] = pokemon_rarity_id
+            mon_payload["rarity"] = pokemon_rarity_id
+            # mon_payload["rarity_id"] = pokemon_rarity_id
 
         entire_payload = {"type": "pokemon", "message": mon_payload}
         to_be_sent = json.dumps(entire_payload, indent=4, sort_keys=True)

--- a/utils/webhookHelper.py
+++ b/utils/webhookHelper.py
@@ -234,7 +234,7 @@ class WebhookHelper(object):
                              move_1=None, move_2=None, height=None, weight=None, gender=None, boosted_weather=None):
         if self.__application_args.webhook and self.__application_args.pokemon_webhook:
             # Get Pokemon Rarity
-            pokemon_rarity = Rarity.rarity_by_id(pokemon_id)
+            pokemon_rarity = self.rarity.rarity_by_id(pokemonid=pokemon_id)
             self.__add_task_to_loop(self._submit_pokemon_webhook(encounter_id=encounter_id, pokemon_id=pokemon_id,
                                                                  last_modified_time=last_modified_time,
                                                                  spawnpoint_id=spawnpoint_id, lat=lat, lon=lon,

--- a/utils/webhookHelper.py
+++ b/utils/webhookHelper.py
@@ -233,8 +233,6 @@ class WebhookHelper(object):
                              individual_attack=None, individual_defense=None, individual_stamina=None,
                              move_1=None, move_2=None, height=None, weight=None, gender=None, boosted_weather=None):
         if self.__application_args.webhook and self.__application_args.pokemon_webhook:
-            # Get Pokemon Rarity
-            pokemon_rarity = self.rarity.rarity_by_id(pokemonid=pokemon_id)
             self.__add_task_to_loop(self._submit_pokemon_webhook(encounter_id=encounter_id, pokemon_id=pokemon_id,
                                                                  last_modified_time=last_modified_time,
                                                                  spawnpoint_id=spawnpoint_id, lat=lat, lon=lon,
@@ -247,8 +245,7 @@ class WebhookHelper(object):
                                                                  individual_stamina=individual_stamina,
                                                                  move_1=move_1, move_2=move_2,
                                                                  height=height, weight=weight, gender=gender,
-                                                                 boosted_weather=boosted_weather,
-                                                                 rarity=pokemon_rarity)
+                                                                 boosted_weather=boosted_weather)
                                     )
 
     def submit_quest_webhook(self, rawquest):
@@ -457,8 +454,11 @@ class WebhookHelper(object):
                                       pokemon_level=None, cp_multiplier=None, form=None, cp=None,
                                       individual_attack=None, individual_defense=None, individual_stamina=None,
                                       move_1=None, move_2=None, height=None, weight=None, gender=None,
-                                      boosted_weather=None, rarity=None):
-        log.info('Sending Pokemon %s (#%s) to webhook', pokemon_id, id)
+                                      boosted_weather=None):
+        log.info('Sending Pokemon %s to webhook', pokemon_id)
+        # Get Pokemon Rarity
+        pokemon_rarity_name = self.rarity.rarity_by_id(pokemonid=pokemon_id)
+        pokemon_rarity_id = rarity_list[str(pokemon_rarity_name)]
 
         mon_payload = {"encounter_id": encounter_id, "pokemon_id": pokemon_id, "last_modified_time": last_modified_time,
                        "spawnpoint_id": spawnpoint_id, "latitude": lat, "longitude": lon,
@@ -505,8 +505,9 @@ class WebhookHelper(object):
         if boosted_weather is not None:
             mon_payload["boosted_weather"] = boosted_weather
 
-        if rarity is not None:
-            mon_payload["rarity"] = rarity
+        if pokemon_rarity_name is not None:
+            mon_payload["rarity"] = pokemon_rarity_name
+            mon_payload["rarity_id"] = pokemon_rarity_id
 
         entire_payload = {"type": "pokemon", "message": mon_payload}
         to_be_sent = json.dumps(entire_payload, indent=4, sort_keys=True)


### PR DESCRIPTION
Sending rarity id in webhook.

rarity_list = {'New Spawn': 0, 'Common': 1, 'Uncommon': 2, 'Rare': 3, 'Very Rare': 4, 'Ultra Rare': 5}

See:
https://github.com/PokeAlarm/PokeAlarm/pull/649

This adds two dts - rarity_id and rarity.

Examples:
without encounter
[{"message": {"boosted_weather": 4, "disappear_time": 1551558726, "encounter_id": "6843967737754651027", "form": 0, "gender": 1, "last_modified_time": 1551556489, "latitude": 00.7293243709125, "longitude": 00.222932807639868, "pokemon_id": 23, **"rarity": 1**, "spawnpoint_id": 0021735363315, "time_until_hidden_ms": 2237}, "type": "pokemon"}]

with encounter
[{"message": {"boosted_weather": 0, "cp": 1189, "cp_multiplier": 0.6941436529159546, "disappear_time": 1551558125.0, "encounter_id": 12694692075012318237, "form": 0, "gender": 1, "height": 1.5707002878189087, "individual_attack": 8, "individual_defense": 8, "individual_stamina": 7, "last_modified_time": 1551556572, "latitude": 00.730262926909475, "longitude": 00.175345730512138, "move_1": 202, "move_2": 26, "pokemon_id": 206, "pokemon_level": 26.99989241506408, **"rarity": 3,** "spawnpoint_id":0021734801151, "time_until_hidden_ms": 1553.0, "weight": 16.634532928466797}, "type": "pokemon"}]

@LegitDongo :)