### PR TITLE
Fix Quest Webhook

### DIFF
--- a/db/dbWrapperBase.py
+++ b/db/dbWrapperBase.py
@@ -854,6 +854,7 @@ class DbWrapperBase(ABC):
         if 'challenge_quest' not in map_proto:
             return False
         quest_type = map_proto['challenge_quest']['quest'].get("quest_type", None)
+        quest_template = map_proto['challenge_quest']['quest'].get("template_id", None)
         if map_proto['challenge_quest']['quest'].get("quest_rewards", None):
             rewardtype = map_proto['challenge_quest']['quest']['quest_rewards'][0].get("type", None)
             reward = map_proto['challenge_quest']['quest'].get("quest_rewards", None)
@@ -864,23 +865,23 @@ class DbWrapperBase(ABC):
                 "pokemon_id", None)
             target = map_proto['challenge_quest']['quest']['goal'].get("target", None)
             condition = map_proto['challenge_quest']['quest']['goal'].get("condition", None)
-            
+
             task = questtask(int(quest_type), str(condition), int(target))
 
             query_quests = (
-                "INSERT into trs_quest (GUID, quest_type, quest_timestamp, quest_stardust, quest_pokemon_id, "
+                "INSERT INTO trs_quest (GUID, quest_type, quest_timestamp, quest_stardust, quest_pokemon_id, "
                 "quest_reward_type, quest_item_id, quest_item_amount, quest_target, quest_condition, quest_reward, "
-                "quest_task) values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"
+                "quest_task, quest_template) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"
                 "ON DUPLICATE KEY UPDATE quest_type=VALUES(quest_type), quest_timestamp=VALUES(quest_timestamp), "
                 "quest_stardust=VALUES(quest_stardust), quest_pokemon_id=VALUES(quest_pokemon_id), "
                 "quest_reward_type=VALUES(quest_reward_type), quest_item_id=VALUES(quest_item_id), "
                 "quest_item_amount=VALUES(quest_item_amount), quest_target=VALUES(quest_target), "
                 "quest_condition=VALUES(quest_condition), quest_reward=VALUES(quest_reward), "
-                "quest_task=VALUES(quest_task)"
+                "quest_task=VALUES(quest_task), quest_template=VALUES(quest_template)"
             )
             vals = (
                 fort_id, quest_type, time.time(), stardust, pokemon_id, rewardtype, item, itemamount, target,
-                str(condition), str(reward), task
+                str(condition), str(reward), task, quest_template
             )
             log.debug("{DbWrapperBase::submit_quest_proto} submitted quest typ %s at stop %s" % (
                 str(quest_type), str(fort_id)))

--- a/db/monocleWrapper.py
+++ b/db/monocleWrapper.py
@@ -1101,7 +1101,7 @@ class MonocleWrapper(DbWrapperBase):
                 to_return[i][1] = list_of_coords[i][1]
             return to_return
 
-    def quests_from_db(self, GUID = False):
+    def quests_from_db(self, GUID=False):
         log.debug("{MonocleWrapper::quests_from_db} called")
         questinfo = {}
 
@@ -1111,7 +1111,7 @@ class MonocleWrapper(DbWrapperBase):
                 "trs_quest.quest_stardust, trs_quest.quest_pokemon_id, trs_quest.quest_reward_type, "
                 "trs_quest.quest_item_id, trs_quest.quest_item_amount, "
                 "pokestops.name, pokestops.url, trs_quest.quest_target, trs_quest.quest_condition, "
-                "trs_quest.quest_timestamp,trs_quest.quest_task "
+                "trs_quest.quest_timestamp, trs_quest.quest_task, trs_quest.quest_template "
                 "FROM pokestops inner join trs_quest on "
                 "pokestops.external_id = trs_quest.GUID where "
                 "DATE(from_unixtime(trs_quest.quest_timestamp,'%Y-%m-%d')) = CURDATE()"
@@ -1123,7 +1123,7 @@ class MonocleWrapper(DbWrapperBase):
                 "trs_quest.quest_stardust, trs_quest.quest_pokemon_id, trs_quest.quest_reward_type, "
                 "trs_quest.quest_item_id, trs_quest.quest_item_amount, "
                 "pokestops.name, pokestops.url, trs_quest.quest_target, trs_quest.quest_condition, "
-                "trs_quest.quest_timestamp,trs_quest.quest_task "
+                "trs_quest.quest_timestamp, trs_quest.quest_task, trs_quest.quest_template "
                 "FROM pokestops inner join trs_quest on "
                 "pokestops.external_id = trs_quest.GUID where "
                 "DATE(from_unixtime(trs_quest.quest_timestamp,'%Y-%m-%d')) = CURDATE() and "
