### PR TITLE
New Monocle/RDM to RM Migration script

### DIFF
--- a/SQL/rocketmap.sql
+++ b/SQL/rocketmap.sql
@@ -308,6 +308,7 @@ CREATE TABLE `trs_quest` (
   `quest_target` tinyint(3) NOT NULL,
   `quest_condition` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `quest_reward` varchar(1000) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `quest_template` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `quest_task` varchar(150) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`GUID`),
   KEY `quest_type` (`quest_type`)

--- a/scripts/migrate_to_rocketmap.sh
+++ b/scripts/migrate_to_rocketmap.sh
@@ -34,7 +34,13 @@ read olddbname
 echo -n "Name for you new Database ?         "
 read newdbname
 
-DB_CHECK=$(MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "SHOW DATABASES;" | grep $newdbname)
+# Create Query function
+
+query(){
+MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "$1"
+}
+
+DB_CHECK=$(query "SHOW DATABASES;" | grep $newdbname)
 if [ ! -z "${DB_CHECK}" ]; then
        echo -e "\033[31m"
        echo "Database Already Exist. Cannot Proceed"
@@ -60,35 +66,35 @@ MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname < ../SQL/rocketmap.sql
 for table in trs_quest trs_spawn trs_spawnsightings trs_status trshash
 do
    echo "Importing $table..."
-   MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "INSERT INTO $table SELECT * FROM $olddbname.$table;"
+   query "INSERT INTO $table SELECT * FROM $olddbname.$table;"
 done
 
 for table in trs_s2cells trs_stats_detect trs_stats_detect_raw trs_stats_location trs_stats_location_raw trs_usage
 do
    echo "Creating and Importing $table..."
-   MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "CREATE TABLE $table LIKE $olddbname.$table;"
-   MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "INSERT INTO $table SELECT * FROM $olddbname.$table;"
+   query "CREATE TABLE $table LIKE $olddbname.$table;"
+   query "INSERT INTO $table SELECT * FROM $olddbname.$table;"
 done
 
 if [ $dbtype == 'monocle' ]
 then
 
       echo "Importing Gyms from forts..."
-      MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "INSERT INTO gym (gym_id, latitude, longitude) SELECT external_id, lat, lon from $olddbname.forts;"
+      query "INSERT INTO gym (gym_id, latitude, longitude) SELECT external_id, lat, lon from $olddbname.forts;"
       echo "Importing Gymdetails from forts..."
-      MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "INSERT INTO gymdetails (gym_id, name, url) SELECT external_id, IFNULL(name,''), IFNULL(url,'') from $olddbname.forts;"
+      query "INSERT INTO gymdetails (gym_id, name, url) SELECT external_id, IFNULL(name,''), IFNULL(url,'') from $olddbname.forts;"
       echo "Importing Pokestops..."
-      MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "INSERT INTO pokestop (pokestop_id, latitude, longitude, name, image) SELECT external_id, lat, lon, name, url from $olddbname.pokestops;"
+      query "INSERT INTO pokestop (pokestop_id, latitude, longitude, name, image) SELECT external_id, lat, lon, name, url from $olddbname.pokestops;"
 
 elif [ $dbtype == 'rdm' ]
 then
 
       echo "Importing Gyms from Gym..."
-      MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "INSERT INTO gym (gym_id, latitude, longitude) SELECT id, lat, lon from $olddbname.gym;"
+      query "INSERT INTO gym (gym_id, latitude, longitude) SELECT id, lat, lon from $olddbname.gym;"
       echo "Importing Gymdetails from Gym..."
-      MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "INSERT INTO gymdetails (gym_id, name, url) SELECT id, IFNULL(name,''), IFNULL(url,'') from $olddbname.gym;"
+      query "INSERT INTO gymdetails (gym_id, name, url) SELECT id, IFNULL(name,''), IFNULL(url,'') from $olddbname.gym;"
       echo "Importing Pokestops..."
-      MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "INSERT INTO pokestop (pokestop_id, latitude, longitude, name, image) SELECT id, lat, lon, name, url from $olddbname.pokestop;"
+      query "INSERT INTO pokestop (pokestop_id, latitude, longitude, name, image) SELECT id, lat, lon, name, url from $olddbname.pokestop;"
 
 fi
 

--- a/scripts/migrate_to_rocketmap.sh
+++ b/scripts/migrate_to_rocketmap.sh
@@ -1,89 +1,105 @@
 #!/bin/bash
 
