### PR TITLE
Fix oversight in spinnable check

### DIFF
--- a/worker/WorkerQuests.py
+++ b/worker/WorkerQuests.py
@@ -590,7 +590,7 @@ class WorkerQuests(MITMBase):
             # wait for GMO in case we moved too far away
             data_received = self._wait_for_data(
                     timestamp=timestamp, proto_to_wait_for=106, timeout=35)
-            if data_received == LatestReceivedType.UNDEFINED and not self._current_position_has_spinnable_stop(timestamp):
+            if data_received != LatestReceivedType.UNDEFINED and not self._current_position_has_spinnable_stop(timestamp):
                 logger.info("Stop {}, {} considered to be ignored in the next round due to failed spinnable check",
                             str(self.current_location.lat), str(self.current_location.lng))
                 self._mapping_manager.routemanager_add_coords_to_be_removed(self._routemanager_name,


### PR DESCRIPTION
If spinnable check fails in first try, we add stop to ignore list ONLY if we didn't get a new GMO.

This causes clients that are bugged out (player char is gone from overworld view + no map features visible) to simply start ignoring any and all pokestops instead of timing out and restarting pogo after N amount of retries.

This *should* reduce amount of stops we skip because of a bugged out worker by only considering stops to be ignored IF we got a GMO AND the stop wasn't in that GMO.