### PR TITLE
Prevent leaflet rendering multiple worlds.

### DIFF
--- a/madmin/static/js/madmin.js
+++ b/madmin/static/js/madmin.js
@@ -1406,14 +1406,25 @@ new Vue({
       // get stored center and zoom level if they exists
       const storedZoom = this.getStoredSetting('zoomlevel', 3);
       const storedCenter = this.getStoredSetting('center', '52.521374,13.411201');
-      leaflet_data.tileLayer = L.tileLayer(this.maptiles[this.settings.maptiles].url);
+      leaflet_data.tileLayer = L.tileLayer(this.maptiles[this.settings.maptiles].url, {
+        noWrap: true,
+        bounds: [
+          [-90, -180],
+          [90, 180]
+        ]
+      });
 
       map = L.map('map', {
         layers: [leaflet_data.tileLayer],
         zoomControl: false,
         updateWhenZooming: false,
         updateWhenIdle: true,
-        preferCanvas: true
+        preferCanvas: true,
+        worldCopyJump: true,
+        maxBounds: [
+          [-90, -180],
+          [90, 180]
+        ]
       }).setView(storedCenter.split(','), storedZoom);
 
       // add custom button


### PR DESCRIPTION
## Description
More robust implementation to prevent issues with leaflet rendering multiple worlds, causing issues with marker locations, bounds, geofences, etc.

Relies on leaflet's own bound limits and lesser known features.

[Reference here](https://leafletjs.com/reference-1.5.0.html). Settings used:

**L.tileLayer:**
* noWrap
* bounds

**L.map:**
* worldCopyJump
* maxBounds

## Motivation and Context
* Extends #335.
* Fixes #329.

Also fixes the issue of markers not rendering outside of the first world.

## How Has This Been Tested?
Untested.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project.