### PR TITLE
walk_after_teleport_distance description fix

### DIFF
--- a/madmin/static/vars/vars_parser.json
+++ b/madmin/static/vars/vars_parser.json
@@ -63,7 +63,7 @@
 					"settings": {
 						"type": "text",
 						"require": "false",
-						"description": "Max. distance of walking - otherwise teleport to new location"
+						"description": "Walk n metres in both directions after teleport for getting data"
 					}
 				},
 				{

--- a/madmin/static/vars/vars_parser.json
+++ b/madmin/static/vars/vars_parser.json
@@ -63,7 +63,7 @@
 					"settings": {
 						"type": "text",
 						"require": "false",
-						"description": "Walk n seconds after teleport for getting data"
+						"description": "Max. distance of walking - otherwise teleport to new location"
 					}
 				},
 				{


### PR DESCRIPTION
From the looks of it:
Commits on Mar 11, 2019
Switch section Devices with Areas. (#116)
overrides
Commits on Feb 26, 2019
Description fix for `walk_after_teleport_distance`.

This looks like a lack of rebase and the fix being lost. From what i gather #116 shouldn't of altered this description.

This will correct the alteration should it be necessary.