### PR TITLE
fix delsetting in Madmin

### DIFF
--- a/madmin/madmin.py
+++ b/madmin/madmin.py
@@ -1582,7 +1582,7 @@ def delsetting():
         if 'devicepool' in entry:
             _checkfield = 'devicepool'
 
-        if str(edit) in str(entry[_checkfield]):
+        if str(edit) == str(entry[_checkfield]):
             del mapping[area][key]
 
     with open('configs/mappings.json', 'w') as outfile:


### PR DESCRIPTION
Example:
create areas under "Mapping Editor" with name "test123" and name "test".
The first area is "test123" and second is "test" then try to delete "test".
Expected: 
"test" should be deleted, not "test123"

