### PR TITLE
mysql-connector==2.1.6 has been removed from PyPi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ Jinja2==2.10
 kiwisolver==1.0.1
 MarkupSafe==1.1.0
 matplotlib==3.0.2
-mysql-connector==2.1.6
+mysql-connector==2.1.7
 mysqlclient==1.3.14
 numpy==1.16.0
 pathtools==0.1.2


### PR DESCRIPTION
This causes new installs to fail when pip installing the requirements, 2.1.7 is available, so this changes the requirements.txt file to use 2.1.7