### PR TITLE
This thing need rework

### DIFF
--- a/db/rmWrapper.py
+++ b/db/rmWrapper.py
@@ -1128,7 +1128,7 @@ class RmWrapper(DbWrapperBase):
             "SELECT raid.gym_id, raid.level, raid.spawn, raid.start, raid.end, raid.pokemon_id, "
             "raid.cp, raid.move_1, raid.move_2, raid.last_scanned, raid.form, raid.is_exclusive, "
             "gymdetails.name, gymdetails.url, gym.latitude, gym.longitude, "
-            "gym.team_id, weather_boosted_condition "
+            "gym.team_id, raid.weather_boosted_condition "
             "FROM raid "
             "LEFT JOIN gymdetails ON gymdetails.gym_id = raid.gym_id "
             "LEFT JOIN gym ON gym.gym_id = raid.gym_id "


### PR DESCRIPTION
Quick fix, it's was broken for someone in Discord. The weather_boosted_condition is in both gym and raid tables, MySQL complained about "Column 'weather_boosted_condition' in field list is ambiguous". This one needs a rework - no idea why that column is in both tables and it's not used at all in inserts, so both of those are useless. This is just quick fix, I decided to go with raid table, but you need to decide how it is supposed to work.