### PR TITLE
Potentially webhook fix

### DIFF
--- a/webhook/webhookworker.py
+++ b/webhook/webhookworker.py
@@ -364,8 +364,6 @@ class WebhookWorker:
 
             if mon["pokemon_id"] in self.__IV_MON and (
                 mon["individual_attack"] is None
-                and mon["individual_defense"] is None
-                and mon["individual_stamina"] is None
             ):
                 # skipping this mon since IV has not been scanned yet
                 continue
@@ -586,13 +584,15 @@ class WebhookWorker:
         logger.info("Starting webhook worker thread")
 
         while not terminate_mad.is_set():
+            preparing_timestamp = int(time.time())
+
             # fetch data and create payload
             full_payload = self.__create_payload()
 
             # send our payload
             self.__send_webhook(full_payload)
 
-            self.__last_check = int(time.time())
+            self.__last_check = preparing_timestamp
             time.sleep(self.__worker_interval_sec)
 
         logger.info("Stopping webhook worker thread")


### PR DESCRIPTION
**I don't know why my Git closed #275 so reopen:**

Users reporting in Discord that they have missed some 100% IV Mons in their webhook clients. They were _probably_ not sent by MAD.
While reading the code I noticed that the `last_check` in webhookworker.py could cause a small race condition: If the query or the for-loop is slow we could miss Mons.

**Example:**
12:00:00:00: Big webhook preparing to send. Loop is slow because big amount of data.
12:00:01:00: Webhook finally sent. => `last_check` = 12:00:01
But the async scanner found a Mon:
12:00:00:50: Mon inserted into database with `last_modified` = 12:00:00
12:00:10:00: Next webhook preparing to send with Mons between 12:00:01 and 12:00:10.
=> Mon from 12:00:00:50 is missing.

~~So I added a 5 seconds interval to the query. Maybe this is too much and we can change it to 1-2 seconds.
Other method could be to modify the `tsdt`. But for me this is a more readable solution.~~

I also removed two unnecessary IF conditions to speed up the webhook-preparing loop.

~~Maybe this could also be a problem with raids and quests.~~

Feel free to merge, close or discuss.

Edit: Now it should work in a more simple way. The function can be slow as it wants, we'll not missing any data. Thank @temp666 for the idea and help.