### PR TITLE
retry check_windows while waiting for injection

### DIFF
--- a/worker/MITMBase.py
+++ b/worker/MITMBase.py
@@ -132,6 +132,10 @@ class MITMBase(WorkerBase):
                 self._reboot(self._mitm_mapper)
                 return False
             logger.info("Worker {} is not injected till now (Count: {})", str(self._id), str(self._not_injected_count))
+            if self._not_injected_count in [5, 10, 15]:
+                logger.info("Worker {} will retry check_windows while waiting for injection at count {}",
+                        str(self._id), str(self._not_injected_count))
+                self._check_windows()
             if self._stop_worker_event.isSet():
                 logger.error("Worker {} get killed while waiting for injection", str(self._id))
                 return False


### PR DESCRIPTION
This will make handling the MARKETING screen more reliable.