### PR TITLE
fix: Correct payload key for porcale mon weather

### DIFF
--- a/webhook/webhookworker.py
+++ b/webhook/webhookworker.py
@@ -430,7 +430,10 @@ class WebhookWorker:
                 mon["weather_boosted_condition"] is not None
                 and mon["weather_boosted_condition"] > 0
             ):
-                mon_payload["boosted_weather"] = mon["weather_boosted_condition"]
+                if self.__args.quest_webhook_flavor == "default":
+                    mon_payload["boosted_weather"] = mon["weather_boosted_condition"]
+                if self.__args.quest_webhook_flavor == "poracle":
+                    mon_payload["weather"] = mon["weather_boosted_condition"]
 
             entire_payload = {"type": "pokemon", "message": mon_payload}
             ret.append(entire_payload)


### PR DESCRIPTION
PoracleJS is using the `weather` key to determine if a pokemon has a weather boost however MAD defaults to using using the `boosted_weather` key. https://github.com/KartulUdus/PoracleJS/blob/3368ec2913de9b5407096e9842cb739b57dc4c46/src/controllers/monster.js#L137

This fixes the problem if someone sets the `quest_webhook_flavor` to poracle however this might cause an issue if someone uses another webhook for pokemon alerts?

Would the dev team rather create a new "mon_webhook_flavor" config option? Or can we just send both keys?
```json
mon_payload["boosted_weather"] = mon["weather_boosted_condition"]
mon_payload["weather"] = mon["weather_boosted_condition"]
```

I've tested this patch works but again maybe it's not the best solution long term. 