### PR TITLE
Multiworld support when saving geofences from madmin

### DIFF
--- a/madmin/routes/map.py
+++ b/madmin/routes/map.py
@@ -361,7 +361,8 @@ class map(object):
         file = open(os.path.join(geofence_file_path, (str(name) + ".txt")), "a")
         file.write("[" + str(name) + "]\n")
         for i in range(len(coords_split)):
-            file.write(str(coords_split[i]) + "\n")
+            latlon_split = coords_split[i].split(",")
+            file.write("{0},{1}\n".format(str(float(latlon_split[0]) % 90), str(float(latlon_split[0]) % 360)))
 
         file.close()
 


### PR DESCRIPTION
Leaflet handles very zoomed out views by simply adding multiple worlds. This causes coordinates from it to not always be inside [90, 360] - this fix makes sure we don't duck up saving of geofences.