### PR TITLE
Webhook URL extension for every type of webhook

### DIFF
--- a/configs/config.ini.example
+++ b/configs/config.ini.example
@@ -86,7 +86,7 @@ pogoasset:                   # Path to Pogo Assets: See: https://github.com/ZeCh
 ######################
 
 #webhook                     # Activate support for webhook
-#webhook_url:                # URL endpoint/s for webhooks (seperated by commas) - urls have to start with http*
+#webhook_url:                # URL endpoint/s for webhooks (seperated by commas) with [<type>] for restriction like [mon|weather|raid]http://example.org/foo/bar - urls have to start with http*
 #webhook_submit_exraids      # Send Ex-raids to the webhook if detected
 #weather_webhook             # Activate support for weather webhook
 #pokemon_webhook             # Activate support for pokemon webhook

--- a/utils/walkerArgs.py
+++ b/utils/walkerArgs.py
@@ -152,7 +152,7 @@ def parseArgs():
     parser.add_argument('-wh', '--webhook', action='store_true', default=False,
                         help='Activate webhook support')
     parser.add_argument('-whurl', '--webhook_url', default='',
-                        help='URL endpoint/s for webhooks (seperated by commas) - urls have to start with http*')
+                        help='URL endpoint/s for webhooks (seperated by commas) with [<type>] for restriction like [mon|weather|raid]http://example.org/foo/bar - urls have to start with http*')
     parser.add_argument('-pwh', '--pokemon_webhook', action='store_true', default=False,
                         help='Activate pokemon webhook support')
     parser.add_argument('-wwh', '--weather_webhook', action='store_true', default=False,

--- a/webhook/webhookworker.py
+++ b/webhook/webhookworker.py
@@ -36,6 +36,8 @@ class WebhookWorker:
             log.info("Payload empty. Skip sending to webhook.")
             return
 
+        payloadToSend = []
+
         # get list of urls
         webhooks = self._args.webhook_url.replace(" ", "").split(",")
 
@@ -43,12 +45,24 @@ class WebhookWorker:
             # url cleanup
             url = webhook.strip()
 
+            if url.startswith("["):
+                endIndex = webhook.rindex("]")
+                endIndex += 1
+                subTypes = webhook[:endIndex]
+
+                for payloadData in payload:
+                    if payloadData["type"] in subTypes
+                        payloadToSend.append(payloadData)
+            else
+                payloadToSend = payload
+
+
             log.debug("Sending to webhook %s", url)
-            log.debug("Payload: %s" % str(payload))
+            log.debug("Payload: %s" % str(payloadToSend))
             try:
                 response = requests.post(
                     url,
-                    data=json.dumps(payload),
+                    data=json.dumps(payloadToSend),
                     headers={"Content-Type": "application/json"},
                     timeout=5,
                 )
@@ -60,7 +74,7 @@ class WebhookWorker:
                 else:
                     log.info(
                         "Successfully sent payload to webhook. Stats: %s",
-                        json.dumps(self.__payload_type_count(payload)),
+                        json.dumps(self.__payload_type_count(payloadToSend)),
                     )
             except Exception as e:
                 log.warning("Exception occured while sending webhook: %s" % str(e))

--- a/webhook/webhookworker.py
+++ b/webhook/webhookworker.py
@@ -51,11 +51,11 @@ class WebhookWorker:
                 subTypes = webhook[:endIndex]
                 url = url[endIndex:]
 
-                log.debug("webhook types: %s", % str(subTypes))
+                log.debug("webhook types: %s", subTypes)
 
                 for payloadData in payload:
                     if payloadData["type"] in subTypes:
-                        log.debug("Payload to add: %s", % str(payloadData))
+                        log.debug("Payload to add: %s" % str(payloadData))
                         payloadToSend.append(payloadData)
             else:
                 payloadToSend = payload

--- a/webhook/webhookworker.py
+++ b/webhook/webhookworker.py
@@ -36,12 +36,12 @@ class WebhookWorker:
             log.info("Payload empty. Skip sending to webhook.")
             return
 
-        payloadToSend = []
 
         # get list of urls
         webhooks = self._args.webhook_url.replace(" ", "").split(",")
 
         for webhook in webhooks:
+            payloadToSend = []
             # url cleanup
             url = webhook.strip()
 
@@ -60,6 +60,9 @@ class WebhookWorker:
             else:
                 payloadToSend = payload
 
+            if len(payloadToSend) == 0:
+                log.debug("Payload is empty")
+                continue
 
             log.debug("Sending to webhook %s", url)
             log.debug("Payload: %s" % str(payloadToSend))

--- a/webhook/webhookworker.py
+++ b/webhook/webhookworker.py
@@ -49,6 +49,7 @@ class WebhookWorker:
                 endIndex = webhook.rindex("]")
                 endIndex += 1
                 subTypes = webhook[:endIndex]
+                url = url[endIndex:]
 
                 for payloadData in payload:
                     if payloadData["type"] in subTypes:

--- a/webhook/webhookworker.py
+++ b/webhook/webhookworker.py
@@ -51,8 +51,11 @@ class WebhookWorker:
                 subTypes = webhook[:endIndex]
                 url = url[endIndex:]
 
+                log.debug("webhook types: %s", % str(subTypes))
+
                 for payloadData in payload:
                     if payloadData["type"] in subTypes:
+                        log.debug("Payload to add: %s", % str(payloadData))
                         payloadToSend.append(payloadData)
             else:
                 payloadToSend = payload

--- a/webhook/webhookworker.py
+++ b/webhook/webhookworker.py
@@ -51,7 +51,7 @@ class WebhookWorker:
                 subTypes = webhook[:endIndex]
 
                 for payloadData in payload:
-                    if payloadData["type"] in subTypes
+                    if payloadData["type"] in subTypes:
                         payloadToSend.append(payloadData)
             else
                 payloadToSend = payload

--- a/webhook/webhookworker.py
+++ b/webhook/webhookworker.py
@@ -53,7 +53,7 @@ class WebhookWorker:
                 for payloadData in payload:
                     if payloadData["type"] in subTypes:
                         payloadToSend.append(payloadData)
-            else
+            else:
                 payloadToSend = payload
 
 


### PR DESCRIPTION
A few webhooks only need raids and other need raids and mons.
Here is the extension that it is possible to enter your endpoint for each type of webhook.

Defaults to everything activated:
`webhook_url=http://example.org/foo/bar`

To activate certain options:
`webhook_url=[mon|weather|raid]http://example.org/foo/bar`

With multiple urls:
`webhook_url=[mon|weather]http://example.org/foo/bar,[raid]http://othersite.com/baz`