### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,54 @@
-# Basic docker image 
-# Usage:
-#   docker build -t pogomad .             # Build the docker Image
-#   docker run -d pogomad start.py        # Launch Server
+###########################
+# compile tesseract.
+###########################
+FROM python:3.7-slim AS tesseract_builder
+RUN apt-get update && apt-get install -y automake ca-certificates g++ git libtool libleptonica-dev make pkg-config
+RUN git clone https://github.com/tesseract-ocr/tesseract.git && cd tesseract && ./autogen.sh && ./configure && make &&  make install && ldconfig
 
-FROM python:3.7.1-slim
 
-# Default ports for PogoDroid, RGC and MAdmin
-EXPOSE 8080 8000 5000
+############################
+# MAD
+############################
+FROM python:3.7-slim
+# Copy stuff from buildstage
+COPY --from=tesseract_builder /usr/local/bin/tesseract /usr/local/bin/tesseract
+COPY --from=tesseract_builder /usr/lib/x86_64-linux-gnu/libgomp.so.1 /usr/local/lib/libtesseract.a  /usr/local/lib/libtesseract.la /usr/local/lib/libtesseract.so.5 /usr/local/lib/libtesseract.so /usr/local/lib/libtesseract.so.5.0.0 /usr/lib/
 
 # Working directory for the application
 WORKDIR /usr/src/app
 
-# Set Entrypoint with hard-coded options
-ENTRYPOINT ["python"]
-CMD ["./start.py"] 
-
-# Install required system packages
-RUN apt-get update && apt-get install -y --no-install-recommends libgeos-dev build-essential
-RUN apt-get update && apt-get -y install libglib2.0-0 default-libmysqlclient-dev
-RUN apt-get update && apt-get -y install tesseract-ocr libtesseract-dev
-RUN apt-get -y install tk
-RUN apt-get update
-
+# copy requirements only, to reduce image size and improve cache usage
 COPY requirements.txt /usr/src/app/
-COPY requirements_ocr.txt /usr/src/app/
 
-RUN apt-get update && apt-get install -y git && pip install -r requirements.txt
-RUN apt-get update && apt-get install -y git && pip install -r requirements_ocr.txt
+# Install required system packages + python requirements + cleanup in one layer (yields smaller docker image). 
+# If you try to debug the build you should split into single RUN commands ;)
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update \
+&& apt-get install -y --no-install-recommends \
+build-essential \
+libglib2.0-0 \
+default-libmysqlclient-dev \
+python-opencv \
+libsm6 \
+libxext6 \
+libxrender-dev \
+libtesseract-dev \
+tk \
+wget \
+&& wget https://github.com/tesseract-ocr/tessdata/raw/master/eng.traineddata \
+&& mkdir /usr/local/share/tessdata/ \
+&& mv -v eng.traineddata /usr/local/share/tessdata/ \
+&& python3 -m pip install --no-cache-dir -r requirements.txt \
+&& apt-get remove -y wget \
+&& apt-get remove -y build-essential \
+&& apt-get remove -y python2.7 && rm -rf /usr/lib/python2.7 \
+&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+&& rm -rf /var/lib/apt/lists/*
 
 # Copy everything to the working directory (Python files, templates, config) in one go.
 COPY . /usr/src/app/
+
+# Set Entrypoint with hard-coded options
+ENTRYPOINT ["python3","start.py", "-wm", "-os"]
+
+# Default ports for PogoDroid, RGC and MAdmin
+EXPOSE 8080 8000 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,16 @@
-###########################
-# compile tesseract.
-###########################
-FROM python:3.7-slim AS tesseract_builder
-RUN apt-get update && apt-get install -y automake ca-certificates g++ git libtool libleptonica-dev make pkg-config
-RUN git clone https://github.com/tesseract-ocr/tesseract.git && cd tesseract && ./autogen.sh && ./configure && make &&  make install && ldconfig
-
-
 ############################
 # MAD
 ############################
 FROM python:3.7-slim
-# Copy stuff from buildstage
-COPY --from=tesseract_builder /usr/local/bin/tesseract /usr/local/bin/tesseract
-COPY --from=tesseract_builder /usr/lib/x86_64-linux-gnu/libgomp.so.1 /usr/local/lib/libtesseract.a  /usr/local/lib/libtesseract.la /usr/local/lib/libtesseract.so.5 /usr/local/lib/libtesseract.so /usr/local/lib/libtesseract.so.5.0.0 /usr/lib/
-
 # Working directory for the application
 WORKDIR /usr/src/app
 
 # copy requirements only, to reduce image size and improve cache usage
 COPY requirements.txt /usr/src/app/
+
+# tesseract 
+RUN printf "deb http://httpredir.debian.org/debian stretch-backports main non-free\ndeb-src http://httpredir.debian.org/debian stretch-backports main non-free" > /etc/apt/sources.list.d/backports.list \
+&& apt-get update && apt-get -y --allow-unauthenticated -t stretch-backports install tesseract-ocr libtesseract-dev
 
 # Install required system packages + python requirements + cleanup in one layer (yields smaller docker image). 
 # If you try to debug the build you should split into single RUN commands ;)
@@ -31,7 +23,6 @@ python-opencv \
 libsm6 \
 libxext6 \
 libxrender-dev \
-libtesseract-dev \
 tk \
 wget \
 && wget https://github.com/tesseract-ocr/tessdata/raw/master/eng.traineddata \


### PR DESCRIPTION
This is the Dockerfile we currently use to Build a docker-image for MAD.

As you see the dockerfile has two parts:
(1) In the first stage we have to compile tesseract, because the 3.7-slim python image has only access to tesseract 3.04 via apt. 
(2) In the second stage we copy the compiled binary and libaries  to our final image and then install all required packages and requirements to run MAD, finally we throw away everything we do not need to reduce image size even further.

We try to minimize the amount of layers, because the python-requirements and Open-CV blow up the image size drastically already. 
We end up with a final size of  916MB.

If you see (a) an opportunity to reduce the image size even further or (b) even come up with a solution to run it with an alpine base or (c) spot any bugs -  feel free to inform me :)