### PR TITLE
Drop index if needed, old syntax not MySQL compatibile

### DIFF
--- a/db/dbWrapperBase.py
+++ b/db/dbWrapperBase.py
@@ -42,6 +42,22 @@ class DbWrapperBase(ABC):
                                         pool_size=self.application_args.db_poolsize,
                                         **self.dbconfig)
         self.pool_mutex.release()
+        
+    def check_index_exists(self, table, index):
+        query = (
+            "SELECT count(*) "
+            "FROM information_schema.columns "
+            "WHERE table_name = %s "
+            "AND index_name = %s "
+            "AND table_schema = %s"
+        )
+        vals = (
+            table,
+            index,
+            self.database,
+        )
+
+        return int(self.execute(query, vals)[0][0])
 
     def check_column_exists(self, table, column):
         query = (

--- a/db/dbWrapperBase.py
+++ b/db/dbWrapperBase.py
@@ -46,7 +46,7 @@ class DbWrapperBase(ABC):
     def check_index_exists(self, table, index):
         query = (
             "SELECT count(*) "
-            "FROM information_schema.columns "
+            "FROM information_schema.statistics "
             "WHERE table_name = %s "
             "AND index_name = %s "
             "AND table_schema = %s"

--- a/utils/version.py
+++ b/utils/version.py
@@ -287,7 +287,7 @@ class MADVersion(object):
                     "ALTER TABLE trs_stats_detect_raw "
                     "ADD INDEX typeworker (worker, type_id)"
                 )
-            index_exist = self.dbwrapper.check_column_exists(
+            index_exist = self.dbwrapper.check_index_exists(
                     'trs_stats_detect_raw', 'typeworker')
             
             if index_exist == 1:
@@ -298,14 +298,14 @@ class MADVersion(object):
                 self.dbwrapper.execute(query, commit=True)
             except Exception as e:
                 logger.exception("Unexpected error: {}", e)
-                               
+
             query = (
                 "ALTER TABLE trs_stats_detect_raw "
                 "ADD INDEX shiny (is_shiny)"
             )
-            index_exist = self.dbwrapper.check_column_exists(
+            index_exist = self.dbwrapper.check_index_exists(
                     'trs_stats_detect_raw', 'shiny')
-            
+
             if index_exist == 1:
                 query = (
                     "ALTER TABLE trs_stats_detect_raw DROP INDEX shiny; "

--- a/utils/version.py
+++ b/utils/version.py
@@ -240,10 +240,13 @@ class MADVersion(object):
                 "ADD quest_template VARCHAR(100) NULL DEFAULT NULL "
                 "AFTER quest_reward"
             )
-            try:
-                self.dbwrapper.execute(alter_query, commit=True)
-            except Exception as e:
-                logger.exception("Unexpected error: {}", e)
+            column_exist = self.dbwrapper.check_column_exists(
+                    'trs_quest', 'quest_template')
+            if column_exist == 0:
+                try:
+                    self.dbwrapper.execute(alter_query, commit=True)
+                except Exception as e:
+                    logger.exception("Unexpected error: {}", e)
 
         if self._version < 9:
             alter_query = (
@@ -277,10 +280,13 @@ class MADVersion(object):
                 "ADD is_shiny TINYINT(1) NOT NULL DEFAULT '0' "
                 "AFTER count"
             )
-            try:
-                self.dbwrapper.execute(query, commit=True)
-            except Exception as e:
-                logger.exception("Unexpected error: {}", e)
+            column_exist = self.dbwrapper.check_column_exists(
+                    'trs_stats_detect_raw', 'is_shiny')
+            if column_exist == 0:
+                try:
+                    self.dbwrapper.execute(query, commit=True)
+                except Exception as e:
+                    logger.exception("Unexpected error: {}", e)
 
         if self._version < 12:
             query = (
@@ -290,7 +296,7 @@ class MADVersion(object):
             index_exist = self.dbwrapper.check_index_exists(
                     'trs_stats_detect_raw', 'typeworker')
             
-            if index_exist == 1:
+            if index_exist >= 1:
                 query = (
                     "ALTER TABLE trs_stats_detect_raw DROP INDEX typeworker, ADD INDEX typeworker (worker, type_id)"
                 )     
@@ -306,7 +312,7 @@ class MADVersion(object):
             index_exist = self.dbwrapper.check_index_exists(
                     'trs_stats_detect_raw', 'shiny')
 
-            if index_exist == 1:
+            if index_exist >= 1:
                 query = (
                     "ALTER TABLE trs_stats_detect_raw DROP INDEX shiny, ADD INDEX shiny (is_shiny)"
                 )      

--- a/utils/version.py
+++ b/utils/version.py
@@ -292,8 +292,8 @@ class MADVersion(object):
             
             if index_exist == 1:
                 query = (
-                    "ALTER TABLE trs_stats_detect_raw DROP INDEX typeworker; "
-                ) + query       
+                    "ALTER TABLE trs_stats_detect_raw DROP INDEX typeworker, ADD INDEX typeworker (worker, type_id)"
+                )     
             try:
                 self.dbwrapper.execute(query, commit=True)
             except Exception as e:
@@ -308,8 +308,8 @@ class MADVersion(object):
 
             if index_exist == 1:
                 query = (
-                    "ALTER TABLE trs_stats_detect_raw DROP INDEX shiny; "
-                ) + query       
+                    "ALTER TABLE trs_stats_detect_raw DROP INDEX shiny, ADD INDEX shiny (is_shiny)"
+                )      
             try:
                 self.dbwrapper.execute(query, commit=True)
             except Exception as e:

--- a/utils/version.py
+++ b/utils/version.py
@@ -284,18 +284,32 @@ class MADVersion(object):
 
         if self._version < 12:
             query = (
-                "ALTER TABLE trs_stats_detect_raw DROP INDEX IF EXISTS typeworker, "
-                "ADD INDEX typeworker (worker, type_id)"
-            )
+                    "ALTER TABLE trs_stats_detect_raw "
+                    "ADD INDEX typeworker (worker, type_id)"
+                )
+            index_exist = self.dbwrapper.check_column_exists(
+                    'trs_stats_detect_raw', 'typeworker')
+            
+            if index_exist == 1:
+                query = (
+                    "ALTER TABLE trs_stats_detect_raw DROP INDEX typeworker; "
+                ) + query       
             try:
                 self.dbwrapper.execute(query, commit=True)
             except Exception as e:
                 logger.exception("Unexpected error: {}", e)
-
+                               
             query = (
-                "ALTER TABLE trs_stats_detect_raw DROP INDEX IF EXISTS shiny, "
+                "ALTER TABLE trs_stats_detect_raw "
                 "ADD INDEX shiny (is_shiny)"
             )
+            index_exist = self.dbwrapper.check_column_exists(
+                    'trs_stats_detect_raw', 'shiny')
+            
+            if index_exist == 1:
+                query = (
+                    "ALTER TABLE trs_stats_detect_raw DROP INDEX shiny; "
+                ) + query       
             try:
                 self.dbwrapper.execute(query, commit=True)
             except Exception as e:


### PR DESCRIPTION
Manually check if index exists (use >= 1, because those indexes can be multi column) and then drop and re-create it. Syntax DROP INDEX IF EXISTS is MariaDB syntax, not MySQL syntax - no "IF EXISTS" there.

Also added column check to previous versions so it will stop complaining in logs (after removing version.json) and confusing people with red errors.