### PR TITLE
Enhance migrate_to_rocketmap.sh script

### DIFF
--- a/scripts/migrate_to_rocketmap.sh
+++ b/scripts/migrate_to_rocketmap.sh
@@ -9,6 +9,9 @@
 # before MAD then you want to use import_allspawns.sh as well. This script does not import things like #
 # controlling team/mons, or ex status, because MAD will fill this in after 1 scan.                     #
 #                                                                                                      #
+# If you were already scanning in MAD using your Monocle database, be sure to remove version.json      #
+# so MAD will update your new rocketmap schema.                                                        #
+#                                                                                                      #
 # Blank RocketMap schema created via https://github.com/cecpk/OSM-Rocketmap properly working with MAD  #
 #       https://gist.github.com/sn0opy/fb654915180cfbd07d5a30407c286995i                               #
 #                                                                                                      #

--- a/scripts/migrate_to_rocketmap.sh
+++ b/scripts/migrate_to_rocketmap.sh
@@ -9,6 +9,9 @@
 # before MAD then you want to use import_allspawns.sh as well. This script does not import things like #
 # controlling team/mons, or ex status, because MAD will fill this in after 1 scan.                     #
 #                                                                                                      #
+# Blank RocketMap schema created via https://github.com/cecpk/OSM-Rocketmap properly working with MAD  #
+#       https://gist.github.com/sn0opy/fb654915180cfbd07d5a30407c286995i                               #
+#                                                                                                      #
 # If you get an error like:                                                                            #
 #  "ERROR 1364 (HY000) at line 1: Field 'enabled' doesn't have a default value                         #
 # Then run this in mysql: SET GLOBAL sql_mode='' and run this script again.                            #
@@ -51,6 +54,10 @@ case "$dbtype" in
           stopquery="select external_id, lat, lon, name, url from pokestops"
           mysqldump -h "$olddbip" -u "$olduser" -p"$oldpass" -P "$oldport" "$olddbname" trs_spawn > /tmp/trs_spawn.sql
           mysql -NB -h "$newdbip" -u "$newuser" -p"$newpass" -P "$newport" "$newdbname" < /tmp/trs_spawn.sql
+	  rm /tmp/trs_spawn.sql
+          mysqldump -h "$olddbip" -u "$olduser" -p"$oldpass" -P "$oldport" "$olddbname" trs_quest > /tmp/trs_quest.sql
+          mysql -NB -h "$newdbip" -u "$newuser" -p"$newpass" -P "$newport" "$newdbname" < /tmp/trs_quest.sql
+	  rm /tmp/trs_quest.sql
        ;;
      rdm) gymquery="select id, lat, lon, name, url from gym"
           stopquery="select id, lat, lon, name, url from pokestop"


### PR DESCRIPTION
1) use the old database credentials with sqldump. Otherwise sqldump may fail due to not having permissions
2) enhance the script to support single quotes in gym and pokestop names