### PR TITLE
Add MADmin /quests_pub endpoint

### DIFF
--- a/configs/config.ini.example
+++ b/configs/config.ini.example
@@ -94,6 +94,7 @@
 #unknown_gym_distance:       # MADmin show matchable gyms with this radius (Default: 10)
 #madmin_user: madmin         # MADmin username for login
 #madmin_password: MySecret   # MADmin password for login
+#quests_public               # Disables login for /quests_pub, /get_quests and /asset to use /quests_pub as public quest overview
 
 # webhook
 ######################

--- a/madmin/functions.py
+++ b/madmin/functions.py
@@ -17,7 +17,7 @@ def auth_required(func):
         quests_pub_enabled = getattr(mapping_args, 'quests_public', False)
         if not username:
             return func(*args, **kwargs)
-        if quests_pub_enabled and func.__name__ in ['get_quests', 'quest_pub']:
+        if quests_pub_enabled and func.__name__ in ['get_quests', 'quest_pub', 'pushAssets']:
             return func(*args, **kwargs)
         if request.authorization:
             if (request.authorization.username == username) and (

--- a/madmin/functions.py
+++ b/madmin/functions.py
@@ -14,7 +14,10 @@ def auth_required(func):
     def decorated(*args, **kwargs):
         username = getattr(mapping_args, 'madmin_user', '')
         password = getattr(mapping_args, 'madmin_password', '')
+        quests_pub_enabled = getattr(mapping_args, 'quests_public', False)
         if not username:
+            return func(*args, **kwargs)
+        if quests_pub_enabled and func.__name__ in ['get_quests', 'quest_pub']:
             return func(*args, **kwargs)
         if request.authorization:
             if (request.authorization.username == username) and (

--- a/madmin/routes/path.py
+++ b/madmin/routes/path.py
@@ -27,7 +27,8 @@ class path(object):
             ("/raids", self.raids),
             ("/gyms", self.gyms),
             ("/unknown", self.unknown),
-            ("/quests", self.quest)
+            ("/quests", self.quest),
+            ("/quests_pub", self.quest_pub)
         ]
         for route, view_func in routes:
             self._app.route(route)(view_func)
@@ -85,5 +86,12 @@ class path(object):
 
     @auth_required
     def quest(self):
-        return render_template('quests.html', responsive=str(self._args.madmin_noresponsive).lower(),
+        return render_template('quests.html', pub=False,
+                               responsive=str(self._args.madmin_noresponsive).lower(),
                                title="show daily Quests", running_ocr=(self._args.only_ocr))
+
+    def quest_pub(self):
+        return render_template('quests.html', pub=True,
+                               responsive=str(self._args.madmin_noresponsive).lower(),
+                               title="show daily Quests", running_ocr=(self._args.only_ocr))
+

--- a/madmin/routes/path.py
+++ b/madmin/routes/path.py
@@ -90,6 +90,7 @@ class path(object):
                                responsive=str(self._args.madmin_noresponsive).lower(),
                                title="show daily Quests", running_ocr=(self._args.only_ocr))
 
+    @auth_required
     def quest_pub(self):
         return render_template('quests.html', pub=True,
                                responsive=str(self._args.madmin_noresponsive).lower(),

--- a/madmin/templates/base.html
+++ b/madmin/templates/base.html
@@ -15,6 +15,7 @@
     <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico').lstrip('/') }}" type="image/x-icon">
     <link rel="icon" href="{{ url_for('static', filename='favicon.ico').lstrip('/') }}" type="image/x-icon">
     {% block header %}{% endblock %}
+    {% if not pub %}
     <style>
         body {
           padding-top: 56px;
@@ -23,9 +24,11 @@
             max-height: 20px;
         }
     </style>
+    {% endif %}
 </head>
 
 <body>
+    {% if not pub %}
     <nav class="navbar navbar-dark bg-dark fixed-top navbar-expand-lg">
         <div class="container">
           <a class="navbar-brand" href=".">
@@ -72,6 +75,7 @@
           </div>
         </div>
     </nav>
+    {% endif %}
     <div class="container" role="main">
         {% block content %}{% endblock %}
     </div>

--- a/madmin/templates/quests.html
+++ b/madmin/templates/quests.html
@@ -133,6 +133,8 @@
 {% endblock %}
 
 {% block content %}
+{% if not pub %}
 <h2>Quests</h2>
+{% endif %}
 <table id="show-data" class="table"></table>
 {% endblock %}

--- a/utils/walkerArgs.py
+++ b/utils/walkerArgs.py
@@ -222,6 +222,9 @@ def parseArgs():
     parser.add_argument('-ugd', '--unknown_gym_distance', default='10',
                         help='Show matchable gyms for unknwon with this radius (in km!) (Default: 10)')
 
+    parser.add_argument('-qpub', '--quests_public', action='store_true', default=False,
+                        help='Enables MADmin /quests_pub endpoint for public quests overview')
+
     # etc
 
     parser.add_argument('-rdt', '--raid_time', default='45', type=int,


### PR DESCRIPTION
As requested on discord a couple of times, `/quests_pub` is `/quests` without the MADmin header.

By default, normal auth settings apply. By setting `-qpub` / `--quests_public`, `/quests_pub` and `/get_quests` + ` /asset` will not require auth anymore.

In case my implementation sucks, please roast me :-)