### PR TITLE
Show sleep time in status page

### DIFF
--- a/db/dbWrapperBase.py
+++ b/db/dbWrapperBase.py
@@ -839,7 +839,7 @@ class DbWrapperBase(ABC):
                  ' globalrestartcount INT(11) NULL DEFAULT 0, '
                  ' lastPogoReboot VARCHAR(50) NULL DEFAULT NULL , '
                  ' globalrebootcount INT(11) NULL DEFAULT 0, '
-                 ' currentSleepTime INT(11) NOT NULL DEFAULT 0'
+                 ' currentSleepTime INT(11) NOT NULL DEFAULT 0, '
                  ' PRIMARY KEY (origin))')
 
         self.execute(query, commit=True)

--- a/db/dbWrapperBase.py
+++ b/db/dbWrapperBase.py
@@ -836,6 +836,10 @@ class DbWrapperBase(ABC):
                  ' init TEXT NOT NULL, '
                  ' rebootingOption TEXT NOT NULL, '
                  ' restartCounter TEXT NOT NULL, '
+                 ' globalrestartcount INT(11) NULL DEFAULT 0, '
+                 ' lastPogoReboot VARCHAR(50) NULL DEFAULT NULL , '
+                 ' globalrebootcount INT(11) NULL DEFAULT 0, '
+                 ' currentSleepTime INT(11) NOT NULL DEFAULT 0'
                  ' PRIMARY KEY (origin))')
 
         self.execute(query, commit=True)
@@ -946,19 +950,20 @@ class DbWrapperBase(ABC):
         query = (
             "INSERT into trs_status (origin, currentPos, lastPos, routePos, routeMax, "
             "routemanager, rebootCounter, lastProtoDateTime, "
-            "init, rebootingOption, restartCounter) values "
-            "(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"
+            "init, rebootingOption, restartCounter, currentSleepTime) values "
+            "(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"
             "ON DUPLICATE KEY UPDATE currentPos=VALUES(currentPos), "
             "lastPos=VALUES(lastPos), routePos=VALUES(routePos), "
             "routeMax=VALUES(routeMax), routemanager=VALUES(routemanager), "
             "rebootCounter=VALUES(rebootCounter), lastProtoDateTime=VALUES(lastProtoDateTime), "
-            "init=VALUES(init), rebootingOption=VALUES(rebootingOption), restartCounter=VALUES(restartCounter)"
+            "init=VALUES(init), rebootingOption=VALUES(rebootingOption), restartCounter=VALUES(restartCounter), "
+            "currentSleepTime=VALUES(currentSleepTime)"
         )
         vals = (
             data["Origin"], str(data["CurrentPos"]), str(
                 data["LastPos"]), data["RoutePos"], data["RouteMax"],
             data["Routemanager"], data["RebootCounter"], data["LastProtoDateTime"],
-            data["Init"], data["RebootingOption"], data["RestartCounter"]
+            data["Init"], data["RebootingOption"], data["RestartCounter"], data["CurrentSleepTime"]
         )
         self.execute(query, vals, commit=True)
         return
@@ -1005,14 +1010,15 @@ class DbWrapperBase(ABC):
         query = (
             "SELECT origin, currentPos, lastPos, routePos, routeMax, "
             "routemanager, rebootCounter, lastProtoDateTime, lastPogoRestart, "
-            "init, rebootingOption, restartCounter, globalrebootcount, globalrestartcount, lastPogoReboot "
+            "init, rebootingOption, restartCounter, globalrebootcount, globalrestartcount, lastPogoReboot, "
+            "currentSleepTime "
             "FROM trs_status"
         )
 
         result = self.execute(query)
         for (origin, currentPos, lastPos, routePos, routeMax, routemanager,
                 rebootCounter, lastProtoDateTime, lastPogoRestart, init, rebootingOption, restartCounter,
-                globalrebootcount, globalrestartcount, lastPogoReboot) in result:
+                globalrebootcount, globalrestartcount, lastPogoReboot, currentSleepTime) in result:
             status = {
                 "origin": origin,
                 "currentPos": currentPos,
@@ -1028,7 +1034,8 @@ class DbWrapperBase(ABC):
                 "restartCounter": restartCounter,
                 "lastPogoReboot": lastPogoReboot,
                 "globalrebootcount": globalrebootcount,
-                "globalrestartcount": globalrestartcount
+                "globalrestartcount": globalrestartcount,
+                "currentSleepTime": currentSleepTime
 
             }
 

