### PR TITLE
Set lure to None by default.

### DIFF
--- a/db/rmWrapper.py
+++ b/db/rmWrapper.py
@@ -1097,7 +1097,7 @@ class RmWrapper(DbWrapperBase):
         last_modified = datetime.utcfromtimestamp(
             stop_data['last_modified_timestamp_ms'] / 1000).strftime("%Y-%m-%d %H:%M:%S")
         # lure isn't present anymore...
-        lure = '1970-01-01 00:00:00'
+        lure = None
         active_fort_modifier = None
         if len(stop_data['active_fort_modifier']) > 0:
             active_fort_modifier = stop_data['active_fort_modifier'][0]


### PR DESCRIPTION
There is no need to set the lure expiration to a specific date since lure_expiration is allowed to be set to null in the db.