-########################################################################################################
-#   This is the Monocle/RDM to Rocketmap migration script. Before you run this you should run          #
-# OSM-rocketmap and let it configure its database. After it has built its empty database you can run   #
-# this script to populate your rocketmap database with the gym and pokestop info from your monocle/RDM #
-# database. If you were using Monocle with MAD spawnpoints do not change, so I dump that table from    #
-# your monocle db and import it to your rocketmap db for you. If you have old spawnpoint info from     #
-# before MAD then you want to use import_allspawns.sh as well. This script does not import things like #
-# controlling team/mons, or ex status, because MAD will fill this in after 1 scan.                     #
-#                                                                                                      #
-# If you were already scanning in MAD using your Monocle database, be sure to remove version.json      #
-# so MAD will update your new rocketmap schema.                                                        #
-#                                                                                                      #
-# Blank RocketMap schema created via https://github.com/cecpk/OSM-Rocketmap properly working with MAD  #
-#       https://gist.github.com/sn0opy/fb654915180cfbd07d5a30407c286995                                #
-#                                                                                                      #
-# If you get an error like:                                                                            #
-#  "ERROR 1364 (HY000) at line 1: Field 'enabled' doesn't have a default value                         #
-# Then run this in mysql: SET GLOBAL sql_mode='' and run this script again.                            #
-########################################################################################################
-# Old database format (valid options: monocle/rdm)
-dbtype=""
+# Getting Config Items from User
 
-# Old database, Monocle or RDM format:
-# old database IP:
-olddbip="127.0.0.1"
-# old database username:
-olduser=""
-# old database pass:
-oldpass=""
-# old database name:
-olddbname=""
-# old database port:
-oldport="3306"
+echo ""
+echo "This script will create a new RM DB, create the full schema, and migrate your existing Monocle/RDM data to it".
+echo "It will need ROOT access to your DB to be able to perform those tasks"
+echo ""
+echo -n "IP of your Database ?               "
+read dbip
+echo -n "Running Port of you Database?       "
+read dbport
+echo -n "Root Password for your Database ?   "
+read -s dbpass
 
-# new database, Rocketmap format:
-# Rocketmap database IP:
-newdbip="127.0.0.1"
-# Rocketmap database username:
-newuser=""
-# Rocketmap database pass:
-newpass=""
-# Rocketmap database name:
-newdbname=""
-# Rocketmap database port:
-newport="3306"
-########################################################################################################
-###################################HAPPY HUNTING#####KRZTHEHUNTER#######################################
-########################################################################################################
-#                You should not edit below here unless you know what you're doing                      #
-########################################################################################################
-########################################################################################################
+# Checking Connectivity to Database
 
-case "$dbtype" in
- monocle) gymquery="select external_id, lat, lon, name, url, park from forts"
-          stopquery="select external_id, lat, lon, name, url from pokestops"
-          mysqldump -h "$olddbip" -u "$olduser" -p"$oldpass" -P "$oldport" "$olddbname" trs_spawn > /tmp/trs_spawn.sql
-          mysql -NB -h "$newdbip" -u "$newuser" -p"$newpass" -P "$newport" "$newdbname" < /tmp/trs_spawn.sql
-	  rm /tmp/trs_spawn.sql
-          mysqldump -h "$olddbip" -u "$olduser" -p"$oldpass" -P "$oldport" "$olddbname" trs_quest > /tmp/trs_quest.sql
-          mysql -NB -h "$newdbip" -u "$newuser" -p"$newpass" -P "$newport" "$newdbname" < /tmp/trs_quest.sql
-	  rm /tmp/trs_quest.sql
-       ;;
-     rdm) gymquery="select id, lat, lon, name, url from gym"
-          stopquery="select id, lat, lon, name, url from pokestop"
-       ;;
-       *) echo "you need to configure this script before running it" && exit
-       ;;
-esac
-oldquery(){
-mysql -NB -h "$olddbip" -u "$olduser" -p"$oldpass" -P "$oldport" "$olddbname" -e "$1"
-}
-newquery(){
-mysql -NB -h "$newdbip" -u "$newuser" -p"$newpass" -P "$newport" "$newdbname" -e "$1"
-}
-fix_quotes(){
-    echo $(sed -e "s/'/' \"'\" '/g" <<<"$*") 
-}
-while IFS=';' read -r eid lat lon name url ;do
- [[ $(newquery "select gym_id from gym where gym_id='$eid'") == "$eid" ]] && continue
- newquery "insert into gym set gym_id='$eid', latitude='$lat', longitude='$lon'" && \
- newquery "insert into gymdetails set gym_id='$eid', name='$(fix_quotes "$name")', url='$url'"
-done < <(oldquery "$gymquery"|sed 's/\x09/;/g')
+while ! mysql -h $dbip -P $dbport -u root -p$dbpass  -e ";" ; do
+       echo -e "\033[31m"
+       echo -n "Cannot connect to DB? Password ?  : "
+       echo -ne "\e[0m"
+       read dbpass
+done
 
