### PR TITLE
WIP Add support for Poracle compatible quest webhooks

### DIFF
--- a/configs/config.ini.example
+++ b/configs/config.ini.example
@@ -108,6 +108,7 @@ pogoasset:                   # Path to Pogo Assets: See: https://github.com/ZeCh
 #pokemon_webhook             # Activate support for pokemon webhook
 #gym_webhook                 # Activate support for gym webhook (NOT required for raids!)
 #quest_webhook               # Activate support for quest webhook
+#quest_webhook_flavor:       # Mode for quest webhooks (default or poracle)
 
 # Dynamic Rarity
 ######################

--- a/utils/walkerArgs.py
+++ b/utils/walkerArgs.py
@@ -155,13 +155,17 @@ def parseArgs():
     parser.add_argument('-wh', '--webhook', action='store_true', default=False,
                         help='Activate webhook support')
     parser.add_argument('-whurl', '--webhook_url', default='',
-                        help='URL endpoint/s for webhooks (seperated by commas) with [<type>] for restriction like [mon|weather|raid]http://example.org/foo/bar - urls have to start with http*')
+                        help='URL endpoint/s for webhooks (seperated by commas) with [<type>] '
+                             'for restriction like [mon|weather|raid]http://example.org/foo/bar '
+                             '- urls have to start with http*')
     parser.add_argument('-pwh', '--pokemon_webhook', action='store_true', default=False,
                         help='Activate pokemon webhook support')
     parser.add_argument('-wwh', '--weather_webhook', action='store_true', default=False,
                         help='Activate weather webhook support')
     parser.add_argument('-qwh', '--quest_webhook', action='store_true', default=False,
                         help='Activate quest webhook support')
+    parser.add_argument('-qwhf', '--quest_webhook_flavor', choices=['default', 'poracle'], default='default',
+                        help='Webhook format for Quests: default or poracle compatible')
     parser.add_argument('-gwh', '--gym_webhook', action='store_true', default=False,
                         help='Activate gym webhook support')
     parser.add_argument('-whser', '--webhook_submit_exraids', action='store_true', default=False,

--- a/webhook/webhookworker.py
+++ b/webhook/webhookworker.py
@@ -127,8 +127,21 @@ class WebhookWorker:
         ret = []
 
         for pokestopid in quest_data:
-            quest = generate_quest(quest_data[str(pokestopid)])
-            quest_payload = {
+            try:
+                quest = generate_quest(quest_data[str(pokestopid)])
+                quest_payload = self.__construct_quest_payload(quest)
+
+                entire_payload = {"type": "quest", "message": quest_payload}
+                ret.append(entire_payload)
+            except Exception as e:
+                logger.warning(
+                    "Exception occured while generating quest webhook: {}", str(e))
+
+        return ret
+
+    def __construct_quest_payload(self, quest):
+        if self.__args.quest_webhook_flavor == 'default':
+            return {
                 "pokestop_id": quest['pokestop_id'],
                 "latitude": quest['latitude'],
                 "longitude": quest['longitude'],
@@ -149,10 +162,62 @@ class WebhookWorker:
                 "quest_template": quest['quest_template']
             }
 
-            entire_payload = {"type": "quest", "message": quest_payload}
-            ret.append(entire_payload)
+        # Other known type is Poracle/RDM compatible.
 
-        return ret
+        # For some reason we aren't saving JSON in our databse, so we gotta replace ' with ".
+        # Pray that we never save strings that contain ' inside them.
+        quest_conditions = json.loads(quest['quest_condition'].replace('\'', '"'))
+        quest_condition = []
+        quest_rewards = []
+        a_quest_type = quest['quest_reward_type_raw']
+        a_quest_reward = {}
+        quest_rewards.append(a_quest_reward)
+        a_quest_reward['info'] = {}
+        a_quest_reward['type'] = a_quest_type
+
+        if a_quest_type == 2:
+            a_quest_reward['info']['item_id'] = quest['item_id']
+            a_quest_reward['info']['amount'] = int(quest['item_amount'])
+        if a_quest_type == 3:
+            a_quest_reward['info']['amount'] = int(quest['item_amount'])
+        if a_quest_type == 7:
+            a_quest_reward['info']['pokemon_id'] = int(quest['pokemon_id'])
+            a_quest_reward['info']['shiny'] = 0
+
+        for a_quest_condition in quest_conditions:
+            # Quest condition for special type of pokemon.
+            if "with_pokemon_type" in a_quest_condition:
+                a_quest_condition['info'] = a_quest_condition.pop("with_pokemon_type")
+                a_quest_condition['info']['pokemon_type_ids'] = a_quest_condition['info'].pop('pokemon_type')
+            # Quest condition for raid level(s).
+            if "with_raid_level" in a_quest_condition:
+                a_quest_condition['info'] = a_quest_condition.pop("with_raid_level")
+                a_quest_condition['info']['raid_levels'] = a_quest_condition['info'].pop('raid_level')
+            # Quest condition for throw type.
+            if "with_throw_type" in a_quest_condition:
+                a_quest_condition['info'] = a_quest_condition.pop("with_throw_type")
+                a_quest_condition['info']['throw_type_id'] = a_quest_condition['info'].pop('throw_type')
+            # Quest condition for use of special items
+            if "with_item" in a_quest_condition:
+                a_quest_condition['info'] = a_quest_condition.pop("with_item")
+                a_quest_condition['info']['item_id'] = a_quest_condition['info'].pop('item')
+
+            quest_condition.append(a_quest_condition)
+
+        return {
+            "pokestop_id": quest['pokestop_id'],
+            "pokestop_name": quest['name'].replace('"', '\\"').replace('\n', '\\n'),
+            "template": quest['quest_template'],
+            "pokestop_url": quest['url'],
+            "conditions": quest_condition,
+            "type": quest['quest_type_raw'],
+            "latitude": quest['latitude'],
+            "longitude": quest['longitude'],
+            "rewards": quest_rewards,
+            "target": quest['quest_target'],
+            "timestamp": quest['timestamp'],
+            "quest_task": quest['quest_task']
+        }
 
     def __prepare_weather_data(self, weather_data):
         ret = []


### PR DESCRIPTION
Adds a new optional argument `quest_webhook_flavor` that can be either default or poracle. 

If set to poracle, quest webhooks will be sent in a format that is compatible with PoracleJS :tm:

Includes a new try/catch block for quest gen in case something blows up.

Needs extensive testing by people using Poracle to ensure all quest conditions and rewards come through correctly.