### PR TITLE
Update map.py to ignore empty trailing pipe.

### DIFF
--- a/madmin/routes/map.py
+++ b/madmin/routes/map.py
@@ -361,7 +361,7 @@ class map(object):
 
         file = open(os.path.join(geofence_file_path, (str(name) + ".txt")), "a")
         file.write("[" + str(name) + "]\n")
-        for i in range(len(coords_split)):
+        for i in range(len(coords_split)-1):
             latlon_split = coords_split[i].split(",")
             file.write("{0},{1}\n".format(str(float(latlon_split[0]) % 90), str(float(latlon_split[0]) % 360)))
 


### PR DESCRIPTION
Currently saving geofences has a | at the end, but the code throws an error. May be more elegant ways to fix this issue, but this quick fix removes parsing the last one. Could do an error catch but this fixed it for me near immediately.