### PR TITLE
Updating softban cooldowns to actual values

### DIFF
--- a/worker/WorkerQuests.py
+++ b/worker/WorkerQuests.py
@@ -88,20 +88,30 @@ class WorkerQuests(MITMBase):
             else:
                 if distance < 200:
                     delay_used = 5
-                elif distance < 500:
-                    delay_used = 15
-                elif distance < 1000:
-                    delay_used = 30
-                elif distance < 2000:
-                    delay_used = 100
                 elif distance < 5000:
-                    delay_used = 300
+                    delay_used = 30 
                 elif distance < 10000:
-                    delay_used = 500
-                elif distance < 20000:
-                    delay_used = 1000
+                    delay_used = 120
+                elif distance < 25000:
+                    delay_used = 360
+                elif distance < 30000:
+                    delay_used = 660 
+                elif distance < 65000:
+                    delay_used = 840
+                elif distance < 81000:
+                    delay_used = 1500
+                elif distance < 100000:
+                    delay_used = 2100
+                elif distance < 250000:
+                    delay_used = 2700 
+                elif distance < 500000:
+                    delay_used = 3600 
+                elif distance < 750000:
+                    delay_used = 4680 
+                elif distance < 1000000:
+                    delay_used = 5400
                 else:
-                    delay_used = 2000
+                    delay_used = 7200 
                 log.info("Need more sleep after Teleport: %s seconds!" % str(delay_used))
         else:
             log.info("main: Walking...")


### PR DESCRIPTION
Cooldown values used by Quest Workers are not correct, updating to correct values as described on reddit :

https://www.reddit.com/r/PokemonGoSpoofing/comments/94jpc5/good_information_with_cooldown_time_to_avoid/

As a side note, I think it would be a good idea to use other events as a way to prevent having to set a manual cooldown value. There should be mons around any stop, so we could simply wait for pokemon data to be received after moving to a stop before we try to open/spin it, and keep those manual values as safety values (in other words, receiving pokemon data should interrupt this wait timer).

