### PR TITLE
Fix perfect IV statistics

### DIFF
--- a/db/monocleWrapper.py
+++ b/db/monocleWrapper.py
@@ -1402,16 +1402,12 @@ class MonocleWrapper(DbWrapperBase):
 
     def get_best_pokemon_spawns(self):
         logger.debug('Fetching best pokemon spawns from db')
-        query_date = "unix_timestamp(DATE_FORMAT(FROM_UNIXTIME(timestamp_scan), '%y-%m-%d %k:%i:00'))"
 
         query = (
-                "SELECT encounter_id, GROUP_CONCAT(DISTINCT worker order by worker asc SEPARATOR ', '), pokemon_id, "
-                "%s, atk_iv, def_iv, sta_iv, level, cp FROM sightings join "
-                "trs_stats_detect_raw on sightings.encounter_id=type_id WHERE "
-                "atk_iv>14 and def_iv>14 and sta_iv>14 and "
-                "trs_stats_detect_raw.type in ('mon', 'mon_iv') group by encounter_id "
-                "order by trs_stats_detect_raw.timestamp_scan desc limit 30" %
-                (str(query_date))
+                "SELECT encounter_id, updated, pokemon_id, "
+                "atk_iv, def_iv, sta_iv, level, cp FROM sightings "
+                "WHERE atk_iv>14 and def_iv>14 and sta_iv>14 "
+                "group by encounter_id order by updated desc limit 30"
         )
 
         res = self.execute(query)

--- a/db/rmWrapper.py
+++ b/db/rmWrapper.py
@@ -1496,7 +1496,7 @@ class RmWrapper(DbWrapperBase):
         return {'pokemon': res, 'total': total}
 
     def get_best_pokemon_spawns(self):
-        logger.debug('Fetching best pokemon spawns from db')"
+        logger.debug('Fetching best pokemon spawns from db')
 
         query = (
                 "SELECT encounter_id, pokemon_id, unix_timestamp(last_modified),"

--- a/db/rmWrapper.py
+++ b/db/rmWrapper.py
@@ -1496,17 +1496,13 @@ class RmWrapper(DbWrapperBase):
         return {'pokemon': res, 'total': total}
 
     def get_best_pokemon_spawns(self):
-        logger.debug('Fetching best pokemon spawns from db')
-        query_date = "unix_timestamp(DATE_FORMAT(FROM_UNIXTIME(timestamp_scan), '%y-%m-%d %k:%i:00'))"
+        logger.debug('Fetching best pokemon spawns from db')"
 
         query = (
-                "SELECT encounter_id, GROUP_CONCAT(DISTINCT worker order by worker asc SEPARATOR ', '), pokemon_id, "
-                "%s, individual_attack, individual_defense, individual_stamina, cp_multiplier, cp FROM pokemon join "
-                "trs_stats_detect_raw on pokemon.encounter_id=type_id WHERE "
-                "individual_attack>14 and individual_defense>14 and individual_stamina>14 and "
-                "trs_stats_detect_raw.type in ('mon', 'mon_iv') group by encounter_id "
-                "order by trs_stats_detect_raw.timestamp_scan desc limit 30" %
-                (str(query_date))
+                "SELECT encounter_id, pokemon_id, unix_timestamp(last_modified),"
+                " individual_attack, individual_defense, individual_stamina, cp_multiplier, cp FROM pokemon"
+                " WHERE individual_attack>14 and individual_defense>14 and individual_stamina>14"
+                " GROUP BY encounter_id ORDER BY last_modified DESC LIMIT 30"
         )
 
         res = self.execute(query)

--- a/madmin/routes/statistics.py
+++ b/madmin/routes/statistics.py
@@ -154,18 +154,18 @@ class statistics(object):
         good_spawns = []
         data = self._db.get_best_pokemon_spawns()
         for dat in data:
-            mon = "%03d" % dat[2]
+            mon = "%03d" % dat[1]
             monPic = 'asset/pokemon_icons/pokemon_icon_' + mon + '_00.png'
-            monName_raw = (get_raid_boss_cp(dat[2]))
+            monName_raw = (get_raid_boss_cp(dat[1]))
             monName = i8ln(monName_raw['name'])
             if self._args.db_method == "rm":
-                lvl = calculate_mon_level(dat[7])
+                lvl = calculate_mon_level(dat[6])
             else:
-                lvl = dat[7]
-            good_spawns.append({'id': dat[2], 'iv': round(calculate_iv(dat[4], dat[5], dat[6]), 0),
-                                'lvl': lvl, 'cp': dat[8], 'img': monPic,
+                lvl = dat[6]
+            good_spawns.append({'id': dat[1], 'iv': round(calculate_iv(dat[3], dat[4], dat[5]), 0),
+                                'lvl': lvl, 'cp': dat[7], 'img': monPic,
                                 'name': monName,
-                                'periode': datetime.datetime.fromtimestamp(dat[3]).strftime(self._datetimeformat)})
+                                'periode': datetime.datetime.fromtimestamp(dat[2]).strftime(self._datetimeformat)})
 
         stats = {'spawn': spawn, 'gym': gym, 'detection': detection, 'detection_empty': detection_empty,
                  'quest': quest, 'stop': stop, 'usage': usage, 'good_spawns': good_spawns,


### PR DESCRIPTION
Fix missing mons from "Recent Perfect Pokemon"
Some entries are lacking because of no matching records in `trs_stats_detect_raw`. This PR fixes it by skipping joining the two tables.