--- a/madmin/templates/status.html
+++ b/madmin/templates/status.html
@@ -28,6 +28,7 @@
                 { data: 'routeMax', title: 'Route Length' },
                 { data: 'init', title: 'Init Mode' },
                 { data: 'lastProtoDateTime', title: 'Last Date/Time of Data' },
+                { data: 'currentSleepTime', title: 'Next Action' },
                 { data: 'restartCounter', title: 'Restart Counter' },
                 { data: 'rebootingOption', title: 'Reboot Device' },
                 { data: 'rebootCounter', title: 'Reboot Counter' },
@@ -59,9 +60,20 @@
 
                         return "None";
                     }
+                },
+                {
+                    "targets": [6],
+                    "render": function (data, type, row) {
+                        if(data == '0' || data == 0) {
+                            return 'Now'
+                        }
+                        var dateToShow = new moment().add(parseInt(data),"seconds")
+
+                        return dateToShow.fromNow(true);
+                    }
                 }
             ],
-            "order": [[5, "asc"]],
+            "order": [[0, "asc"]],
             "responsive": {{ responsive }},
             "autoWidth": false,
             "stateSave": true

--- a/utils/version.py
+++ b/utils/version.py
@@ -5,7 +5,7 @@ from utils.logging import logger
 
 from .convert_mapping import convert_mappings
 
-current_version = 12
+current_version = 13
 
 
 class MADVersion(object):
@@ -233,6 +233,18 @@ class MADVersion(object):
                 self.dbwrapper.execute(query, commit=True)
             except Exception as e:
                 logger.exception("Unexpected error: {}", e)
+
+        if self._version < 13:
+            # Adding current_sleep for worker status
+            if self.dbwrapper.check_column_exists('trs_status', 'currentSleepTime') == 0:
+                query = (
+                    "ALTER TABLE trs_status "
+                    "ADD currentSleepTime INT(11) NOT NULL DEFAULT 0"
+                )
+                try:
+                    self.dbwrapper.execute(query, commit=True)
+                except Exception as e:
+                    logger.exception("Unexpected error: {}", e)
 
         self.set_version(current_version)
 

--- a/worker/MITMBase.py
+++ b/worker/MITMBase.py
@@ -39,6 +39,7 @@ class MITMBase(WorkerBase):
         self._mitm_mapper = mitm_mapper
         self._latest_encounter_update = 0
         self._encounter_ids = {}
+        self._current_sleep_time = 0
 
         self._mitm_mapper.collect_location_stats(self._id, self.current_location, 1, time.time(), 2, 0,
                                                  self._mapping_manager.routemanager_get_mode(self._routemanager_name),
@@ -270,7 +271,8 @@ class MITMBase(WorkerBase):
             'RoutePos':          str(routemanager_status[0]),
             'RouteMax':          str(routemanager_status[1]),
             'Init':              str(routemanager_init),
-            'LastProtoDateTime': str(self._rec_data_time)
+            'LastProtoDateTime': str(self._rec_data_time),
+            'CurrentSleepTime': str(self._current_sleep_time)
         }
 
         self._db_wrapper.save_status(dataToSave)


### PR DESCRIPTION
Allows (quest) workers to save the current sleep time in status table so it can be seen in madmin worker status page like this: 

![image](https://user-images.githubusercontent.com/5710881/64339099-8953b100-cfe3-11e9-9446-97651afaeef9.png)

Why? Because then you can see if it's actually stuck or just on a long sleep time between areas.

Tested a bit, but more tested needed 🙏 

Also fixes some missing columns in the code for new dbs `trs_status` table