@@ -1135,7 +1135,7 @@ class MonocleWrapper(DbWrapperBase):
 
         for (pokestop_id, latitude, longitude, quest_type, quest_stardust, quest_pokemon_id, quest_reward_type,
              quest_item_id, quest_item_amount, name, image, quest_target, quest_condition,
-             quest_timestamp, quest_task) in res:
+             quest_timestamp, quest_task, quest_template) in res:
             mon = "%03d" % quest_pokemon_id
             questinfo[pokestop_id] = ({
                 'pokestop_id': pokestop_id, 'latitude': latitude, 'longitude': longitude,
@@ -1145,7 +1145,7 @@ class MonocleWrapper(DbWrapperBase):
                 'quest_item_amount': quest_item_amount, 'name': name, 'image': image,
                 'quest_target': quest_target,
                 'quest_condition': quest_condition, 'quest_timestamp': quest_timestamp,
-                'task': quest_task})
+                'task': quest_task, 'quest_template': quest_template})
         return questinfo
         
     def submit_pokestops_details_map_proto(self, map_proto):

--- a/db/rmWrapper.py
+++ b/db/rmWrapper.py
@@ -1160,7 +1160,7 @@ class RmWrapper(DbWrapperBase):
                 to_return[i][1] = list_of_coords[i][1]
             return to_return
 
-    def quests_from_db(self, GUID = False):
+    def quests_from_db(self, GUID=False):
         log.debug("{RmWrapper::quests_from_db} called")
         questinfo = {}
 
@@ -1170,7 +1170,7 @@ class RmWrapper(DbWrapperBase):
                 "trs_quest.quest_stardust, trs_quest.quest_pokemon_id, trs_quest.quest_reward_type, "
                 "trs_quest.quest_item_id, trs_quest.quest_item_amount, "
                 "pokestop.name, pokestop.image, trs_quest.quest_target, trs_quest.quest_condition, "
-                "trs_quest.quest_timestamp, trs_quest.quest_task "
+                "trs_quest.quest_timestamp, trs_quest.quest_task, trs_quest.quest_template "
                 "FROM pokestop inner join trs_quest on "
                 "pokestop.pokestop_id = trs_quest.GUID where "
                 "DATE(from_unixtime(trs_quest.quest_timestamp,'%Y-%m-%d')) = CURDATE()"
@@ -1182,7 +1182,7 @@ class RmWrapper(DbWrapperBase):
                 "trs_quest.quest_stardust, trs_quest.quest_pokemon_id, trs_quest.quest_reward_type, "
                 "trs_quest.quest_item_id, trs_quest.quest_item_amount, "
                 "pokestop.name, pokestop.image, trs_quest.quest_target, trs_quest.quest_condition, "
-                "trs_quest.quest_timestamp, trs_quest.quest_task "
+                "trs_quest.quest_timestamp, trs_quest.quest_task, trs_quest.quest_template "
                 "FROM pokestop inner join trs_quest on "
                 "pokestop.pokestop_id = trs_quest.GUID where "
                 "DATE(from_unixtime(trs_quest.quest_timestamp,'%Y-%m-%d')) = CURDATE() and "
@@ -1194,7 +1194,7 @@ class RmWrapper(DbWrapperBase):
 
         for (pokestop_id, latitude, longitude, quest_type, quest_stardust, quest_pokemon_id, quest_reward_type,
              quest_item_id, quest_item_amount, name, image, quest_target, quest_condition,
-             quest_timestamp, quest_task) in res:
+             quest_timestamp, quest_task, quest_template) in res:
             mon = "%03d" % quest_pokemon_id
             questinfo[pokestop_id] = ({
                 'pokestop_id': pokestop_id, 'latitude': latitude, 'longitude': longitude,
@@ -1204,7 +1204,7 @@ class RmWrapper(DbWrapperBase):
                 'quest_item_amount': quest_item_amount, 'name': name, 'image': image,
                 'quest_target': quest_target,
                 'quest_condition': quest_condition, 'quest_timestamp': quest_timestamp,
-                'task': quest_task})
+                'task': quest_task, 'quest_template': quest_template})
         return questinfo
 
     def submit_pokestops_details_map_proto(self, map_proto):

--- a/utils/questGen.py
+++ b/utils/questGen.py
@@ -14,55 +14,58 @@ log = logging.getLogger(__name__)
 
 
 def generate_quest(quest):
-    
     gettext.find('quest', 'locales', all=True)
     lang = gettext.translation('quest', localedir='locale', fallback=True)
     lang.install()
