### PR TITLE
Fix lookup of existing spawndef for updating spawnpoints

### DIFF
--- a/db/dbWrapperBase.py
+++ b/db/dbWrapperBase.py
@@ -587,7 +587,7 @@ class DbWrapperBase(ABC):
 
         res = self.execute(query)
         for row in res:
-            spawnret[row[0]] = row[1]
+            spawnret[int(row[0])] = row[1]
         return spawnret
 
     def submit_spawnpoints_map_proto(self, origin, map_proto):


### PR DESCRIPTION
Currently the dictionary provided by getspawndef has strings for keys.
However, when the function is used - while attempting to update spawnpoints - we treat the spawnpoint id as an int. This causes the lookup to fail, and we always overwrite spawndef instead of updating it.
This converts the keys in getspawndef to integers.