### PR TITLE
Improve logging verbosity settings.

### DIFF
--- a/utils/logging.py
+++ b/utils/logging.py
@@ -6,8 +6,8 @@ from loguru import logger
 
 
 def initLogging(args):
-    log_level = logLevel(args.log_level, args.verbose)
-    log_file_level = logLevel(args.log_file_level, args.verbose)
+    log_level_label, log_level = logLevel(args.log_level, args.verbose)
+    _, log_file_level = logLevel(args.log_file_level, args.verbose)
     log_trace = log_level <= 10
     log_file_trace = log_file_level <= 10
 
@@ -64,7 +64,7 @@ def initLogging(args):
         logger.error("Logging parameters/configuration is invalid.")
         sys.exit(1)
 
-    logger.info("Setting log level to {}", str(log_level))
+    logger.info("Setting log level to {} ({}).", str(log_level), log_level_label)
 
 
 def logLevel(arg_log_level, arg_debug_level):
@@ -83,9 +83,8 @@ def logLevel(arg_log_level, arg_debug_level):
         ("ERROR", 40),
         ("CRITICAL", 50)
     ]
-
     # Case insensitive.
-    arg_log_level = arg_log_level.upper()
+    arg_log_level = arg_log_level.upper() if arg_log_level else None
     # Easy label->level lookup.
     verbosity_map = { k.upper(): v for k,v in verbosity_levels }
 
@@ -117,9 +116,9 @@ def logLevel(arg_log_level, arg_debug_level):
     # List goes from TRACE to DEBUG, -v=1=DEBUG is last index.
     # Note: List length is 1-based and so is count(-v).
     debug_level_idx = debug_levels_length - arg_debug_level
-    _, debug_level = debug_levels[debug_level_idx]
+    debug_label, debug_level = debug_levels[debug_level_idx]
 
-    return debug_level
+    return (debug_label, debug_level)
 
 
 def errorFilter(record):

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -106,9 +106,13 @@ def logLevel(arg_log_level, arg_debug_level):
     debug_levels_length = len(debug_levels)
 
     if arg_debug_level < 0 or arg_debug_level > debug_levels_length:
-        logger.debug("Verbosity -v={} is outside of the bounds [0, {}]. Changed to nearest limit.",
-                     str(arg_debug_level),
-                     str(debug_levels_length))
+        # Only show the message once per startup. This method is currently called once
+        # for console logging, once for file logging.
+        if not hasattr(logLevel, 'bounds_exceeded'):
+            logger.debug("Verbosity -v={} is outside of the bounds [0, {}]. Changed to nearest limit.",
+                        str(arg_debug_level),
+                        str(debug_levels_length))
+            logLevel.bounds_exceeded = True
 
         arg_debug_level = min(arg_debug_level, debug_levels_length)
         arg_debug_level = max(arg_debug_level, 0)


### PR DESCRIPTION
## Description
Changes how log level is determined.

## Motivation and Context
The old method did `11 - arg.log_level`. That wasn't flexible and broke MAD if you set it to anything too high.

New:
* Doesn't crash when you set verbosity to above the limit, e.g. `-vvvvvvvvvvvvvvvvvvvvv`. Instead it sets it to the highest available log level and shows a `DEBUG` message (see screenshot).
* Setting log level via name (e.g. `"DEBUG"`) is now case insensitive.
* Shows the name of the log level in console.
* Debug log level steps no longer have to be 1 by 1. Jumps can be whatever they want, it'll automatically pick the right level in the sequence.
* Replaced magic numbers by log level label (`map.get(label)`) via the log level map.

## How Has This Been Tested?
Dungus Maximus helped me test it. @LegitDongo 

More testing is definitely welcome, for both the numeric `-v` and the log level by name.

## Screenshots:
![image](https://user-images.githubusercontent.com/4874269/63214427-5b7ff880-c118-11e9-917c-4d632f8c150c.png)
![image](https://user-images.githubusercontent.com/4874269/63214430-6044ac80-c118-11e9-9964-fdfbe9519e91.png)
![image](https://user-images.githubusercontent.com/4874269/63214447-8ff3b480-c118-11e9-9dfa-702270d841dd.png)
![image](https://user-images.githubusercontent.com/4874269/63214432-63d83380-c118-11e9-8706-efeb7d182212.png)
![image](https://user-images.githubusercontent.com/4874269/63214434-676bba80-c118-11e9-80c6-304518b68e4f.png)
![image](https://user-images.githubusercontent.com/4874269/63214437-6aff4180-c118-11e9-8291-d19551fb8fa6.png)
![image](https://user-images.githubusercontent.com/4874269/63214441-72bee600-c118-11e9-9d02-e4134f207332.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project.