-while IFS=';' read -r eid lat lon name url ;do
- [[ $(newquery "select pokestop_id from pokestop where pokestop_id='$eid'") == "$eid" ]] && continue
- newquery "insert into pokestop set pokestop_id='$eid', latitude='$lat', longitude='$lon', name='$(fix_quotes "$name")', image='$url'"
-done < <(oldquery "$stopquery"|sed 's/\x09/;/g')
+echo -e "\033[32m"
+echo "Connection Succesfull... Proceeding"
+echo ""
+echo -ne "\e[0m"
+
+echo -n "Old schema [rdm/monocle] ?          "
+read dbtype
+echo -n "Name of your old Database ?         "
+read olddbname
+echo -n "Name for you new Database ?         "
+read newdbname
+
+DB_CHECK=$(MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "SHOW DATABASES;" | grep $newdbname)
+if [ ! -z "${DB_CHECK}" ]; then
+       echo -e "\033[31m"
+       echo "Database Already Exist. Cannot Proceed"
+       echo ""
+       echo -ne "\e[0m"
+       exit
+fi
+
+echo -e "\033[32m"
+echo "Thanks, We got all we need. Starting Migration to $newdbname"
+echo ""
+echo -ne "\e[0m"
+
+# Creating DB and Schema
+
+echo "Creating New DATABASE..."
+MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport -e "CREATE DATABASE $newdbname;"
+echo "Creating RM DB Schema..."
+MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname < ../SQL/rocketmap.sql
+
+# Start Importing Data
+
+for table in trs_quest trs_spawn trs_spawnsightings trs_status trshash
+do
+   echo "Importing $table..."
+   MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "INSERT INTO $table SELECT * FROM $olddbname.$table;"
+done
+
+for table in trs_s2cells trs_stats_detect trs_stats_detect_raw trs_stats_location trs_stats_location_raw trs_usage
+do
+   echo "Creating and Importing $table..."
+   MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "CREATE TABLE $table LIKE $olddbname.$table;"
+   MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "INSERT INTO $table SELECT * FROM $olddbname.$table;"
+done
+
+if [ $dbtype == 'monocle' ]
+then
+
+      echo "Importing Gyms from forts..."
+      MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "INSERT INTO gym (gym_id, latitude, longitude) SELECT external_id, lat, lon from $olddbname.forts;"
+      echo "Importing Gymdetails from forts..."
+      MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "INSERT INTO gymdetails (gym_id, name, url) SELECT external_id, IFNULL(name,''), IFNULL(url,'') from $olddbname.forts;"
+      echo "Importing Pokestops..."
+      MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "INSERT INTO pokestop (pokestop_id, latitude, longitude, name, image) SELECT external_id, lat, lon, name, url from $olddbname.pokestops;"
+
+elif [ $dbtype == 'rdm' ]
+then
+
+      echo "Importing Gyms from Gym..."
+      MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "INSERT INTO gym (gym_id, latitude, longitude) SELECT id, lat, lon from $olddbname.gym;"
+      echo "Importing Gymdetails from Gym..."
+      MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "INSERT INTO gymdetails (gym_id, name, url) SELECT id, IFNULL(name,''), IFNULL(url,'') from $olddbname.gym;"
+      echo "Importing Pokestops..."
+      MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "INSERT INTO pokestop (pokestop_id, latitude, longitude, name, image) SELECT id, lat, lon, name, url from $olddbname.pokestop;"
+
+fi
+
+# Last User Interaction
+
+echo -e "\033[32m"
+echo "ALL DONE"
+echo -e "\033[93m"
+echo ""
+echo "IMPORTANT : If you were already scanning in MAD using your Monocle database, be sure to remove version.json"
+echo "This will let MAD create missing columns on your new RM schema"
+echo ""
+echo -ne "\e[0m"
+

--- a/scripts/migrate_to_rocketmap.sh
+++ b/scripts/migrate_to_rocketmap.sh
@@ -41,7 +41,7 @@ MYSQL_PWD=$dbpass mysql -h $dbip -P $dbport $newdbname -e "$1"
 }
 
 DB_CHECK=$(query "SHOW DATABASES;" | grep $newdbname)
-if [ ! -z "${DB_CHECK}" ]; then
+if [[ ! -z "${DB_CHECK}" ]]; then
        echo -e "\033[31m"
        echo "Database Already Exist. Cannot Proceed"
        echo ""
@@ -76,7 +76,7 @@ do
    query "INSERT INTO $table SELECT * FROM $olddbname.$table;"
 done
 
-if [ $dbtype == 'monocle' ]
+if [[ $dbtype == 'monocle' ]]
 then
 
       echo "Importing Gyms from forts..."
@@ -86,7 +86,7 @@ then
       echo "Importing Pokestops..."
       query "INSERT INTO pokestop (pokestop_id, latitude, longitude, name, image) SELECT external_id, lat, lon, name, url from $olddbname.pokestops;"
 
-elif [ $dbtype == 'rdm' ]
+elif [[ $dbtype == 'rdm' ]]
 then
 
       echo "Importing Gyms from Gym..."


### PR DESCRIPTION
Complete rework of the Monocle/RDM to Rocketmap Migration script

- Added User interactivity (easier than config for one-time script);
- Script will now create DB by itself.
- Script will now create the full RM schema by itself.
- Script will also take over all trs tables in order to make switch as transparent as possible.
- Checks added for DB connectivity before proceeding.
- Checks that target DB doens't already exist before proceeding.

I also added missing column in RM schema for trs_quest to make migration easier.

Tested successfully migrating my Monocle DB to RM. Probably needs testing from a RDM user as I don't have a DB to test it, but should be ok as most queries are the same. Please report any issue found. 