### PR TITLE
Don't show OCR options in madmin if not running OCR

### DIFF
--- a/madmin/madmin.py
+++ b/madmin/madmin.py
@@ -100,7 +100,7 @@ def screens():
 @app.route('/', methods=['GET'])
 @auth_required
 def root():
-    return render_template('index.html')
+    return render_template('index.html', running_ocr=(conf_args.only_ocr))
 
 
 @app.route('/raids', methods=['GET'])

--- a/madmin/templates/base.html
+++ b/madmin/templates/base.html
@@ -47,6 +47,7 @@
                   <li class="nav-item">
                     <a href="/status" class="nav-link">Status</a>
                   </li>
+                  {% if running_ocr %}
                   <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         OCR Settings
@@ -58,6 +59,7 @@
                       <a href="/screens" class="dropdown-item">Processed Screens</a>
                     </div>
                   </li>
+                  {% endif %}
               </ul>
           </div>
         </div>

--- a/madmin/templates/index.html
+++ b/madmin/templates/index.html
@@ -12,9 +12,11 @@
     <h3><a href="/quests">Quests</a></h3>
     <h3><a href="/showsettings">Mapping Editor</a></h3>    
     <h3><a href="/status">Status</a></h3>
+    {% if running_ocr %}
     <br />    
     <h3><a href="/raids">Check Raids</a></h3>
     <h3><a href="/gyms">Check Gyms</a></h3>
     <h3><a href="/unknown">Check Unknown Gyms</a></h3>
     <h3><a href="/screens">Processed Screens</a></h3>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
I mean all the URLs are still active and there probably should be some checks/wider approach, but at least for now we can just stop showing links and confusing people while not running (gyms) ocr :-)