### PR TITLE
Fix for malformed pokemon after weather/event changes

### DIFF
--- a/db/monocleWrapper.py
+++ b/db/monocleWrapper.py
@@ -621,7 +621,8 @@ class MonocleWrapper(DbWrapperBase):
             "ON DUPLICATE KEY UPDATE updated=VALUES(updated), atk_iv=VALUES(atk_iv), def_iv=VALUES(def_iv), "
             "sta_iv=VALUES(sta_iv), move_1=VALUES(move_1), move_2=VALUES(move_2), cp=VALUES(cp), "
             "level=VALUES(level), weight=VALUES(weight), costume=VALUES(costume), height=VALUES(height), "
-            "weather_boosted_condition=VALUES(weather_boosted_condition), pokemon_id=VALUES(pokemon_id)"
+            "weather_boosted_condition=VALUES(weather_boosted_condition), form=VALUES(form), "
+            "gender=VALUES(gender), pokemon_id=VALUES(pokemon_id)"
         )
 
         encounter_id = wild_pokemon['encounter_id']

--- a/db/monocleWrapper.py
+++ b/db/monocleWrapper.py
@@ -620,7 +620,8 @@ class MonocleWrapper(DbWrapperBase):
             "VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"
             "ON DUPLICATE KEY UPDATE updated=VALUES(updated), atk_iv=VALUES(atk_iv), def_iv=VALUES(def_iv), "
             "sta_iv=VALUES(sta_iv), move_1=VALUES(move_1), move_2=VALUES(move_2), cp=VALUES(cp), "
-            "level=VALUES(level), weight=VALUES(weight), costume=VALUES(costume), height=VALUES(height)"
+            "level=VALUES(level), weight=VALUES(weight), costume=VALUES(costume), height=VALUES(height), "
+            "weather_boosted_condition=VALUES(weather_boosted_condition), pokemon_id=VALUES(pokemon_id)"
         )
 
         encounter_id = wild_pokemon['encounter_id']

--- a/db/rmWrapper.py
+++ b/db/rmWrapper.py
@@ -714,7 +714,7 @@ class RmWrapper(DbWrapperBase):
             "gender=VALUES(gender), catch_prob_1=VALUES(catch_prob_1), catch_prob_2=VALUES(catch_prob_2), "
             "catch_prob_3=VALUES(catch_prob_3), rating_attack=VALUES(rating_attack), "
             "rating_defense=VALUES(rating_defense), weather_boosted_condition=VALUES(weather_boosted_condition), "
-            "costume=VALUES(costume), form=VALUES(form)"
+            "costume=VALUES(costume), form=VALUES(form), pokemon_id=VALUES(pokemon_id)"
         )
 
         vals = (


### PR DESCRIPTION
This fixes most of the malformed pokemon after event and/or weather changes. For example the falsely boosted community event mons after the event hours have ended.