### PR TITLE
Fix missing quest webhooks in edge cases.

### DIFF
--- a/db/monocleWrapper.py
+++ b/db/monocleWrapper.py
@@ -1042,7 +1042,7 @@ class MonocleWrapper(DbWrapperBase):
             query = query + add_query
             data = (GUID,)
         elif timestamp is not None:
-            add_query = " and trs_quest.quest_timestamp > %s"
+            add_query = " and trs_quest.quest_timestamp >= %s"
             query = query + add_query
             data = (timestamp,)
 

--- a/db/rmWrapper.py
+++ b/db/rmWrapper.py
@@ -1040,7 +1040,7 @@ class RmWrapper(DbWrapperBase):
             query = query + add_query
             data = (GUID,)
         elif timestamp is not None:
-            add_query = " and trs_quest.quest_timestamp > %s"
+            add_query = " and trs_quest.quest_timestamp >= %s"
             query = query + add_query
             data = (timestamp,)
 


### PR DESCRIPTION
Please double check if this make sense, but for all other types we use >= not only > and that would explain why I have some quest webhooks missing on edge cases like this:

```
2019-04-08 05:14:49,138 [    webhook_worker][ webhookworker:89][    INFO] Successfully sent payload to webhook. Stats: {"weather": 1, "gym": 16}
(...)
2019-04-08 05:14:49,252 [             leeco][  WorkerQuests:442][    INFO] Spin Stop
2019-04-08 05:14:51,763 [             leeco][  WorkerQuests:452][    INFO] Getting new Quest
(...)
2019-04-08 05:14:52,012 [             nexus][  WorkerQuests:442][    INFO] Spin Stop
2019-04-08 05:14:54,524 [             nexus][  WorkerQuests:452][    INFO] Getting new Quest
(...)
2019-04-08 05:14:59,320 [    webhook_worker][ webhookworker:89][    INFO] Successfully sent payload to webhook. Stats: {"quest": 1}
```
However I am still not sure if 
```self.__last_check = int(time.time())``` should be set **after** getting all the data from database / __prepare_[type] (which take times) - like shouldn't that one be "froze" before all queries so we don't need to worry about that miliseconds that it takes to query stuff and make sure we won't missing some webhook data on veeery edge cases?