### PR TITLE
Fix webhook for pokemon level

### DIFF
--- a/db/monocleWrapper.py
+++ b/db/monocleWrapper.py
@@ -575,7 +575,7 @@ class MonocleWrapper(DbWrapperBase):
         else:
             pokemon_level = 171.0112688 * pokemon_data.get("cp_multiplier") - 95.20425243
 
-            pokemon_level = round(pokemon_level) * 2 / 2
+        pokemon_level = round(pokemon_level) * 2 / 2
 
         pokemon_display = pokemon_data.get("display")
         if pokemon_display is None:

--- a/db/rmWrapper.py
+++ b/db/rmWrapper.py
@@ -711,7 +711,7 @@ class RmWrapper(DbWrapperBase):
         else:
             pokemon_level = 171.0112688 * pokemon_data.get("cp_multiplier") - 95.20425243
 
-            pokemon_level = round(pokemon_level) * 2 / 2
+        pokemon_level = round(pokemon_level) * 2 / 2
 
         log.debug("Sending webhook")
         self.webhook_helper.send_pokemon_webhook(


### PR DESCRIPTION
Pokemon_level send via webhook is incorrect in it's current state:

`[webhook_asyncio_loop][ webhookHelper][   DEBUG] Payload: [{'message': {'boosted_weather': 4, 'cp': 187, 'cp_multiplier': 0.3210875988006592, 'disappear_time': 1551948704.0, 'encounter_id': 5030221358137761118, 'form': 0, 'gender': 2, 'height': 0.7585014700889587, 'individual_attack': 7, 'individual_defense': 8, 'individual_stamina': 6, 'last_modified_time': 1551948421, 'latitude': XXXX, 'longitude': YYY, 'move_1': 208, 'move_2': 123, 'pokemon_id': 66, 'pokemon_level': 5.958580290952411, 'spawnpoint_id': '47b2566327b', 'time_until_hidden_ms': 283.0, 'weight': 15.229364395141602}, 'type': 'pokemon'}]`