### PR TITLE
Ability to send non-iv'd mons (that are on iv list) via webhook.

### DIFF
--- a/configs/config.ini.example
+++ b/configs/config.ini.example
@@ -124,6 +124,8 @@
 #gym_webhook                 # Activate support for gym webhook (NOT required for raids!)
 #quest_webhook               # Activate support for quest webhook
 #quest_webhook_flavor:       # Mode for quest webhooks (default or poracle)
+#pokemon_webhook_nonivs      # By default MAD will not send mons without IV checked if they are on ANY Global Mon List. Enable this to have them (sometimes) send twice
+                             # once without IV, once with IV. Make sure your webhook reciever can work with the same encounter send twice [e.g. PokeAlarm needs dev branch] 
 
 # Dynamic Rarity
 ######################

--- a/utils/walkerArgs.py
+++ b/utils/walkerArgs.py
@@ -169,6 +169,8 @@ def parseArgs():
                         help='Comma-separated list of area names to exclude elements from within to be sent to a webhook')
     parser.add_argument('-pwh', '--pokemon_webhook', action='store_true', default=False,
                         help='Activate pokemon webhook support')
+    parser.add_argument('-pwhn', '--pokemon_webhook_nonivs', action='store_true', default=False,
+                        help='Send non-IVd pokemon even if they are on Global Mon List')
     parser.add_argument('-swh', '--pokestop_webhook', action='store_true', default=False,
                         help='Activate pokestop webhook support')
     parser.add_argument('-wwh', '--weather_webhook', action='store_true', default=False,

--- a/webhook/webhookworker.py
+++ b/webhook/webhookworker.py
@@ -362,9 +362,11 @@ class WebhookWorker:
             if self.__is_in_excluded_area([mon["latitude"], mon["longitude"]]):
                 continue
 
-            if not self.__args.pokemon_webhook_nonivs 
+            if (
+                not self.__args.pokemon_webhook_nonivs 
                 and mon["pokemon_id"] in self.__IV_MON 
-                and (mon["individual_attack"] is None):
+                and (mon["individual_attack"] is None)
+            ):
                 # skipping this mon since IV has not been scanned yet
                 continue
 

--- a/webhook/webhookworker.py
+++ b/webhook/webhookworker.py
@@ -362,9 +362,9 @@ class WebhookWorker:
             if self.__is_in_excluded_area([mon["latitude"], mon["longitude"]]):
                 continue
 
-            if mon["pokemon_id"] in self.__IV_MON and (
-                mon["individual_attack"] is None
-            ):
+            if not self.__args.pokemon_webhook_nonivs 
+                and mon["pokemon_id"] in self.__IV_MON 
+                and (mon["individual_attack"] is None):
                 # skipping this mon since IV has not been scanned yet
                 continue
 


### PR DESCRIPTION
By default MAD do not send non-iv'd pokemon via webhook if they are on ANY IV list.
It's still marked as #TODO and I don't want to mess with @sn0opy vision how to do it - this way we can safely enable sending non-IV'd mons to webhook, I guess.

Default behavior is not changed - user must uncomment a line in config.ini to have it working.

**WARNING**: Your webhook receiver must support getting same encounter twice - once with IVs, once without IVs. For example PokeAlarm does this only in dev branch.