### PR TITLE
Added gender support for raid bosses

### DIFF
--- a/db/monocleWrapper.py
+++ b/db/monocleWrapper.py
@@ -38,6 +38,11 @@ class MonocleWrapper(DbWrapperBase):
                 "ctype": "tinyint(1) NULL"
             },
             {
+                "table": "raids",
+                "column": "gender",
+                "ctype": "tinyint(1) NULL"
+            },
+            {
                 "table": "fort_sightings",
                 "column": "is_ex_raid_eligible",
                 "ctype": "tinyint(1) NULL"

--- a/db/monocleWrapper.py
+++ b/db/monocleWrapper.py
@@ -851,13 +851,13 @@ class MonocleWrapper(DbWrapperBase):
         raid_vals = []
         query_raid = (
             "INSERT INTO raids (external_id, fort_id, level, pokemon_id, time_spawn, time_battle, "
-            "time_end, cp, move_1, move_2, form, last_updated, is_exclusive) "
+            "time_end, cp, move_1, move_2, form, last_updated, is_exclusive, gender) "
             "VALUES( (SELECT id FROM forts WHERE forts.external_id=%s), "
-            "(SELECT id FROM forts WHERE forts.external_id=%s), %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
+            "(SELECT id FROM forts WHERE forts.external_id=%s), %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
             "ON DUPLICATE KEY UPDATE level=VALUES(level), pokemon_id=VALUES(pokemon_id), "
             "time_spawn=VALUES(time_spawn), time_battle=VALUES(time_battle), time_end=VALUES(time_end), "
             "cp=VALUES(cp), move_1=VALUES(move_1), move_2=VALUES(move_2), "
-            "form=VALUES(form), last_updated=VALUES(last_updated)"
+            "form=VALUES(form), last_updated=VALUES(last_updated), gender=VALUES(gender)"
         )
 
         for cell in cells:
@@ -869,12 +869,14 @@ class MonocleWrapper(DbWrapperBase):
                         move_1 = gym['gym_details']['raid_info']['raid_pokemon']['move_1']
                         move_2 = gym['gym_details']['raid_info']['raid_pokemon']['move_2']
                         form = gym['gym_details']['raid_info']['raid_pokemon']['display']['form_value']
+                        gender = gym['gym_details']['raid_info']['raid_pokemon']['display']['gender_value']
                     else:
                         pokemon_id = None
                         cp = 0
                         move_1 = 1
                         move_2 = 2
                         form = None
+                        gender = None
 
                     raidendSec = int(gym['gym_details']
                                      ['raid_info']['raid_end'] / 1000)
@@ -906,7 +908,8 @@ class MonocleWrapper(DbWrapperBase):
                             cp, move_1, move_2,
                             form,
                             int(now),
-                            is_exclusive
+                            is_exclusive,
+                            gender
                         )
                     )
         self.executemany(query_raid, raid_vals, commit=True)
@@ -1183,7 +1186,7 @@ class MonocleWrapper(DbWrapperBase):
         query = (
             "SELECT forts.external_id, level, time_spawn, time_battle, time_end, "
             "pokemon_id, cp, move_1, move_2, last_updated, form, is_exclusive, name, url, "
-            "lat, lon, team, weather.condition, is_ex_raid_eligible "
+            "lat, lon, team, weather.condition, is_ex_raid_eligible, gender "
             "FROM raids "
             "LEFT JOIN fort_sightings ON raids.fort_id = fort_sightings.fort_id "
             "LEFT JOIN forts ON raids.fort_id = forts.id "
@@ -1197,7 +1200,7 @@ class MonocleWrapper(DbWrapperBase):
         for (gym_id, level, spawn, start, end, pokemon_id,
                 cp, move_1, move_2, last_scanned, form, is_exclusive,
                 name, url, latitude, longitude, team_id,
-                weather_boosted_condition, is_ex_raid_eligible) in res:
+                weather_boosted_condition, is_ex_raid_eligible, gender) in res:
             ret.append({
                 "gym_id": gym_id,
                 "level": level,
@@ -1217,7 +1220,8 @@ class MonocleWrapper(DbWrapperBase):
                 "team_id": team_id,
                 "weather_boosted_condition": weather_boosted_condition,
                 "is_exclusive": is_exclusive,
-                "is_ex_raid_eligible": is_ex_raid_eligible
+                "is_ex_raid_eligible": is_ex_raid_eligible,
+                "gender": gender
             })
 
         return ret

