### PR TITLE
Add option to disable coloring in stdout/err

### DIFF
--- a/utils/logging.py
+++ b/utils/logging.py
@@ -11,14 +11,44 @@ def initLogging(args):
     log_trace = log_level <= 10
     log_file_trace = log_file_level <= 10
 
-    logconfig = {
-        "levels": [
+    if args.no_color:
+        logconfig = {
+            "levels": [
+            {"name": "DEBUG2", "no": 9},
+            {"name": "DEBUG3", "no": 8},
+            {"name": "DEBUG4", "no": 7},
+            {"name": "DEBUG5", "no": 6}
+        ],
+            "handlers": [
+            {
+                "sink": sys.stdout,
+                "format": "[{time:MM-DD HH:mm:ss.SS}] [{thread.name: >17}] [{module: >19}:{line: <4}] [<lvl>{level: >8}</lvl>] <level>{message}</level>",
+                "colorize": False,
+                "level": log_level,
+                "enqueue": True,
+                "filter": errorFilter
+            },
+            {
+                "sink": sys.stderr,
+                "format": "[{time:MM-DD HH:mm:ss.SS}] [{thread.name: >17}] [{module: >19}:{line: <4}] [<lvl>{level: >8}</lvl>] <level>{message}</level>",
+
+                "colorize": False,
+                "level": "ERROR",
+                "backtrace": log_trace,
+                "enqueue": True
+            }
+        ]
+    }
+
+    if not args.no_color:
+        logconfig = {
+            "levels": [
             {"name": "DEBUG2", "no": 9, "color": "<blue>"},
             {"name": "DEBUG3", "no": 8, "color": "<blue>"},
             {"name": "DEBUG4", "no": 7, "color": "<blue>"},
             {"name": "DEBUG5", "no": 6, "color": "<blue>"}
         ],
-        "handlers": [
+            "handlers": [
             {
                 "sink": sys.stdout,
                 "format": "[<cyan>{time:MM-DD HH:mm:ss.SS}</cyan>] [<cyan>{thread.name: >17}</cyan>] [<cyan>{module: >19}:{line: <4}</cyan>] [<lvl>{level: >8}</lvl>] <level>{message}</level>",

--- a/utils/walkerArgs.py
+++ b/utils/walkerArgs.py
@@ -314,7 +314,10 @@ def parseArgs():
                          type=int, dest='verbose')
     parser.set_defaults(DEBUG=False)
 
-    args = parser.parse_args()
+    parser.add_argument('-nc', '--no_color', action='store_true', default=False,
+                        help=("Disable colored output in stdout and stderr"))
+	
+	args = parser.parse_args()
 
     # Allow status name and date formatting in log filename.
     args.log_filename = strftime(args.log_filename)


### PR DESCRIPTION
Perhaps useful for those who running MAD by systemd. Color codes make the syslog difficult to read.

Added option -nc (--no_color) to cmdline to disable coloring in stdout/stderr.
MAD can be run by systemd and split logs using syslog into a seperate logfile. So every output logged to stdout/stderr including tracebacks is written to this file.

My first PR. Possibly dirty code ahed :-)