-    
-    pokestop_id  = (quest['pokestop_id'])
-    quest_reward_type = (questreward(quest['quest_reward_type']))
-    quest_reward_type_raw = quest['quest_reward_type']
-    quest_type_raw = quest['quest_type']
-    quest_type = (questtype(quest['quest_type']))
-    quest_condition = quest['quest_condition']
-    name = quest['name']
-    latitude = quest['latitude']
-    longitude = quest['longitude']
-    url = quest['image']
-    timestamp = quest['quest_timestamp']
-    quest_target = str(quest['quest_target'])
-    
-    if quest_reward_type == _("Item"):
-        item_amount = str(quest['quest_item_amount'])
-        item_id = quest['quest_item_id']
-        item_type = str(rewarditem(quest['quest_item_id']))
-        pokemon_id = "0"
-        pokemon_name = ""
-    elif quest_reward_type == _("Stardust"):
-        item_amount = str(quest['quest_stardust'])
-        item_type = _("Stardust")
-        item_id = "000"
-        pokemon_id = "0"
-        pokemon_name = ""
-    elif quest_reward_type == _("Pokemon"):
-        item_amount = "1"
-        item_type = "Pokemon"
-        item_id = "000"
-        pokemon_name = i8ln(pokemonname(str(quest['quest_pokemon_id'])))
-        pokemon_id = str(quest['quest_pokemon_id'])
+
+    quest_reward_type = questreward(quest['quest_reward_type'])
+    quest_type = questtype(quest['quest_type'])
     if '{0}' in quest_type:
-        quest_type_text = quest_type.replace('{0}', quest_target)            
+        quest_type_text = quest_type.replace('{0}', str(quest['quest_target']))
+
+    item_id = 0
+    item_amount = 1
+    pokemon_id = '000'
+    pokemon_name = ''
+
+    if quest_reward_type == _('Item'):
+        item_amount = quest['quest_item_amount']
+        item_type = rewarditem(quest['quest_item_id'])
+        item_id = quest['quest_item_id']
+    elif quest_reward_type == _('Stardust'):
+        item_amount = quest['quest_stardust']
+        item_type = _('Stardust')
+    elif quest_reward_type == _('Pokemon'):
+        item_type = 'Pokemon'
+        pokemon_name = i8ln(pokemonname(str(quest['quest_pokemon_id'])))
+        pokemon_id = quest['quest_pokemon_id']
 
     if not quest['task']:
         quest_task = questtask(quest['quest_type'], quest['quest_condition'], quest['quest_target'])
     else:
         quest_task = quest['task']
-        
-    quest_raw = ({'pokestop_id': pokestop_id, 'latitude': latitude, 'longitude': longitude, 
-        'quest_type_raw': quest_type_raw, 'quest_type': quest_type_text, 'quest_condition': quest_condition, 'item_amount': item_amount, 'item_type': item_type, 
-        'quest_target': quest_target, 'name': name, 'url': url, 'timestamp': timestamp, 'pokemon_id': pokemon_id, 'item_id': item_id,
-        'pokemon_name': pokemon_name, 'quest_reward_type': quest_reward_type, 'quest_reward_type_raw': quest_reward_type_raw, 'quest_task': quest_task,
-        'quest_condition': quest_condition})
+
+    quest_raw = ({
+        'pokestop_id': quest['pokestop_id'],
+        'name': quest['name'],
+        'url': quest['image'],
+        'latitude': quest['latitude'],
+        'longitude': quest['longitude'],
+        'timestamp': quest['quest_timestamp'],
+        'item_id': item_id,
+        'item_amount': item_amount,
+        'item_type': item_type,
+        'pokemon_id': pokemon_id,
+        'pokemon_name': pokemon_name,
+        'quest_type': quest_type_text,
+        'quest_type_raw': quest['quest_type'],
+        'quest_reward_type': quest_reward_type,
+        'quest_reward_type_raw': quest['quest_reward_type'],
+        'quest_task': quest_task,
+        'quest_target': quest['quest_target'],
+        'quest_condition': quest['quest_condition'],
+        'quest_template': quest['quest_template']
+    })
     return quest_raw
     
 def questreward(quest_reward_type):

--- a/utils/questGen.py
+++ b/utils/questGen.py
@@ -21,7 +21,7 @@ def generate_quest(quest):
     quest_reward_type = questreward(quest['quest_reward_type'])
     quest_type = questtype(quest['quest_type'])
     if '{0}' in quest_type:
