### PR TITLE
Validate walkervalue.

### DIFF
--- a/madmin/madmin.py
+++ b/madmin/madmin.py
@@ -1158,7 +1158,7 @@ def addwalker():
 
     fieldwebsite.append('<div class="form-group"><label>Value for Walkermode</label><br />'
                         '<small class="form-text text-muted"></small>'
-                        '<input type="text" name="walkervalue" value="' + str(walkervalue) + '"></div>')
+                        '<input type="text" name="walkervalue" value="' + str(walkervalue) + '" pattern="((2[0-3]|[01]?[0-9]):([0-5][0-9])|((2[0-3]|[01]?[0-9]):([0-5][0-9])\s*-\s*(2[0-3]|[01]?[0-9]):([0-5][0-9])))"></div>')
 
     fieldwebsite.append('<div class="form-group"><label>Max. Walker in Area</label><br />'
                         '<small class="form-text text-muted">Empty = infinitely</small>'

--- a/madmin/madmin.py
+++ b/madmin/madmin.py
@@ -1158,7 +1158,7 @@ def addwalker():
 
     fieldwebsite.append('<div class="form-group"><label>Value for Walkermode</label><br />'
                         '<small class="form-text text-muted"></small>'
-                        '<input type="text" name="walkervalue" value="' + str(walkervalue) + '"></div>')
+                        '<input type="text" name="walkervalue" value="' + str(walkervalue) + '" data-rule-validatewalkervalue="true"></div>')
 
     fieldwebsite.append('<div class="form-group"><label>Max. Walker in Area</label><br />'
                         '<small class="form-text text-muted">Empty = infinitely</small>'

--- a/madmin/madmin.py
+++ b/madmin/madmin.py
@@ -1158,7 +1158,7 @@ def addwalker():
 
     fieldwebsite.append('<div class="form-group"><label>Value for Walkermode</label><br />'
                         '<small class="form-text text-muted"></small>'
-                        '<input type="text" name="walkervalue" value="' + str(walkervalue) + '" pattern="((2[0-3]|[01]?[0-9]):([0-5][0-9])|((2[0-3]|[01]?[0-9]):([0-5][0-9])\s*-\s*(2[0-3]|[01]?[0-9]):([0-5][0-9])))"></div>')
+                        '<input type="text" name="walkervalue" value="' + str(walkervalue) + '"></div>')
 
     fieldwebsite.append('<div class="form-group"><label>Max. Walker in Area</label><br />'
                         '<small class="form-text text-muted">Empty = infinitely</small>'

--- a/madmin/templates/parser.html
+++ b/madmin/templates/parser.html
@@ -149,7 +149,6 @@ jQuery.validator.addMethod("validateWalkervalue", function(value, element) {
                 validateWalkervalueMsg = rules[type][1];
                 return false;
         }
-    return true;
 }, validateWalkervalueDynamicErrorMsg);
 </script>
 

--- a/madmin/templates/parser.html
+++ b/madmin/templates/parser.html
@@ -116,6 +116,42 @@ function updateOrder(data) {
     })
 }
 </script>
+<script>
+var validateWalkervalueMsg;
+var validateWalkervalueDynamicErrorMsg = function () { return validateWalkervalueMsg; }
+jQuery.validator.addMethod("validateWalkervalue", function(value, element) {
+
+        var digitsOnlyOrEmptyPattern = "^[0-9]*$";
+        var hourPattern = "((2[0-3]|[01]?[0-9]):([0-5][0-9]))";
+        var rangeHoursPattern = "("+hourPattern+"\s*-\s*"+hourPattern+")";
+        validateWalkervalueMsg = "";
+
+        // define rules we using,
+        // key-typename : array(pattern, message)
+        var rules = {
+                countdown : [digitsOnlyOrEmptyPattern, "Please set correct number of seconds - digits only."],
+                timer : ['^(|'+hourPattern+')$', "Please set correct time (24h format: XX:XX)."],
+                round: [digitsOnlyOrEmptyPattern, "Please set correct number of rounds - digits only."],
+                period : ['^(|'+rangeHoursPattern+')$', "Please set correct time (24h format: XX:XX-XX:XX)."],
+                coords: ['^(|'+hourPattern+'|'+rangeHoursPattern+')$', "Please set correct time."],
+                idle: ['^(|'+hourPattern+'|'+rangeHoursPattern+')$', "Please set correct time."],
+        };
+
+        var type = $("select[name='walkertype']").val();
+        if (!(type in rules)) {
+                        console.log("No rule implemented for " + type + " please fix :)");
+                        return true;
+        }
+        var ruleToUse = new RegExp(rules[type][0], "");
+        if (ruleToUse.test(value)) {
+                return true;
+        } else {
+                validateWalkervalueMsg = rules[type][1];
+                return false;
+        }
+    return true;
+}, validateWalkervalueDynamicErrorMsg);
+</script>
 
 {% endblock %}
 

--- a/madmin/templates/parser.html
+++ b/madmin/templates/parser.html
@@ -119,7 +119,7 @@ function updateOrder(data) {
 <script>
 var validateWalkervalueMsg;
 var validateWalkervalueDynamicErrorMsg = function () { return validateWalkervalueMsg; }
-jQuery.validator.addMethod("validateWalkervalue", function(value, element) {
+jQuery.validator.addMethod("validatewalkervalue", function(value, element) {
 
         var digitsOnlyOrEmptyPattern = "^[0-9]*$";
         var hourPattern = "((2[0-3]|[01]?[0-9]):([0-5][0-9]))";


### PR DESCRIPTION
We force two digits for minutes (just like the description by cec states ;)), so people won't end with 1:1, it must be 1:10 or 1:01. Whitespaces between hyphen allowed. This regexp validate for non-existing hours, so no more 25:49 or other typos.

No jquery btw. :-D