--- a/db/rmWrapper.py
+++ b/db/rmWrapper.py
@@ -34,6 +34,11 @@ class RmWrapper(DbWrapperBase):
                 "ctype": "tinyint(1) NULL"
             },
             {
+                "table": "raid",
+                "column": "gender",
+                "ctype": "tinyint(1) NULL"
+            },
+            {
                 "table": "gym",
                 "column": "is_ex_raid_eligible",
                 "ctype": "tinyint(1) NOT NULL DEFAULT '0'"

--- a/db/rmWrapper.py
+++ b/db/rmWrapper.py
@@ -907,12 +907,12 @@ class RmWrapper(DbWrapperBase):
             time.time()).strftime("%Y-%m-%d %H:%M:%S")
 
         query_raid = (
-            "INSERT INTO raid (gym_id, level, spawn, start, end, pokemon_id, cp, move_1, move_2, last_scanned, form, is_exclusive) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
+            "INSERT INTO raid (gym_id, level, spawn, start, end, pokemon_id, cp, move_1, move_2, last_scanned, form, is_exclusive, gender) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
             "ON DUPLICATE KEY UPDATE level=VALUES(level), spawn=VALUES(spawn), start=VALUES(start), "
             "end=VALUES(end), pokemon_id=VALUES(pokemon_id), cp=VALUES(cp), move_1=VALUES(move_1), "
             "move_2=VALUES(move_2), last_scanned=VALUES(last_scanned), is_exclusive=VALUES(is_exclusive), "
-            "form=VALUES(form)"
+            "form=VALUES(form), gender=VALUES(gender)"
         )
 
         for cell in cells:
@@ -925,12 +925,14 @@ class RmWrapper(DbWrapperBase):
                         move_1 = gym['gym_details']['raid_info']['raid_pokemon']['move_1']
                         move_2 = gym['gym_details']['raid_info']['raid_pokemon']['move_2']
                         form = gym['gym_details']['raid_info']['raid_pokemon']['display']['form_value']
+                        gender = gym['gym_details']['raid_info']['raid_pokemon']['display']['gender_value']
                     else:
                         pokemon_id = None
                         cp = 0
                         move_1 = 1
                         move_2 = 2
                         form = None
+                        gender = None
 
                     raidendSec = int(gym['gym_details']
                                      ['raid_info']['raid_end'] / 1000)
@@ -964,7 +966,8 @@ class RmWrapper(DbWrapperBase):
                             raidend_date,
                             pokemon_id, cp, move_1, move_2, now,
                             form,
-                            is_exclusive
+                            is_exclusive,
+                            gender
                         )
                     )
         self.executemany(query_raid, raid_args, commit=True)
@@ -1245,7 +1248,7 @@ class RmWrapper(DbWrapperBase):
     def get_raids_changed_since(self, timestamp):
         query = (
             "SELECT raid.gym_id, raid.level, raid.spawn, raid.start, raid.end, raid.pokemon_id, "
-            "raid.cp, raid.move_1, raid.move_2, raid.last_scanned, raid.form, raid.is_exclusive, "
+            "raid.cp, raid.move_1, raid.move_2, raid.last_scanned, raid.form, raid.is_exclusive, raid.gender, "
             "gymdetails.name, gymdetails.url, gym.latitude, gym.longitude, "
             "gym.team_id, weather_boosted_condition, gym.is_ex_raid_eligible "
             "FROM raid "
@@ -1260,7 +1263,7 @@ class RmWrapper(DbWrapperBase):
         ret = []
 
         for (gym_id, level, spawn, start, end, pokemon_id,
-                cp, move_1, move_2, last_scanned, form, is_exclusive,
+                cp, move_1, move_2, last_scanned, form, is_exclusive, gender,
                 name, url, latitude, longitude, team_id,
                 weather_boosted_condition, is_ex_raid_eligible) in res:
             ret.append({
@@ -1282,6 +1285,7 @@ class RmWrapper(DbWrapperBase):
                 "team_id": team_id,
                 "weather_boosted_condition": weather_boosted_condition,
                 "is_exclusive": is_exclusive,
+                "gender": gender,
                 "is_ex_raid_eligible": is_ex_raid_eligible
             })
 

--- a/webhook/webhookworker.py
+++ b/webhook/webhookworker.py
@@ -340,6 +340,9 @@ class WebhookWorker:
 
             if raid["is_ex_raid_eligible"] is not None:
                 raid_payload["is_ex_raid_eligible"] = raid["is_ex_raid_eligible"]
+                
+            if raid["gender"] is not None:
+                raid_payload["gender"] = raid["gender"]
 
             # create final message
             entire_payload = {"type": "raid", "message": raid_payload}


### PR DESCRIPTION
Added gender support for webhook type "raid" which is supported by PA for example.
Also modified rm wrapper to pick up information to fill the needed gender data.

This additional gender information for raids is useful for Burmy, Snorunt etc.