### PR TITLE
Rename Phonecontrol to Devicecontrol

### DIFF
--- a/configs/config.ini.example
+++ b/configs/config.ini.example
@@ -82,7 +82,7 @@
 
 # ADB
 ######################
-#use_adb                      # Use ADB for phonecontrol (Default: False)
+#use_adb                      # Use ADB for devicecontrol (Default: False)
 #adb_server_ip:               # IP address of ADB server (Default: 127.0.0.1)
 #adb_server_port:             # Port of ADB server (Default: 5037)
 

--- a/madmin/routes/control.py
+++ b/madmin/routes/control.py
@@ -34,7 +34,7 @@ class control(object):
 
     def add_route(self):
         routes = [
-            ("/phonecontrol", self.get_phonescreens),
+            ("/devicecontrol", self.get_phonescreens),
             ("/take_screenshot", self.take_screenshot),
             ("/click_screenshot", self.click_screenshot),
             ("/swipe_screenshot", self.swipe_screenshot),
@@ -113,7 +113,7 @@ class control(object):
                                                 dummy=True)
                             )
 
-        return render_template('phonescreens.html', editform=screens_phone, header="Phonecontrol", title="Phonecontrol",
+        return render_template('phonescreens.html', editform=screens_phone, header="Devicecontrol", title="Devicecontrol",
                                running_ocr=(self._args.only_ocr))
 
     @auth_required
@@ -233,7 +233,7 @@ class control(object):
         devicemappings = self._mapping_manager.get_all_devicemappings()
 
         adb = devicemappings.get(origin, {}).get('adb', False)
-        self._logger.info('MADmin: Restart Phone ({})', str(origin))
+        self._logger.info('MADmin: Restart Device ({})', str(origin))
         if (useadb == 'True' and
                 self._adb_connect.send_shell_command(
                         adb, origin,"am broadcast -a android.intent.action.BOOT_COMPLETED")):
@@ -241,7 +241,7 @@ class control(object):
         else:
             temp_comm = self._ws_server.get_origin_communicator(origin)
             temp_comm.reboot()
-        return redirect(getBasePath(request) + '/phonecontrol')
+        return redirect(getBasePath(request) + '/devicecontrol')
 
     @auth_required
     def clear_game_data(self):
@@ -258,7 +258,7 @@ class control(object):
         else:
             temp_comm = self._ws_server.get_origin_communicator(origin)
             temp_comm.resetAppdata("com.nianticlabs.pokemongo")
-        return redirect(getBasePath(request) + '/phonecontrol')
+        return redirect(getBasePath(request) + '/devicecontrol')
 
 
     @auth_required

--- a/madmin/static/vars/template/phone.tpl
+++ b/madmin/static/vars/template/phone.tpl
@@ -13,5 +13,5 @@
 <div id=button><a id=screenshot origin=<<phonename>> href='take_screenshot?origin=<<phonename>>&adb=<<adb_option>>'>Take Screenshot</a></div>
 <div id=button><a href='clear_game_data?origin=<<phonename>>&adb=<<adb_option>>' id='resetgamedata' origin=<<phonename>> class='confirm' title='Do you really want to clear data for pogo, this will result in the need to re-login?'>Reset Game Data</a></div>
 <div id=button><a href='quit_pogo?origin=<<phonename>>&adb=<<adb_option>>' id='quit' origin=<<phonename>>>Quit Pogo</a></div>
-<div id=button><a href='restart_phone?origin=<<phonename>>&adb=<<adb_option>>' class='confirm' title='Do you really want to restart phone?'>Reboot Phone</a></div>
+<div id=button><a href='restart_phone?origin=<<phonename>>&adb=<<adb_option>>' class='confirm' title='Do you really want to restart this device?'>Reboot Device</a></div>
 </div>

--- a/madmin/static/vars/vars_parser.json
+++ b/madmin/static/vars/vars_parser.json
@@ -120,7 +120,7 @@
           "settings": {
             "type": "text",
             "require": "false",
-            "description": "Set click delay for pokestop walker (VPS -> local phone) (Default: 0)"
+            "description": "Set click delay for pokestop walker (VPS -> local device) (Default: 0)"
           }
         },
         {
@@ -137,7 +137,7 @@
           "settings": {
             "type": "text",
             "require": "false",
-            "description": "Restart Phone after restart Pogo N times. (Default: 3)"
+            "description": "Restart Device after restart Pogo N times. (Default: 3)"
           }
         },
         {
@@ -161,7 +161,7 @@
           "settings": {
             "type": "text",
             "require": "false",
-            "description": "Adjust the x-axis click offset on phones with softbars and/or black upper bars. (+ right - left / Default: 0)"
+            "description": "Adjust the x-axis click offset on devices with softbars and/or black upper bars. (+ right - left / Default: 0)"
           }
         },
         {
@@ -169,7 +169,7 @@
           "settings": {
             "type": "text",
             "require": "false",
-            "description": "Adjust the y-axis click offset on phones with softbars and/or black upper bars. (+ down - up / Default: 0)"
+            "description": "Adjust the y-axis click offset on devices with softbars and/or black upper bars. (+ down - up / Default: 0)"
           }
         },
         {
@@ -229,7 +229,7 @@
           "settings": {
             "type": "text",
             "require": "false",
-            "description": "Declare a login address or domain from phone (Empty = first @gmail.com entry)<br>Use | to set more the one account (address|address)"
+            "description": "Declare a login address or domain from device (Empty = first @gmail.com entry)<br>Use | to set more the one account (address|address)"
           }
         },
         {
@@ -399,7 +399,7 @@
           "settings": {
             "type": "text",
             "require": "false",
-            "description": "Set click delay for pokestop walker (VPS -> local phone) (Default: 0)"
+            "description": "Set click delay for pokestop walker (VPS -> local device) (Default: 0)"
           }
         },
         {
@@ -416,7 +416,7 @@
           "settings": {
             "type": "text",
             "require": "false",
-            "description": "Restart Phone after restart Pogo N times. (Default: 3)"
+            "description": "Restart Device after restart Pogo N times. (Default: 3)"
           }
         },
         {
@@ -440,7 +440,7 @@
           "settings": {
             "type": "text",
             "require": "false",
-            "description": "Adjust the x-axis click offset on phones with softbars and/or black upper bars. (+ right - left / Default: 0)"
+            "description": "Adjust the x-axis click offset on devices with softbars and/or black upper bars. (+ right - left / Default: 0)"
           }
         },
         {
@@ -448,7 +448,7 @@
           "settings": {
             "type": "text",
             "require": "false",
-            "description": "Adjust the y-axis click offset on phones with softbars and/or black upper bars. (+ down - up / Default: 0)"
+            "description": "Adjust the y-axis click offset on devices with softbars and/or black upper bars. (+ down - up / Default: 0)"
           }
         },
         {

--- a/madmin/templates/base.html
+++ b/madmin/templates/base.html
@@ -61,7 +61,7 @@
                     </div>
                   </li>
                   <li class="nav-item">
-                    <a href="phonecontrol" class="nav-link">Phonecontrol</a>
+                    <a href="devicecontrol" class="nav-link">Devicecontrol</a>
                   </li>
 
                   {% if running_ocr %}

--- a/madmin/templates/index.html
+++ b/madmin/templates/index.html
@@ -13,7 +13,7 @@
     <h3><a href="showsettings">Mapping Editor</a></h3>
     <h3><a href="status">Status</a></h3>
     <h3><a href="statistics">Statistics</a></h3>
-    <h3><a href="phonecontrol">Phonecontrol</a></h3>
+    <h3><a href="devicecontrol">Devicecontrol</a></h3>
     {% if running_ocr %}
     <br />
     <h3><a href="raids">Check Raids</a></h3>

--- a/utils/walkerArgs.py
+++ b/utils/walkerArgs.py
@@ -259,7 +259,7 @@ def parseArgs():
 
     # adb
     parser.add_argument('-adb', '--use_adb', action='store_true', default=False,
-                        help='Use ADB for phonecontrol (Default: False)')
+                        help='Use ADB for device (Default: False)')
     parser.add_argument('-adbservip', '--adb_server_ip', default='127.0.0.1',
                         help='IP address of ADB server (Default: 127.0.0.1)')
 


### PR DESCRIPTION
I don't know if that's a useful PR but i thought it's more correct to use the term `device` instead of `phone` considering the increased popularity of ATVs

But maybe its just my inner monk and nobody cares about it :D if that's the case: just close the PR ^^