### PR TITLE
Fix for accessing jobs from subdirectories

### DIFF
--- a/madmin/templates/base.html
+++ b/madmin/templates/base.html
@@ -69,11 +69,11 @@
                         Jobs
                     </a>
                       <div class="dropdown-menu"i aria-labelledby="navbarDropdown">
-                      <a href="uploaded_files" class="dropdown-item">Existing Files / Jobs</a>
-                      <a href="upload" class="dropdown-item">Upload File</a>
-                          <a href="install_status" class="dropdown-item">Job Status</a>
-                          <a href="install_status?withautojobs=true" class="dropdown-item">Auto Job Status</a>
-                          <a href="reload_jobs" class="dropdown-item">Reload existing Jobs</a>
+                      <a href="/uploaded_files" class="dropdown-item">Existing Files / Jobs</a>
+                      <a href="/upload" class="dropdown-item">Upload File</a>
+                      <a href="/install_status" class="dropdown-item">Job Status</a>
+                      <a href="/install_status?withautojobs=true" class="dropdown-item">Auto Job Status</a>
+                      <a href="/reload_jobs" class="dropdown-item">Reload existing Jobs</a>
                     </div>
                   </li>
               </ul>


### PR DESCRIPTION
The URI generated when clicking on a job when not in the document root creates an invalid URL and displays a 404.