### PR TITLE
'Last possible moved' timestamp in /status/

### DIFF
--- a/mitm_receiver/MITMDataProcessor.py
+++ b/mitm_receiver/MITMDataProcessor.py
@@ -83,6 +83,7 @@ class MitmDataProcessor(Process):
                 self.__db_wrapper.submit_mons_map_proto(
                     origin, data["payload"], mon_ids_iv, self.__mitm_mapper)
                 self.__db_wrapper.submit_cells(origin, data["payload"])
+                self.__mitm_mapper.submit_gmo_for_location(origin, data["payload"])
                 logger.debug2("Done processing GMO of {}".format(origin))
             elif type == 102:
                 playerlevel = self.__mitm_mapper.get_playerlevel(origin)

--- a/mitm_receiver/MITMReceiver.py
+++ b/mitm_receiver/MITMReceiver.py
@@ -184,6 +184,7 @@ class MITMReceiver(Process):
             origin_return[origin]['injection_status'] = self.__mitm_mapper.get_injection_status(origin)
             origin_return[origin]['latest_data'] = self.__mitm_mapper.request_latest(origin, 'timestamp_last_data')
             origin_return[origin]['mode_value'] = self.__mitm_mapper.request_latest(origin, 'injected_settings')
+            origin_return[origin]['last_possibly_moved'] = self.__mitm_mapper.get_last_timestamp_possible_moved(origin)
 
         for process in self.worker_threads:
             process_return['MITMReceiver-' + str(process_count)] = {}

--- a/mitm_receiver/MitmMapper.py
+++ b/mitm_receiver/MitmMapper.py
@@ -26,6 +26,8 @@ class MitmMapper(object):
         self.__mapping_mutex = Lock()
         self.__mapping_manager: MappingManager = mapping_manager
         self.__injected = {}
+        self.__last_cellsid = {}
+        self.__last_possibly_moved = {}
         self.__application_args = args
         self.__db_wrapper: DbWrapperBase = db_wrapper
         self.__playerstats_db_update_stop: Event = Event()

--- a/mitm_receiver/MitmMapper.py
+++ b/mitm_receiver/MitmMapper.py
@@ -182,28 +182,23 @@ class MitmMapper(object):
         if self.__playerstats.get(origin, None) is not None:
             self.__playerstats.get(origin).gen_player_stats(inventory_proto)
 
-     def submit_gmo_for_location(self, origin, payload):
-         logger.debug4("submit_gmo_for_location of {}", origin)
-         cells = payload.get("cells", None)
-         # can this even happen?
-         if cells is None:
-             return
- 
-         current_cells_id = sorted(list(map(lambda x : x['id'], cells)))
-         if origin in self.__last_cellsid:
-              last_cells_id = self.__last_cellsid[origin]
-              self.__last_cellsid[origin] = current_cells_id
-              if last_cells_id != current_cells_id:
-                  #logger.debug4("Worker {} has moved from {} to {}", origin, last_cells_id, current_cells_id)
-                  self.__last_possibly_moved[origin] = time.time()
-                  # update timestamp
-              #else:
-                  #logger.debug4("Worker {} has NOT moved from {} to {}", origin, last_cells_id, current_cells_id)
-         else:
-             # just started, nothing to do here
-             self.__last_cellsid[origin] = current_cells_id
-             self.__last_possibly_moved[origin] = time.time()
-         logger.debug4("Done submit_gmo_for_location of {} with {}", origin, current_cells_id)
- 
-     def get_last_timestamp_possible_moved(self, origin):
-         return self.__last_possibly_moved.get(origin, None)
+    def submit_gmo_for_location(self, origin, payload):
+        logger.debug4("submit_gmo_for_location of {}", origin)
+        cells = payload.get("cells", None)
+        
+        if cells is None:
+            return
+
+        current_cells_id = sorted(list(map(lambda x : x['id'], cells)))
+        if origin in self.__last_cellsid:
+            last_cells_id = self.__last_cellsid[origin]
+            self.__last_cellsid[origin] = current_cells_id
+            if last_cells_id != current_cells_id:
+                self.__last_possibly_moved[origin] = time.time()
+        else:
+            self.__last_cellsid[origin] = current_cells_id
+            self.__last_possibly_moved[origin] = time.time()
+        logger.debug4("Done submit_gmo_for_location of {} with {}", origin, current_cells_id)
+
+    def get_last_timestamp_possible_moved(self, origin):
+        return self.__last_possibly_moved.get(origin, None)

--- a/mitm_receiver/MitmMapper.py
+++ b/mitm_receiver/MitmMapper.py
@@ -179,4 +179,28 @@ class MitmMapper(object):
     def generate_player_stats(self, origin: str, inventory_proto: dict):
         if self.__playerstats.get(origin, None) is not None:
             self.__playerstats.get(origin).gen_player_stats(inventory_proto)
-
+     def submit_gmo_for_location(self, origin, payload):
+         logger.debug4("submit_gmo of {}", origin)
+         cells = payload.get("cells", None)
+         # can this even happen?
+         if cells is None:
+             return
+ 
+         current_cells_id = sorted(list(map(lambda x : x['id'], cells)))
+         if origin in self.__last_cellsid:
+              last_cells_id = self.__last_cellsid[origin]
+              self.__last_cellsid[origin] = current_cells_id
+              if last_cells_id != current_cells_id:
+                  #logger.debug4("Worker {} has moved from {} to {}", origin, last_cells_id, current_cells_id)
+                  self.__last_possibly_moved[origin] = time.time()
+                  # update timestamp
+              #else:
+                  #logger.debug4("Worker {} has NOT moved from {} to {}", origin, last_cells_id, current_cells_id)
+         else:
+             # just started, nothing to do here
+             self.__last_cellsid[origin] = current_cells_id
+             self.__last_possibly_moved[origin] = time.time()
+         logger.debug4("Done submit_gmo of {} with {}", origin, current_cells_id)
+ 
+     def get_last_timestamp_possible_moved(self, origin):
+         return self.__last_possibly_moved.get(origin, None)

--- a/mitm_receiver/MitmMapper.py
+++ b/mitm_receiver/MitmMapper.py
@@ -179,8 +179,9 @@ class MitmMapper(object):
     def generate_player_stats(self, origin: str, inventory_proto: dict):
         if self.__playerstats.get(origin, None) is not None:
             self.__playerstats.get(origin).gen_player_stats(inventory_proto)
+
      def submit_gmo_for_location(self, origin, payload):
-         logger.debug4("submit_gmo of {}", origin)
+         logger.debug4("submit_gmo_for_location of {}", origin)
          cells = payload.get("cells", None)
          # can this even happen?
          if cells is None:
@@ -200,7 +201,7 @@ class MitmMapper(object):
              # just started, nothing to do here
              self.__last_cellsid[origin] = current_cells_id
              self.__last_possibly_moved[origin] = time.time()
-         logger.debug4("Done submit_gmo of {} with {}", origin, current_cells_id)
+         logger.debug4("Done submit_gmo_for_location of {} with {}", origin, current_cells_id)
  
      def get_last_timestamp_possible_moved(self, origin):
          return self.__last_possibly_moved.get(origin, None)


### PR DESCRIPTION
Every submitted GMO look at cellsid in that GMO and if those cellsid changed from last (saved) set current timestamp to now - as 'last time worker possibly moved'. It's used now in that amazing /status/ JSON - just to monitor of your device isn't stuck somewhere - maybe routemanager died, maybe no more coords, maybe RGC died. 

