### PR TITLE
Add trs_s2cells table to rocketmap.sql

### DIFF
--- a/scripts/SQL/rocketmap.sql
+++ b/scripts/SQL/rocketmap.sql
@@ -303,6 +303,14 @@ CREATE TABLE `trs_quest` (
   KEY `quest_type` (`quest_type`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+CREATE TABLE `trs_s2cells` (
+  `id` bigint(20) unsigned NOT NULL,
+  `level` int(11) NOT NULL,
+  `center_latitude` double NOT NULL,
+  `center_longitude` double NOT NULL,
+  `updated` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `trs_spawn` (
   `spawnpoint` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,


### PR DESCRIPTION
I created a new instance from scratch for testing and kept getting errors since the trs_s2cells table didn't exist.

```bash
09-03 17:01:57.05] [   MITMReceiver-0] [      dbWrapperBase:174 ] [   ERROR] Failed executing query: 1146 (42S02): Table 'mad.trs_s2cells' doesn't exist
```