-        quest_type_text = quest_type.replace('{0}', str(quest['quest_target']))
+        quest_type = quest_type.replace('{0}', str(quest['quest_target']))
 
     item_id = 0
     item_amount = 1
@@ -57,7 +57,7 @@ def generate_quest(quest):
         'item_type': item_type,
         'pokemon_id': pokemon_id,
         'pokemon_name': pokemon_name,
-        'quest_type': quest_type_text,
+        'quest_type': quest_type,
         'quest_type_raw': quest['quest_type'],
         'quest_reward_type': quest_reward_type,
         'quest_reward_type_raw': quest['quest_reward_type'],

--- a/utils/version.py
+++ b/utils/version.py
@@ -5,7 +5,7 @@ import sys
 
 log = logging.getLogger(__name__)
 
-current_version = 6
+current_version = 7
 
 
 class MADVersion(object):
@@ -207,6 +207,17 @@ class MADVersion(object):
                             self._dbwrapper.execute(alter_query, commit=True)
                         except Exception as e:
                             log.info("Unexpected error: %s" % e)
+
+            if self._version < 7:
+                alter_query = (
+                    "ALTER TABLE trs_quest "
+                    "ADD quest_template VARCHAR(100) NULL DEFAULT NULL "
+                    "AFTER quest_reward"
+                )
+                try:
+                    self._dbwrapper.execute(alter_query, commit=True)
+                except Exception as e:
+                    log.info("Unexpected error: %s" % e)
 
         self.set_version(current_version)
 

--- a/utils/webhookHelper.py
+++ b/utils/webhookHelper.py
@@ -58,22 +58,22 @@ egg_webhook_payload = """[{{
 quest_webhook_payload = """[{{
       "message": {{
                 "pokestop_id": "{pokestop_id}",
-                "latitude": "{latitude}",
-                "longitude": "{longitude}",
+                "latitude": {latitude},
+                "longitude": {longitude},
                 "quest_type": "{quest_type}",
-                "quest_type_raw": "{quest_type_raw}",
+                "quest_type_raw": {quest_type_raw},
                 "item_type": "{item_type}",
-                "item_amount": "{item_amount}",
-                "item_id": "{item_id}",
-                "pokemon_id": "{pokemon_id}",
+                "item_amount": {item_amount},
+                "item_id": {item_id},
+                "pokemon_id": {pokemon_id},
                 "name": "{name}",
                 "url": "{url}",
-                "timestamp": "{timestamp}",
+                "timestamp": {timestamp},
                 "quest_reward_type": "{quest_reward_type}",
-                "quest_reward_type_raw": "{quest_reward_type_raw}",
-                "quest_target": "{quest_target}",
+                "quest_reward_type_raw": {quest_reward_type_raw},
+                "quest_target": {quest_target},
                 "quest_task": "{quest_task}",
-                "quest_condition": "{quest_condition}"
+                "quest_condition": {quest_condition}
         }},
       "type": "quest"
    }} ]"""
@@ -163,8 +163,13 @@ class WebhookHelper(object):
         for webhook in webhooks:
             url = webhook.strip()
 
+            if 'bookofquests' in url and 'quest_type' not in payload[0]['message']:
+                log.debug("Do not send non-quest webhook to bookofquests")
+                return
+
             log.debug("Sending to webhook %s", url)
-            log.debug("Payload: %s" % str(payload))
+            log.debug("Payload: %s" % json.dumps(payload))
+
             try:
                 response = requests.post(
                     url, data=json.dumps(payload),
@@ -520,12 +525,12 @@ class WebhookHelper(object):
             quest_reward_type=quest['quest_reward_type'],
             quest_reward_type_raw=quest['quest_reward_type_raw'],
             quest_target=quest['quest_target'],
-            pokemon_id=quest['pokemon_id'],
+            pokemon_id=int(quest['pokemon_id']),
             item_amount=quest['item_amount'],
             item_id=quest['item_id'],
             quest_task=quest['quest_task'],
-            quest_condition=quest['quest_condition'])
+            quest_condition=quest['quest_condition'].replace('\'', '"').lower(),
+            quest_template=quest['quest_template'])
 
         payload = json.loads(data)
         self.__sendToWebhook(payload)
-


### PR DESCRIPTION
Currently, the quest webhook sends some data that is mostly not well processable by e.g. BookOfQuests.

After some discussions with the guy from BoQ, we found a solution to make the current quest webhook messages compatible.

Changes:
- also store and deliver `quest_template`
- include all non-string values correctly (int, float, json)
- fix the condition to be valid json

__As usual from my side: untested as it is__

_(I also have some changes in my own code base that enables compatibility with PokeAlarm dev, but this is not included here.)_