### PR TITLE
Fix saving geofence coords for negative values

### DIFF
--- a/madmin/routes/map.py
+++ b/madmin/routes/map.py
@@ -364,7 +364,7 @@ class map(object):
         for i in range(len(coords_split)):
             if coords_split[i] != '':
                 latlon_split = coords_split[i].split(",")
-                file.write("{0},{1}\n".format(str(float(latlon_split[0]) % 90), str(float(latlon_split[1]) % 360)))
+                file.write("{0},{1}\n".format(str(float(latlon_split[0])), str(float(latlon_split[1]))))
 
         file.close()
 


### PR DESCRIPTION
There are bounds there in map definition now, there is no need for modulo 360/90.
Btw. it was broken before too.
```
>>> 80%360
80
>>> -80%360
280
```