### PR TITLE
Real levelup mode that remembers what is already visited

### DIFF
--- a/db/dbWrapperBase.py
+++ b/db/dbWrapperBase.py
@@ -423,10 +423,9 @@ class DbWrapperBase(ABC):
         return spawnret
 
     def submit_pokestop_visited(self, origin, latitude, longitude):
-        logger.info("Flag pokestop as visited")
+        logger.debug("Flag pokestop as visited...")
         query = "INSERT IGNORE INTO trs_visited SELECT pokestop_id,'{}' " \
                 "FROM pokestop WHERE latitude={} AND longitude={}".format(origin, str(latitude), str(longitude))
-        logger.info("Query: {}", query)
         self.execute(query, commit=True)
 
     def submit_spawnpoints_map_proto(self, origin, map_proto):

--- a/db/dbWrapperBase.py
+++ b/db/dbWrapperBase.py
@@ -422,6 +422,13 @@ class DbWrapperBase(ABC):
             spawnret[int(row[0])] = row[1]
         return spawnret
 
+    def submit_pokestop_visited(self, origin, latitude, longitude):
+        logger.info("Flag pokestop as visited")
+        query = "INSERT IGNORE INTO trs_visited SELECT pokestop_id,'{}' " \
+                "FROM pokestop WHERE latitude={} AND longitude={}".format(origin, str(latitude), str(longitude))
+        logger.info("Query: {}", query)
+        self.execute(query, commit=True)
+
     def submit_spawnpoints_map_proto(self, origin, map_proto):
         logger.debug(
             "DbWrapperBase::submit_spawnpoints_map_proto called with data received by {}", str(origin))

--- a/madmin/routes/control.py
+++ b/madmin/routes/control.py
@@ -71,7 +71,8 @@ class control(object):
             ("/get_all_workers", self.get_all_workers),
             ("/job_for_worker", self.job_for_worker),
             ("/reload_jobs", self.reload_jobs),
-            ("/trigger_research_menu", self.trigger_research_menu)
+            ("/trigger_research_menu", self.trigger_research_menu),
+            ("/flushlevel", self.flush)
         ]
         for route, view_func in routes:
             self._app.route(route, methods=['GET', 'POST'])(view_func)
@@ -550,6 +551,14 @@ class control(object):
 
         flash('Job successfully queued')
         return redirect(url_for('install_status'), code=302)
+
+    @logger.catch
+    @auth_required
+    def flush(self):
+        origin = request.args.get("origin")
+        logger.info('Removing visitation status for {}...', origin)
+        self._db.flush_levelinfo(origin)
+        return redirect(url_for('settings_devices'), code=302)
 
     @auth_required
     @logger.catch()

