### PR TITLE
is_exclusive in raid webhook

### DIFF
--- a/webhook/webhookworker.py
+++ b/webhook/webhookworker.py
@@ -343,6 +343,9 @@ class WebhookWorker:
 
             if raid["is_ex_raid_eligible"] is not None:
                 raid_payload["is_ex_raid_eligible"] = raid["is_ex_raid_eligible"]
+                
+            if raid["is_exclusive"] is not None:
+                raid_payload["is_exclusive"] = raid["is_exclusive"]
 
             if raid["gender"] is not None:
                 raid_payload["gender"] = raid["gender"]


### PR DESCRIPTION
We have that data already, just use it :)
webhook receivers can now distinguish between normal eggs and ex-raids eggs (not 'ex-raid eligible gyms'). Game (and MAD) does sent ex-eggs info to everyone, but not what actually hatched from those - you need invite for that.