### PR TITLE
urllib3 version incompatibility fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ PyWavelets==1.0.1
 pyyaml>=4.2b1
 scipy==1.1.0
 six==1.11.0
-urllib3>=1.24.2
+urllib3==1.24.2
 websockets==7.0
 Werkzeug==0.15.2
 requests


### PR DESCRIPTION
Using urllib3>=1.24.2 would update to 1.25.1 which isn't compatible with the current requests version used by this file. Forcing version 1.24.2 works as it should.