--- a/madmin/templates/settings_singledevice.html
+++ b/madmin/templates/settings_singledevice.html
@@ -9,6 +9,26 @@
 <script type="text/javascript" src="{{ url_for('static', filename='js/madmin_settings.js') }}"></script>
 <script>
 $(document).ready(function () {
+    $("#clearLevelup").click(function() {
+        if(!confirm('Do you really wanna delete all information about visited pokestops for device {{ element.origin }}?')) {
+          return;
+        }
+        $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Clearing ...</h2>' });
+        $.ajax({
+            url : "/flushlevel?origin={{ element.origin }}",
+            type : 'GET',
+            contentType : 'application/json',
+            success: function(data, status, xhr) {
+              $.unblockUI();
+              if(xhr.status < 400)
+                window.location.replace('{{ redirect }}');
+            },
+            error: function() {
+              $.unblockUI();
+              alert('Unable to clear levelup data!  An unknown error occurred');
+            }
+        });
+    });
     $("#submit").click(function() {
         $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Saving {{ subtab }}...</h2>' });
         save_data = get_save_data();
@@ -36,7 +56,7 @@ $(document).ready(function () {
     <div class="form-group">
       <label for="origin">origin</label>
       <input type="input" class="form-control" id="origin" name="origin" value="{{ element.origin }}" data-default="{{ element.origin }}">
-      <small class="form-text text-muted">origin</small>
+      <small class="form-text text-muted">origin is the unique name of your device</small>
     </div>
     {% for key, field in settings_vars.settings|dictsort %}
     <div class="form-group">
@@ -82,6 +102,7 @@ $(document).ready(function () {
       <small class="form-text text-muted">ADB device name</small>
     </div>
     <button type="button" id="submit" class="btn btn-success btn-lg btn-block">Save</button>
+    <button type="button" id="clearLevelup" class="btn btn-danger btn-lg btn-block">Clear levelup data</button>
   </div>
 </div>
 {% endif %}

--- a/route/RouteManagerBase.py
+++ b/route/RouteManagerBase.py
@@ -543,84 +543,88 @@ class RouteManagerBase(ABC):
                 self._positiontyp[origin] = 1
                 logger.info("Route {} is moving to {}, {} for a priority event",
                             self.name, next_coord.lat, next_coord.lng)
-            else:
-                logger.debug("{}: Moving on with route", self.name)
-                self._positiontyp[origin] = 0
-                # TODO: this check is likely always true now.............
-                if self.check_worker_rounds() > self._roundcount:
-                    self._roundcount = self.check_worker_rounds()
-                    if self._round_started_time is not None:
-                        logger.info("All subroutes of {} reached the first spot again. It took {}",
-                                    self.name, self._get_round_finished_string())
-                    self._round_started_time = datetime.now()
-                    if len(self._route) == 0:
-                        return None
-                    logger.info("Round of route {} started at {}",
-                                self.name, self._round_started_time)
-                elif self._round_started_time is None:
-                    self._round_started_time = datetime.now()
+                if self.check_coord_and_maybe_del(next_coord, origin) is None:
+                    # Recurse
+                    return self.get_next_location(origin)
 
-                if len(self._routepool[origin].queue) == 0:
-                    # worker do the part of route
-                    self._routepool[origin].rounds += 1
+            logger.debug("{}: Moving on with route", self.name)
+            self._positiontyp[origin] = 0
+            # TODO: this check is likely always true now.............
+            if self.check_worker_rounds() > self._roundcount:
+                self._roundcount = self.check_worker_rounds()
+                if self._round_started_time is not None:
+                    logger.info("All subroutes of {} reached the first spot again. It took {}",
+                                self.name, self._get_round_finished_string())
+                self._round_started_time = datetime.now()
+                if len(self._route) == 0:
+                    return None
+                logger.info("Round of route {} started at {}",
+                            self.name, self._round_started_time)
+            elif self._round_started_time is None:
+                self._round_started_time = datetime.now()
 
-                # continue as usual
-                if self.init and self.check_worker_rounds() >= int(self.settings.get("init_mode_rounds", 1)) and \
-                        len(self._routepool[origin].queue) == 0:
-                    # we are done with init, let's calculate a new route
-                    logger.warning("Init of {} done, it took {}, calculating new route...",
-                                   self.name, self._get_round_finished_string())
-                    if self._start_calc:
-                        logger.info("Another process already calculate the new route")
+            if len(self._routepool[origin].queue) == 0:
+                # worker do the part of route
+                self._routepool[origin].rounds += 1
+
+            # continue as usual
+            if self.init and self.check_worker_rounds() >= int(self.settings.get("init_mode_rounds", 1)) and \
+                    len(self._routepool[origin].queue) == 0:
+                # we are done with init, let's calculate a new route
+                logger.warning("Init of {} done, it took {}, calculating new route...",
+                               self.name, self._get_round_finished_string())
+                if self._start_calc:
+                    logger.info("Another process already calculate the new route")
+                    return None
+                self._start_calc = True
+                self._clear_coords()
+                coords = self._get_coords_post_init()
+                logger.debug("Setting {} coords to as new points in route of {}",
+                             len(coords), self.name)
+                self.add_coords_list(coords)
+                logger.debug("Route of {} is being calculated", self.name)
+                self._recalc_route_workertype()
+                self.init = False
+                self.change_init_mapping(self.name)
+                self._start_calc = False
+                logger.debug("Initroute of {} is finished - restart worker", self.name)
+                return None
+
+            elif len(self._current_route_round_coords) >= 0 and len(self._routepool[origin].queue) == 0:
+                # only quest could hit this else!
+                logger.info("Worker finished his subroute, updating all subroutes if necessary")
+
+                if self.mode == 'pokestops' and not self.init:
+                    # check for coords not in other workers to get a real open coord list
+                    if not self._get_coords_after_finish_route():
+                        logger.info("No more coords available - dont update routepool")
                         return None
-                    self._start_calc = True
-                    self._clear_coords()
-                    coords = self._get_coords_post_init()
-                    logger.debug("Setting {} coords to as new points in route of {}",
-                                 len(coords), self.name)
-                    self.add_coords_list(coords)
-                    logger.debug("Route of {} is being calculated", self.name)
-                    self._recalc_route_workertype()
-                    self.init = False
-                    self.change_init_mapping(self.name)
-                    self._start_calc = False
-                    logger.debug("Initroute of {} is finished - restart worker", self.name)
+
+                if not self.__worker_changed_update_routepools():
+                    logger.info("Failed updating routepools ...")
                     return None
 
-                elif len(self._current_route_round_coords) >= 0 and len(self._routepool[origin].queue) == 0:
-                    # only quest could hit this else!
-                    logger.info("Worker finished his subroute, updating all subroutes if necessary")
-
-                    if self.mode == 'pokestops' and not self.init:
-                        # check for coords not in other workers to get a real open coord list
-                        if not self._get_coords_after_finish_route():
-                            logger.info("No more coords available - dont update routepool")
-                            return None
-
-                    if not self.__worker_changed_update_routepools():
-                        logger.info("Failed updating routepools ...")
-                        return None
-
-                    if len(self._routepool[origin].queue) == 0 and len(self._routepool[origin].subroute) == 0:
-                        logger.info("Subroute-update won't help or queue and subroute are empty, "
-                                    "signalling worker to reconnect")
-                        self._routepool[origin].last_access = time.time()
-                        return None
-                    elif len(self._routepool[origin].queue) == 0 and len(self._routepool[origin].subroute) > 0:
-                        [self._routepool[origin].queue.append(i) for i in self._routepool[origin].subroute]
-                    elif len(self._routepool[origin].queue) > 0 and len(self._routepool[origin].subroute) > 0:
-                        logger.info("Getting new coords for route {}", str(self.name))
-                    else:
-                        logger.info("Not getting new coords - leaving worker")
-                        return None
-
-                if len(self._routepool[origin].queue) == 0:
-                    logger.warning("Having updated routepools and checked lengths of queue and subroute, "
-                                   "{}'s queue is still empty, signalling worker to stop whatever he is doing",
-                                   self.name)
+                if len(self._routepool[origin].queue) == 0 and len(self._routepool[origin].subroute) == 0:
+                    logger.info("Subroute-update won't help or queue and subroute are empty, "
+                                "signalling worker to reconnect")
                     self._routepool[origin].last_access = time.time()
                     return None
+                elif len(self._routepool[origin].queue) == 0 and len(self._routepool[origin].subroute) > 0:
+                    [self._routepool[origin].queue.append(i) for i in self._routepool[origin].subroute]
+                elif len(self._routepool[origin].queue) > 0 and len(self._routepool[origin].subroute) > 0:
+                    logger.info("Getting new coords for route {}", str(self.name))
+                else:
+                    logger.info("Not getting new coords - leaving worker")
+                    return None
 
+            if len(self._routepool[origin].queue) == 0:
+                logger.warning("Having updated routepools and checked lengths of queue and subroute, "
+                               "{}'s queue is still empty, signalling worker to stop whatever he is doing",
+                               self.name)
+                self._routepool[origin].last_access = time.time()
+                return None
+
+            while len(self._routepool[origin].queue) > 0:
                 next_coord = self._routepool[origin].queue.popleft()
                 if self._delete_coord_after_fetch() and next_coord in self._current_route_round_coords \
                         and not self.init:
@@ -630,19 +634,26 @@ class RouteManagerBase(ABC):
 
                 self._last_round_prio[origin] = False
                 self._routepool[origin].last_round_prio_event = False
-            logger.debug("{}: Done grabbing next coord, releasing lock and returning location: {}", str(
-                self.name), str(next_coord))
-            if self._check_coords_before_returning(next_coord.lat, next_coord.lng, origin):
+                the_coord = self.check_coord_and_maybe_del(next_coord, origin)
+                if the_coord is not None:
+                    return the_coord
 
-                if self._delete_coord_after_fetch() and next_coord in self._current_route_round_coords \
-                        and not self.init:
-                    self._current_route_round_coords.remove(next_coord)
+            # No more coords in the queue
+            return None
 
-                self.__set_routepool_entry_location(origin, next_coord)
+    def check_coord_and_maybe_del(self, next_coord, origin):
+        logger.debug("{}: Done grabbing next coord, releasing lock and returning location: {}", str(
+            self.name), str(next_coord))
+        if self._check_coords_before_returning(next_coord.lat, next_coord.lng, origin):
 
-                return next_coord
-            else:
-                return self.get_next_location(origin)
+            if self._delete_coord_after_fetch() and next_coord in self._current_route_round_coords \
+                    and not self.init:
+                self._current_route_round_coords.remove(next_coord)
+
+            self.__set_routepool_entry_location(origin, next_coord)
+
+            return next_coord
+        return None
 
     def check_worker_rounds(self) -> int:
         temp_worker_round_list: list = []

--- a/route/RouteManagerBase.py
+++ b/route/RouteManagerBase.py
@@ -396,7 +396,7 @@ class RouteManagerBase(ABC):
         pass
 
     @abstractmethod
-    def _check_coords_before_returning(self, lat, lng):
+    def _check_coords_before_returning(self, lat, lng, origin):
         """
         Return list of coords to be fetched and used for routecalc
         :return:
@@ -632,7 +632,7 @@ class RouteManagerBase(ABC):
                 self._routepool[origin].last_round_prio_event = False
             logger.debug("{}: Done grabbing next coord, releasing lock and returning location: {}", str(
                 self.name), str(next_coord))
-            if self._check_coords_before_returning(next_coord.lat, next_coord.lng):
+            if self._check_coords_before_returning(next_coord.lat, next_coord.lng, origin):
 
                 if self._delete_coord_after_fetch() and next_coord in self._current_route_round_coords \
                         and not self.init:

--- a/route/RouteManagerFactory.py
+++ b/route/RouteManagerFactory.py
@@ -4,6 +4,7 @@ from route.RouteManagerIV import RouteManagerIV
 from route.RouteManagerMon import RouteManagerMon
 from route.RouteManagerQuests import RouteManagerQuests
 from route.RouteManagerRaids import RouteManagerRaids
+from route.RouteManagerLeveling import RouteManagerLeveling
 
 class RouteManagerFactory:
     @staticmethod
@@ -34,7 +35,14 @@ class RouteManagerFactory:
                                               mode=mode, settings=settings, init=init, name=name, joinqueue=joinqueue
                                               )
         elif mode == "pokestops":
-            route_manager = RouteManagerQuests(db_wrapper, dbm, area_id, coords, max_radius, max_coords_within_radius,
+            if level:
+                route_manager = RouteManagerLeveling(db_wrapper,  dbm, area_id, coords, max_radius, max_coords_within_radius,
+                                                     path_to_include_geofence, path_to_exclude_geofence, routefile,
+                                                     mode=mode, settings=settings, init=init, name=name, level=True,
+                                                     calctype=calctype, joinqueue=joinqueue
+                                                     )
+            else:
+                route_manager = RouteManagerQuests(db_wrapper, dbm, area_id, coords, max_radius, max_coords_within_radius,
                                                path_to_include_geofence, path_to_exclude_geofence, routefile,
                                                mode=mode, settings=settings, init=init, name=name, level=level,
                                                calctype=calctype, joinqueue=joinqueue

--- a/route/RouteManagerIV.py
+++ b/route/RouteManagerIV.py
@@ -82,5 +82,5 @@ class RouteManagerIV(RouteManagerBase):
         self._is_started = False
         self._round_started_time = None
 
-    def _check_coords_before_returning(self, lat, lng):
+    def _check_coords_before_returning(self, lat, lng, origin):
         return True

--- a/route/RouteManagerLeveling.py
+++ b/route/RouteManagerLeveling.py
@@ -2,12 +2,13 @@ import collections
 import time
 from typing import List
 from db.dbWrapperBase import DbWrapperBase
-from route.RouteManagerBase import RouteManagerBase, RoutePoolEntry
+from route.RouteManagerBase import RoutePoolEntry
+from route.RouteManagerQuests import RouteManagerQuests
 from utils.logging import logger
 from utils.collections import LocationWithVisits, Location
 
 
-class RouteManagerLeveling(RouteManagerBase):
+class RouteManagerLeveling(RouteManagerQuests):
     def generate_stop_list(self):
         time.sleep(5)
         stops, stops_with_visits = self.db_wrapper.stop_from_db_without_quests(
@@ -17,18 +18,6 @@ class RouteManagerLeveling(RouteManagerBase):
         logger.debug('Detected stops without quests: {}', str(stops_with_visits))
         self._stoplist: List[Location] = stops
         self._stops_with_visits: List[LocationWithVisits] = stops_with_visits
-
-    def _retrieve_latest_priority_queue(self):
-        return None
-
-    def _get_coords_post_init(self):
-        return self.db_wrapper.stops_from_db(self.geofence_helper)
-
-    def _cluster_priority_queue_criteria(self):
-        pass
-
-    def _priority_queue_update_interval(self):
-        return 0
 
     def __worker_changed_update_routepools(self):
         with self._manager_mutex:
@@ -55,200 +44,19 @@ class RouteManagerLeveling(RouteManagerBase):
             any_at_all = len(origin_local_list) > 0 or any_at_all
         return any_at_all
 
-    def _recalc_route_workertype(self):
-        if self.init:
-            self.recalc_route(self._max_radius, self._max_coords_within_radius, 1, delete_old_route=True,
-                              nofile=False)
-        else:
-            self.recalc_route(self._max_radius, self._max_coords_within_radius, 1, delete_old_route=False,
-                              nofile=True)
-
-        self._init_route_queue()
-
-    def __init__(self, db_wrapper: DbWrapperBase, dbm, uri, coords: List[Location], max_radius: float,
+    def __init__(self, db_wrapper: DbWrapperBase, dbm, area_id, coords: List[Location], max_radius: float,
                  max_coords_within_radius: int, path_to_include_geofence: str, path_to_exclude_geofence: str,
                  routefile: str, mode=None, init: bool = False, name: str = "unknown", settings: dict = None,
-                 level: bool = False, calctype: str = "optimized", joinqueue = None):
-        RouteManagerBase.__init__(self, db_wrapper=db_wrapper, dbm=dbm, uri=uri,  coords=coords, max_radius=max_radius,
-                                  max_coords_within_radius=max_coords_within_radius,
-                                  path_to_include_geofence=path_to_include_geofence,
-                                  path_to_exclude_geofence=path_to_exclude_geofence,
-                                  routefile=routefile, init=init,
-                                  name=name, settings=settings, mode=mode, level=level, calctype=calctype,
-                                  joinqueue=joinqueue
-                                  )
-        self.starve_route = False
-        self._stoplist: List[Location] = []
+                 level: bool = False, calctype: str = "optimized", joinqueue=None):
+        RouteManagerQuests.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id, coords=coords,
+                                    max_radius=max_radius, max_coords_within_radius=max_coords_within_radius,
+                                    path_to_include_geofence=path_to_include_geofence,
+                                    path_to_exclude_geofence=path_to_exclude_geofence,
+                                    routefile=routefile, init=init,
+                                    name=name, settings=settings, mode=mode, level=level, calctype=calctype,
+                                    joinqueue=joinqueue
+                                    )
         self._stops_with_visits: List[LocationWithVisits] = []
-
-        self._shutdown_route: bool = False
-        self._routecopy: List[Location] = []
-        self._tempinit: bool = False
-
-    def _get_coords_after_finish_route(self) -> bool:
-        self._manager_mutex.acquire()
-        try:
-
-            if self._shutdown_route:
-                logger.info('Other worker shutdown route {} - leaving it', str(self.name))
-                return False
-
-            if self._start_calc:
-                logger.info("Another process already calculate the new route")
-                return True
-            self._start_calc = True
-            self.generate_stop_list()
-            if len(self._stoplist) == 0:
-                logger.info("Dont getting new stops - leaving now.")
-                self._shutdown_route = True
-                self._restore_original_route()
-                self._start_calc = False
-                return False
-            coords: List[Location] = self._check_unprocessed_stops()
-            # remove coords to be ignored from coords
-            coords = [coord for coord in coords if coord not in self._coords_to_be_ignored]
-            if len(coords) > 0:
-                logger.info("Getting new coords - recalc quick route")
-                self._recalc_stop_route(coords)
-                self._start_calc = False
-            else:
-                logger.info("Dont getting new stops - leaving now.")
-                self._shutdown_route = True
-                self._start_calc = False
-                self._restore_original_route()
-                return False
-            return True
-        finally:
-            self._manager_mutex.release()
-
-    def _restore_original_route(self):
-        if not self._tempinit:
-            logger.info("Restoring original route")
-            self._route = self._routecopy.copy()
-
-    def _check_unprocessed_stops(self):
-        self._manager_mutex.acquire()
-
-        try:
-            list_of_stops_to_return: List[Location] = []
-
-            if len(self._stoplist) == 0:
-                return list_of_stops_to_return
-            else:
-                # we only want to add stops that we haven't spun yet
-                for stop in self._stoplist:
-                    if stop not in self._stops_not_processed:
-                        self._stops_not_processed[stop] = 1
-                    else:
-                        self._stops_not_processed[stop] += 1
-
-            for stop, error_count in self._stops_not_processed.items():
-                if stop not in self._stoplist:
-                    logger.info("Location {} is no longer in our stoplist and will be ignored".format(str(stop)))
-                    self._coords_to_be_ignored.add(stop)
-                elif error_count < 4:
-                    logger.warning("Found stop not processed yet: {}".format(str(stop)))
-                    list_of_stops_to_return.append(stop)
-                else:
-                    logger.error("Stop {} has not been processed thrice in a row, "
-                                 "please check your DB".format(str(stop)))
-                    self._coords_to_be_ignored.add(stop)
-
-            if len(list_of_stops_to_return) > 0:
-                logger.info("Found stops not yet processed, retrying those in the next round")
-            return list_of_stops_to_return
-        finally:
-            self._manager_mutex.release()
-
-    def _start_routemanager(self):
-        self._manager_mutex.acquire()
-        try:
-            if not self._is_started:
-                self._is_started = True
-                logger.info("Starting routemanager {}", str(self.name))
-
-                if self._shutdown_route:
-                    logger.info('Other worker shutdown route {} - leaving it', str(self.name))
-                    return False
-
-                self.generate_stop_list()
-                stops = self._stoplist
-                self._prio_queue = None
-                self.delay_after_timestamp_prio = None
-                self.starve_route = False
-                self._first_round_finished = False
-                self._start_check_routepools()
-
-                if self.init:
-                    logger.info('Starting init mode')
-                    self._init_route_queue()
-                    self._tempinit = True
-                    return True
-
-                if not self._first_started:
-                    logger.info(
-                        "First starting quest route - copying original route {} for later use", str(self.name))
-                    self._routecopy = self._route.copy()
-                    self._first_started = True
-                else:
-                    logger.info("Restoring original route {} ", str(self.name))
-                    self._route = self._routecopy.copy()
-
-                new_stops = list(set(stops) - set(self._route))
-                if len(new_stops) > 0:
-                    for stop in new_stops:
-                        logger.warning("Stop with coords {} seems new and not in route.", str(stop))
-
-                if len(stops) == 0:
-                    logger.info('No unprocessed Stops detected in route {} - quit worker', str(self.name))
-                    self._shutdown_route = True
-                    self._restore_original_route()
-                    self._route: List[Location] = []
-                    return False
-
-                if 0 < len(stops) < len(self._route) \
-                        and len(stops)/len(self._route) <= 0.3:
-                    # Calculating new route because 70 percent of stops are processed
-                    logger.info('There are less stops without quest than routepositions - recalc')
-                    self._recalc_stop_route(stops)
-                elif len(self._route) == 0 and len(stops) > 0:
-                    logger.warning("Something wrong with area {}: it have many new stops - better delete routefile!",
-                                   str(self.name))
-                    logger.info("Recalc new route for area {}", str(self.name))
-                    self._recalc_stop_route(stops)
-                else:
-                    self._init_route_queue()
-
-                logger.info('Getting {} positions in route {}'.format(len(self._route), str(self.name)))
-                return True
-
-        finally:
-            self._manager_mutex.release()
-
-        return True
-
-    def _recalc_stop_route(self, stops):
-        self._clear_coords()
-        self.add_coords_list(stops)
-        self._overwrite_calculation = True
-        self._recalc_route_workertype()
-        self._init_route_queue()
-
-    def _delete_coord_after_fetch(self) -> bool:
-        return True
-
-    def _quit_route(self):
-        logger.info('Shutdown Route {}', str(self.name))
-        if self._is_started:
-            self._is_started = False
-            self._round_started_time = None
-            if self.init: self._first_started = False
-            self._restore_original_route()
-            self._shutdown_route = False
-
-        # clear not processed stops
-        self._stops_not_processed.clear()
-        self._coords_to_be_ignored.clear()
 
     def _check_coords_before_returning(self, lat, lng, origin):
         if self.init:
@@ -257,7 +65,7 @@ class RouteManagerLeveling(RouteManagerBase):
         stop = Location(lat, lng)
         logger.info('Checking Stop with ID {}', str(stop))
         if stop not in self._stoplist:
-            logger.info('Already got this Stop')
+            logger.info('Stop is not in stoplist, either no longer in route or spun already...')
             return False
 
         if self._stops_with_visits is None or len(self._stops_with_visits) == 0:
@@ -266,7 +74,7 @@ class RouteManagerLeveling(RouteManagerBase):
 
         for stop in self._stops_with_visits:
             if stop.lat == lat and stop.lng == lng and stop.visited_by is not None and origin in stop.visited_by:
-                logger.info("Already spun stop, ignore")
+                logger.info("DB says we Already spun stop, ignore it...")
                 return False
 
         logger.info('Getting new Stop')

--- a/route/RouteManagerMon.py
+++ b/route/RouteManagerMon.py
@@ -69,5 +69,5 @@ class RouteManagerMon(RouteManagerBase):
         self._is_started = False
         self._round_started_time = None
 
-    def _check_coords_before_returning(self, lat, lng):
+    def _check_coords_before_returning(self, lat, lng, origin):
         return True

--- a/route/RouteManagerQuests.py
+++ b/route/RouteManagerQuests.py
@@ -12,7 +12,7 @@ Location = collections.namedtuple('Location', ['lat', 'lng'])
 class RouteManagerQuests(RouteManagerBase):
     def generate_stop_list(self):
         time.sleep(5)
-        stops = self.db_wrapper.stop_from_db_without_quests(self.geofence_helper, False)
+        stops, _ = self.db_wrapper.stop_from_db_without_quests(self.geofence_helper, False)
 
         logger.info('Detected stops without quests: {}', str(len(stops)))
         logger.debug('Detected stops without quests: {}', str(stops))

--- a/route/RouteManagerQuests.py
+++ b/route/RouteManagerQuests.py
@@ -12,16 +12,7 @@ Location = collections.namedtuple('Location', ['lat', 'lng'])
 class RouteManagerQuests(RouteManagerBase):
     def generate_stop_list(self):
         time.sleep(5)
-        stops, stops_with_visits = self.db_wrapper.stop_from_db_without_quests(
-            self.geofence_helper, self._level)
-
-        if self._level:
-            logger.info("Some stops maybe visited before, trying to filter them out... # unfiltered: {}",
-                        str(len(stops)))
-            stops = []
-            for lv in stops_with_visits:
-                if lv.visited_by is None or lv.visited_by == '':
-                    stops.append(Location(lv.lat, lv.lng))
+        stops = self.db_wrapper.stop_from_db_without_quests(self.geofence_helper, False)
 
         logger.info('Detected stops without quests: {}', str(len(stops)))
         logger.debug('Detected stops without quests: {}', str(stops))
@@ -69,9 +60,6 @@ class RouteManagerQuests(RouteManagerBase):
         self._tempinit: bool = False
 
     def _get_coords_after_finish_route(self) -> bool:
-        if self._level:
-            logger.info("Level Mode - switch to next area")
-            return False
         self._manager_mutex.acquire()
         try:
 

--- a/route/RouteManagerRaids.py
+++ b/route/RouteManagerRaids.py
@@ -66,5 +66,5 @@ class RouteManagerRaids(RouteManagerBase):
         self._is_started = False
         self._round_started_time = None
 
-    def _check_coords_before_returning(self, lat, lng):
+    def _check_coords_before_returning(self, lat, lng, origin):
         return True

--- a/utils/collections.py
+++ b/utils/collections.py
@@ -1,6 +1,7 @@
 import collections
 
 Location = collections.namedtuple('Location', ['lat', 'lng'])
+LocationWithVisits = collections.namedtuple('LocationWithVisits', ['lat', 'lng', 'visited_by'])
 Relation = collections.namedtuple(
     'Relation', ['other_event', 'distance', 'timedelta'])
 Trash = collections.namedtuple('Trash', ['x', 'y'])

--- a/utils/version.py
+++ b/utils/version.py
@@ -370,6 +370,19 @@ class MADVersion(object):
             with open(self._application_args.mappings, 'w') as outfile:
                 json.dump(settings, outfile, indent=4, sort_keys=True)
 
+        if self._version < 15:
+            query = (
+                "CREATE TABLE IF NOT EXISTS `trs_visited` ("
+                "`pokestop_id` varchar(50) NOT NULL,"
+                "`origin` varchar(50) NOT NULL,"
+                "PRIMARY KEY (`pokestop_id`,`origin`)"
+                ")"
+            )
+            try:
+                self.dbwrapper.execute(query, commit=True)
+            except Exception as e:
+                logger.exception("Unexpected error: {}", e)
+
         self.set_version(current_version)
 
     def set_version(self, version):

--- a/worker/MITMBase.py
+++ b/worker/MITMBase.py
@@ -21,6 +21,7 @@ class LatestReceivedType(Enum):
     STOP = 2
     MON = 3
     CLEAR = 4
+    GMO = 5
 
 
 class MITMBase(WorkerBase):

--- a/worker/MITMBase.py
+++ b/worker/MITMBase.py
@@ -258,7 +258,7 @@ class MITMBase(WorkerBase):
 
         dataToSave = {
             'Origin':            self._id,
-            'Routemanager':      str(self._mapping_manager.routemanager_get_name(self._routemanager_name)),
+            'Routemanager':      str(self._routemanager_name),
             'RebootCounter':     str(self._reboot_count),
             'RestartCounter':    str(self._restart_count),
             'RebootingOption':   str(self.get_devicesettings_value("reboot", False)),

--- a/worker/MITMBase.py
+++ b/worker/MITMBase.py
@@ -258,7 +258,7 @@ class MITMBase(WorkerBase):
 
         dataToSave = {
             'Origin':            self._id,
-            'Routemanager':      str(self._routemanager_name),
+            'Routemanager':      str(self._mapping_manager.routemanager_get_name(self._routemanager_name)),
             'RebootCounter':     str(self._reboot_count),
             'RestartCounter':    str(self._restart_count),
             'RebootingOption':   str(self.get_devicesettings_value("reboot", False)),

--- a/worker/WorkerQuests.py
+++ b/worker/WorkerQuests.py
@@ -745,6 +745,13 @@ class WorkerQuests(MITMBase):
                 time.sleep(600)
                 break
             elif data_received == FortSearchResultTypes.QUEST or data_received == FortSearchResultTypes.COOLDOWN:
+                if self._level_mode:
+                    logger.info("Saving visitation info...")
+                    self._db_wrapper.submit_pokestop_visited(self._id,
+                                                             self.current_location.lat, self.current_location.lng)
+                    # This is leveling mode, it's faster to just ignore spin result and continue ?
+                    break
+
                 if data_received == FortSearchResultTypes.COOLDOWN:
                     logger.info('Stop is on cooldown.. sleeping 10 seconds but probably should just move on')
                     time.sleep(10)
@@ -755,10 +762,6 @@ class WorkerQuests(MITMBase):
                 elif data_received == FortSearchResultTypes.QUEST:
                     logger.info('Received new Quest')
 
-                if self._level_mode:
-                    logger.info("Saving visitation info...")
-                    self._db_wrapper.submit_pokestop_visited(self._id,
-                                                             self.current_location.lat, self.current_location.lng)
                 if not self._always_cleanup:
                     self._clear_quest_counter += 1
                     if self._clear_quest_counter == 3:


### PR DESCRIPTION
Introducing: A levelup mode that you can restart quickly!

How? - Just sit back and let the magic of databases remember where you've been so route coordinates can be skipped quickly in quest level mode.
note: this works for areas in mode pokestop with "level" set to true.

Caveats: Currently only one worker can visit an area before it is forever tainted as visited. A better version is in the works but requires more work and maybe a new mode.
 
FAQ:
Q "one worker finished up a quest area and now the next worker one just says there's nothing to spin"
A run `DELETE FROM trs_visited WHERE origin'thatoldworkerorigin'` and restart MAD
Q how come there are no more questions
A I run out of time