### PR TITLE
MADmin behind reverse proxy (non-root)

### DIFF
--- a/madmin/api/__init__.py
+++ b/madmin/api/__init__.py
@@ -37,7 +37,7 @@ class APIHandler(object):
             self._modules[tmp.uri_base] = tmp.description
 
     def create_routes(self):
-        self._app.route(self.uri_base, methods=['GET'], endpoint=self.component)(self.process_request)
+        self._app.route(self.uri_base, methods=['GET'], endpoint='api_%s' % (self.component,))(self.process_request)
 
     def process_request(self):
         """ API call to get data """

--- a/madmin/api/apiHandler.py
+++ b/madmin/api/apiHandler.py
@@ -37,10 +37,10 @@ class ResourceHandler(object):
         """ Creates all pertinent routes to for the API resource """
         if self.component:
             route = self.uri_base
-            self._app.route(route, methods=['GET', 'POST'], endpoint=self.component)(self.process_request)
+            self._app.route(route, methods=['GET', 'POST'], endpoint='api_%s' % (self.component,))(self.process_request)
             if self.iterable:
                 route = '%s/<string:identifier>' % (self.uri_base,)
-                self._app.route(route, methods=['DELETE', 'GET', 'PATCH', 'PUT'], endpoint=self.component)(self.process_request)
+                self._app.route(route, methods=['DELETE', 'GET', 'PATCH', 'PUT'], endpoint='api_%s' % (self.component,))(self.process_request)
 
     def format_data(self, data, config, operation):
         save_data = {}

--- a/madmin/madmin.py
+++ b/madmin/madmin.py
@@ -15,6 +15,7 @@ from madmin.routes.map import map
 from madmin.routes.config import config
 from madmin.routes.path import path
 from madmin.api import APIHandler
+from madmin.reverseproxy import ReverseProxied
 
 
 sys.path.append("..")  # Adds higher directory to python modules path.
@@ -28,6 +29,8 @@ log = logger
 
 def madmin_start(args, db_wrapper: DbWrapperBase, ws_server, mapping_manager: MappingManager, data_manager, deviceUpdater, jobstatus):
     # load routes
+    if args.madmin_base_path:
+        app.wsgi_app = ReverseProxied(app.wsgi_app, script_name=args.madmin_base_path)
 
     statistics(db_wrapper, args, app, mapping_manager)
     control(db_wrapper, args, mapping_manager, ws_server, logger, app, deviceUpdater)

--- a/madmin/reverseproxy.py
+++ b/madmin/reverseproxy.py
@@ -1,0 +1,28 @@
+from flask import Flask, flash, render_template, redirect, url_for, session, request, send_from_directory, abort
+from flask import Response, Blueprint
+from werkzeug.serving import run_simple
+from werkzeug.wsgi import DispatcherMiddleware
+import datetime
+
+class ReverseProxied(object):
+
+    def __init__(self, app, script_name=None, scheme=None, server=None):
+        self.app = app
+        self.script_name = script_name
+        self.scheme = scheme
+        self.server = server
+
+    def __call__(self, environ, start_response):
+        script_name = environ.get('HTTP_X_SCRIPT_NAME', '') or self.script_name
+        if script_name:
+            environ['SCRIPT_NAME'] = script_name
+            path_info = environ['PATH_INFO']
+            if path_info.startswith(script_name):
+                environ['PATH_INFO'] = path_info[len(script_name):]
+        scheme = environ.get('HTTP_X_SCHEME', '') or self.scheme
+        if scheme:
+            environ['wsgi.url_scheme'] = scheme
+        server = environ.get('HTTP_X_FORWARDED_SERVER', '') or self.server
+        if server:
+            environ['HTTP_HOST'] = server
+        return self.app(environ, start_response)

--- a/madmin/templates/base.html
+++ b/madmin/templates/base.html
@@ -39,41 +39,41 @@
           <div id="navbarNav" class="navbar-collapse collapse">
               <ul class="navbar-nav mr-auto">
                   <li class="nav-item">
-                    <a href="/map" class="nav-link">Map</a>
+                    <a href="{{ url_for('map') }}" class="nav-link">Map</a>
                   </li>
                   <li class="nav-item">
-                    <a href="/quests" class="nav-link">Quests</a>
+                    <a href="{{ url_for('quest') }}" class="nav-link">Quests</a>
                   </li>
                   <li class="nav-item">
-                    <a href="/settings/devices" class="nav-link">Settings</a>
+                    <a href="{{ url_for('settings_devices') }}" class="nav-link">Settings</a>
                   </li>
                   <li class="nav-item">
-                    <a href="/status" class="nav-link">Status</a>
+                    <a href="{{ url_for('status') }}" class="nav-link">Status</a>
                   </li>
                   <li class="nav-item dropdown">
                       <a class="nav-link dropdown-toggle" href="statistics" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         Statistics
                     </a>
                       <div class="dropdown-menu"i aria-labelledby="navbarDropdown">
-                      <a href="/statistics" class="dropdown-item">Global Stats</a>
-                      <a href="/statistics_mon" class="dropdown-item">Mon Stats</a>
-                      <a href="/statistics_shiny" class="dropdown-item">Shiny Stats</a>
-                      <a href="/statistics_spawns" class="dropdown-item">Spawnpoint Stats</a>
+                      <a href="{{ url_for('statistics') }}" class="dropdown-item">Global Stats</a>
+                      <a href="{{ url_for('statistics_mon') }}" class="dropdown-item">Mon Stats</a>
+                      <a href="{{ url_for('statistics_shiny') }}" class="dropdown-item">Shiny Stats</a>
+                      <a href="{{ url_for('statistics_spawns') }}" class="dropdown-item">Spawnpoint Stats</a>
                     </div>
                   </li>
                   <li class="nav-item">
-                    <a href="/phonecontrol" class="nav-link">Phonecontrol</a>
+                    <a href="{{ url_for('get_phonescreens') }}" class="nav-link">Phonecontrol</a>
                   </li>
                   <li class="nav-item dropdown">
                       <a class="nav-link dropdown-toggle" href="uploaded_files" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         Jobs
                     </a>
                       <div class="dropdown-menu"i aria-labelledby="navbarDropdown">
-                      <a href="/uploaded_files" class="dropdown-item">Existing Files / Jobs</a>
-                      <a href="/upload" class="dropdown-item">Upload File</a>
-                      <a href="/install_status" class="dropdown-item">Job Status</a>
-                      <a href="/install_status?withautojobs=true" class="dropdown-item">Auto Job Status</a>
-                      <a href="/reload_jobs" class="dropdown-item">Reload existing Jobs</a>
+                      <a href="{{ url_for('uploaded_files') }}" class="dropdown-item">Existing Files / Jobs</a>
+                      <a href="{{ url_for('upload') }}" class="dropdown-item">Upload File</a>
+                      <a href="{{ url_for('install_status') }}" class="dropdown-item">Job Status</a>
+                      <a href="{{ url_for('install_status', withautojobs='true') }}" class="dropdown-item">Auto Job Status</a>
+                      <a href="{{ url_for('reload_jobs') }}" class="dropdown-item">Reload existing Jobs</a>
                     </div>
                   </li>
               </ul>

--- a/madmin/templates/settings.html
+++ b/madmin/templates/settings.html
@@ -8,12 +8,12 @@
 
 {% block content %}
 <nav class="nav nav-pills nav-fill mt-3 mb-3 flex-column flex-sm-row">
-  <a class="flex-sm-fill text-sm-center nav-link {{ "active" if subtab == "device"}}" href="/settings/devices">Devices</a>
-  <a class="flex-sm-fill text-sm-center nav-link {{ "active" if subtab == "devicesetting" }}" href="/settings/shared">Shared settings</a>
-  <a class="flex-sm-fill text-sm-center nav-link {{ "active" if subtab == "area" }}" href="/settings/areas">Areas</a>
-  <a class="flex-sm-fill text-sm-center nav-link {{ "active" if subtab == "walker" }}" href="/settings/walker">Walker</a>
-  <a class="flex-sm-fill text-sm-center nav-link {{ "active" if subtab == "auth" }}" href="/settings/auth">Auth</a>
-  <a class="flex-sm-fill text-sm-center nav-link {{ "active" if subtab == "monivlist" }}" href="/settings/ivlists">IV lists</a>
+  <a class="flex-sm-fill text-sm-center nav-link {{ "active" if subtab == "device"}}" href="{{ url_for('settings_devices') }}">Devices</a>
+  <a class="flex-sm-fill text-sm-center nav-link {{ "active" if subtab == "devicesetting" }}" href="{{ url_for('settings_pools') }}">Shared settings</a>
+  <a class="flex-sm-fill text-sm-center nav-link {{ "active" if subtab == "area" }}" href="{{ url_for('settings_areas') }}">Areas</a>
+  <a class="flex-sm-fill text-sm-center nav-link {{ "active" if subtab == "walker" }}" href="{{ url_for('settings_walkers') }}">Walker</a>
+  <a class="flex-sm-fill text-sm-center nav-link {{ "active" if subtab == "auth" }}" href="{{ url_for('settings_auth') }}">Auth</a>
+  <a class="flex-sm-fill text-sm-center nav-link {{ "active" if subtab == "monivlist" }}" href="{{ url_for('settings_ivlists') }}">IV lists</a>
 </nav>
 {% endblock %}
 

--- a/madmin/templates/settings_areas.html
+++ b/madmin/templates/settings_areas.html
@@ -13,7 +13,7 @@ $(document).ready(function () {
             var elem =  $(this);
             $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Deleting a {{ subtab }}...</h2>' });
             $.ajax({
-                url : $(this).data('identifier'),
+                url : '{{ base_uri }}/'+ $(this).data('identifier').substr($(this).data('identifier').lastIndexOf('/')+1),
                 type : 'DELETE',
                 success: function(data, status, xhr) {
                     if(xhr.status == 202) {
@@ -57,7 +57,7 @@ $(document).ready(function () {
   <div class="col">
     <div class="card border-secondary">
       <div class="card-body py-2">
-        <p class="card-text">Areas define zones where scanning should happen. Areas can be asigned to Walkers and Walkers must be asigned to Devices. Every area requires a file containing one or more geofences. MAD will build a route based on these areas and the elements within them.</p>
+        <p class="card-text">Areas define zones where scanning should happen. Areas can be assigned to Walkers and Walkers must be assigned to Devices. Every area requires a file containing one or more geofences. MAD will build a route based on these areas and the elements within them.</p>
       </div>
     </div>
   </div>
@@ -76,11 +76,11 @@ $(document).ready(function () {
                   <i class="fas fa-plus"></i>
                 </button>
                 <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                  <a class="dropdown-item" href="{{ redirect }}?id=new&mode=idle">Idle <span class="badge badge-secondary">idle</span></a>
-                  <a class="dropdown-item" href="{{ redirect }}?id=new&mode=iv_mitm">Mon IV scanner <span class="badge badge-secondary">iv_mitm</span></a>
-                  <a class="dropdown-item" href="{{ redirect }}?id=new&mode=mon_mitm">General mon scanner <span class="badge badge-secondary">mon_mitm</span></a>
-                  <a class="dropdown-item" href="{{ redirect }}?id=new&mode=pokestops">Quest scanner <span class="badge badge-secondary">pokestops</span></a>
-                  <a class="dropdown-item" href="{{ redirect }}?id=new&mode=raids_mitm">Raid scanner <span class="badge badge-secondary">raids_mitm</span></a>
+                  <a class="dropdown-item" href="{{ url_for('settings_areas', id='new', mode='idle') }}">Idle <span class="badge badge-secondary">idle</span></a>
+                  <a class="dropdown-item" href="{{ url_for('settings_areas', id='new', mode='iv_mitm') }}">Mon IV scanner <span class="badge badge-secondary">iv_mitm</span></a>
+                  <a class="dropdown-item" href="{{ url_for('settings_areas', id='new', mode='mon_mitm') }}">General mon scanner <span class="badge badge-secondary">mon_mitm</span></a>
+                  <a class="dropdown-item" href="{{ url_for('settings_areas', id='new', mode='pokestops') }}">Quest scanner <span class="badge badge-secondary">pokestops</span></a>
+                  <a class="dropdown-item" href="{{ url_for('settings_areas', id='new', mode='raids_mitm') }}">Raid scanner <span class="badge badge-secondary">raids_mitm</span></a>
                 </div>
             </div>
           </th>
@@ -93,7 +93,7 @@ $(document).ready(function () {
         {% for area_id, area in area.items() %}
         <tr>
           <td class="align-middle">
-            <a href="{{ redirect }}?id={{ area_id }}&mode={{ area.mode }}">{{ area.name }}</a> 
+            <a href="{{ url_for('settings_areas', id=area_id, mode=area.mode) }}">{{ area.name }}</a>
           </td>
           <td><small class="badge badge-secondary">{{ area.mode }}</small></td>
           <td class="d-none d-lg-table-cell">
@@ -102,7 +102,7 @@ $(document).ready(function () {
             {% if area.settings[key] != "" %}
             {% if key == "mon_ids_iv" %}
               {% if area.settings[key] in monlist %}
-              {{ key }}: <a href="/settings/ivlists?id={{area.settings[key]}}">{{ monlist[area.settings[key]].monlist }}</a><br>
+              {{ key }}: <a href="{{ url_for('settings_ivlists', id=area.settings[key]) }}">{{ monlist[area.settings[key]].monlist }}</a><br>
               {% else %}
               {{ key }}: <b><font color="red">ERROR IN IV LIST - CHECK IT</font></b>
               {% endif %}

--- a/madmin/templates/settings_auth.html
+++ b/madmin/templates/settings_auth.html
@@ -13,7 +13,7 @@ $(document).ready(function () {
             var elem =  $(this);
             $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Deleting a {{ subtab }}...</h2>' });
             $.ajax({
-                url : $(this).data('identifier'),
+                url : '{{ url_for('api_auth') }}/'+ $(this).data('identifier').substr($(this).data('identifier').lastIndexOf('/')+1),
                 type : 'DELETE',
                 success: function(data, status, xhr) {
                     if(xhr.status == 202) {
@@ -68,7 +68,7 @@ $(document).ready(function () {
       <thead class="thead-dark">
         <tr>
           <th style="width: 80%" class="align-middle">Name <i class="fas fa-info-circle" data-toggle="tooltip" title="These usernames are being used to authenticate RGC and PogoDroid against MAD."></th>
-          <th style="width: 20%" class="text-right align-middle"><a href='{{ redirect }}?id=new'><button type="button" class="btn btn-sm btn-success"><i class="fas fa-plus"></i></button></a></th>
+          <th style="width: 20%" class="text-right align-middle"><a href='{{ url_for('settings_auth', id='new') }}'><button type="button" class="btn btn-sm btn-success"><i class="fas fa-plus"></i></button></a></th>
         </tr>
       </thead>
       {% if auth is none %}
@@ -78,7 +78,7 @@ $(document).ready(function () {
         {% for auth_id, auth in auth.items() %}
         <tr>
           <td class="align-middle">
-            <a href="{{ redirect }}?id={{ auth_id }}">{{ auth.username }}</a>
+            <a href="{{ url_for('settings_auth', id=auth_id) }}">{{ auth.username }}</a>
           </td>
           <td class="text-right align-middle">
             <button data-identifier='{{ auth_id }}' type="button" class="delete btn btn-danger btn-sm"><i class="fas fa-trash-alt"></i>

--- a/madmin/templates/settings_devices.html
+++ b/madmin/templates/settings_devices.html
@@ -9,7 +9,7 @@
 <script>
 $(document).ready(function () {
     $("select").change(function() {
-        var uri = $(this).data('identifier');
+        var uri = '{{ base_uri }}/'+ $(this).data('identifier').substr($(this).data('identifier').lastIndexOf('/')+1);
         var val = $(this).children("option:selected").attr('name');
         var patch_data = {"walker": val};
         $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Load...</h2>' });
@@ -26,8 +26,10 @@ $(document).ready(function () {
         if(confirm('Are you sure you want to delete this resource?')) {
             var elem =  $(this);
             $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Deleting a {{ subtab }}...</h2>' });
+            console.log('{{ base_uri }}');
+            console.log($(this).data('identifier'));
             $.ajax({
-                url : $(this).data('identifier'),
+                url : '{{ base_uri }}/'+ $(this).data('identifier').substr($(this).data('identifier').lastIndexOf('/')+1),
                 type : 'DELETE',
                 success: function(data, status, xhr) {
                     if(xhr.status == 202) {
@@ -84,7 +86,7 @@ $(document).ready(function () {
           <th style="width: 30%" class="align-middle">Origin</th>
           <th style="width: 20%" class="align-middle d-none d-lg-table-cell">Settings</th>
           <th style="width: 30%" class="align-middle">Walker <i class="fas fa-info-circle" data-toggle="tooltip" title="Changing a walker for a device is saved automatically"></i></th>
-          <th style="width: 20%" class="text-right align-middle"><a href='{{ redirect }}?id=new'><button type="button" class="btn btn-sm btn-success"><i class="fas fa-plus"></i></button></a></th>
+          <th style="width: 20%" class="text-right align-middle"><a href='{{ url_for('settings_devices', id='new') }}'><button type="button" class="btn btn-sm btn-success"><i class="fas fa-plus"></i></button></a></th>
         </tr>
       </thead>
       {% if device is none %}
@@ -94,7 +96,7 @@ $(document).ready(function () {
       {% for dev_uri, device in device.items() %}
         <tr>
           <td class="align-middle">
-            <a href="{{ redirect }}?id={{ dev_uri }}">{{ device.origin }}</a>
+            <a href="{{ url_for('settings_devices', id=dev_uri) }}">{{ device.origin }}</a>
           </td>
           <td class="align-middle d-none d-lg-table-cell">
             <p style="font-size: 65%; min-height: 50px; display: inline-box">

--- a/madmin/templates/settings_ivlists.html
+++ b/madmin/templates/settings_ivlists.html
@@ -13,7 +13,7 @@ $(document).ready(function () {
             var elem =  $(this);
             $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Deleting a {{ subtab }}...</h2>' });
             $.ajax({
-                url : $(this).data('identifier'),
+                url : '{{ base_uri }}/'+ $(this).data('identifier').substr($(this).data('identifier').lastIndexOf('/')+1),
                 type : 'DELETE',
                 success: function(data, status, xhr) {
                     if(xhr.status == 202) {
@@ -68,7 +68,7 @@ $(document).ready(function () {
       <thead class="thead-dark">
         <tr>
           <th style="width: 80%" class="align-middle">Name</th>
-          <th style="width: 20%" class= "text-right align-middle"><a href='{{ redirect }}?id=new'><button type="button" class="btn btn-sm btn-success"><i class="fas fa-plus"></i></button></a></th>
+          <th style="width: 20%" class= "text-right align-middle"><a href='{{ url_for('settings_ivlists', id='new') }}'><button type="button" class="btn btn-sm btn-success"><i class="fas fa-plus"></i></button></a></th>
         </tr>
       </thead>
       {% if monivlist is none %}
@@ -78,7 +78,7 @@ $(document).ready(function () {
         {% for monlist_id, elem in monivlist.items() %}
         <tr>
           <td class="align-middle">
-            <a href="{{ redirect }}?id={{ monlist_id }}">{{ elem.monlist }}</a>
+            <a href="{{ url_for('settings_ivlists', id=monlist_id) }}">{{ elem.monlist }}</a>
           </td>
           <td class="text-right align-middle">
             <button data-identifier='{{ monlist_id }}' type="button" class="delete btn btn-danger btn-sm"><i class="fas fa-trash-alt"></i>

--- a/madmin/templates/settings_sharedsettings.html
+++ b/madmin/templates/settings_sharedsettings.html
@@ -13,7 +13,7 @@ $(document).ready(function () {
             var elem =  $(this);
             $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Deleting a {{ subtab }}...</h2>' });
             $.ajax({
-                url : $(this).data('identifier'),
+                url : '{{ base_uri }}/'+ $(this).data('identifier').substr($(this).data('identifier').lastIndexOf('/')+1),
                 type : 'DELETE',
                 success: function(data, status, xhr) {
                     if(xhr.status == 202) {
@@ -69,7 +69,7 @@ $(document).ready(function () {
         <tr>
           <th style="width: 40%" class="align-middle">Name</th>
           <th style="width: 40%" class="align-middle">Settings</th>
-          <th style="width: 20%" class= "text-right align-middle"><a href='{{ redirect }}?id=new'><button type="button" class="btn btn-sm btn-success"><i class="fas fa-plus"></i></button></a></th>
+          <th style="width: 20%" class= "text-right align-middle"><a href='{{ url_for('settings_pools', id='new') }}'><button type="button" class="btn btn-sm btn-success"><i class="fas fa-plus"></i></button></a></th>
         </tr>
       </thead>
         {% if devicesetting is none %}
@@ -79,7 +79,7 @@ $(document).ready(function () {
         {% for pool_id, devicesetting in devicesetting.items() %}
         <tr>
           <td class="align-middle">
-            <a href="{{ redirect }}?id={{ pool_id }}">{{ devicesetting.devicepool }}</a>
+            <a href="{{ url_for('settings_pools', id=pool_id) }}">{{ devicesetting.devicepool }}</a>
           </td>
           <td>
             <p style="font-size: 65%; min-height: 40px; display: inline-box">

--- a/madmin/templates/settings_singleivlist.html
+++ b/madmin/templates/settings_singleivlist.html
@@ -75,7 +75,7 @@
         $(".result-hint").hide();
         if(val.length >= 3) {
             $.ajax({
-                url : "/settings/monsearch",
+                url : "{{ url_for('monsearch') }}",
                 data : jQuery.param({'search': val, 'monlist': '{{ uri }}'}),
                 type : 'GET',
                 contentType : 'application/json',

--- a/madmin/templates/settings_singlewalker.html
+++ b/madmin/templates/settings_singlewalker.html
@@ -141,7 +141,7 @@
                         <th class="align-middle">Walker mode</th>
                         <th class="align-middle">Setting</th>
                         <th class="align-middle">Max devices</th>
-                        <th>{% if uri != '/api/walker' %}<a href='{{ redirect }}/areaeditor?id={{ uri }}'><button type="button" class="btn btn-sm btn-success"><i class="fas fa-plus"></i></button></a>{% endif %}</th>
+                        <th>{% if uri != '/api/walker' %}<a href='{{ url_for('settings_walker_area', id=uri) }}'><button type="button" class="btn btn-sm btn-success"><i class="fas fa-plus"></i></button></a>{% endif %}</th>
                     </tr>
                 </tbody>
                 <tbody class="row_position ui-sortable">
@@ -149,12 +149,12 @@
                         {% set area = walkerarea[walkerarea_uri] %}
                         <tr id='{{ walkerarea_uri }}'>
                             <td><i class="fa fa-fw fa-sort handle ui-sortable-handle"></i></td>
-                            <td class='walkerarea' data-save='{{ area.walkerarea }}' data-walkertext='{{ area.walkertext }}'><a href="/settings/areas?id={{area['walkerarea']}}&mode={{areas[area['walkerarea']].mode}}">{{ areas[area['walkerarea']].name }}</a><br>{{ area.walkertext }}</td>
+                            <td class='walkerarea' data-save='{{ area.walkerarea }}' data-walkertext='{{ area.walkertext }}'><a href="{{ url_for('settings_areas', id=area['walkerarea'], mode=areas[area['walkerarea']].mode) }}">{{ areas[area['walkerarea']].name }}</a><br>{{ area.walkertext }}</td>
                             <td class='walkertype' data-save='{{ area.walkertype }}'>{{ area.walkertype }}</td>
                             <td class='walkervalue' data-save='{{ area.walkervalue }}'>{{ area.walkervalue }}</td>
                             <td class='walkermax' data-save='{{ area.walkermax }}'>{{ area.walkermax }}</td>
                             <td>
-                                <a href="{{ redirect }}/areaeditor?id={{ uri }}&walkerarea={{ walkerarea_uri }}"><button type="button" class="btn btn-success btn-sm edit" data-identifier="{{ loop.index }}"><i class="far fa-edit"></i></button></a>
+                                <a href="{{ url_for('settings_walker_area', id=uri, walkerarea=walkerarea_uri) }}"><button type="button" class="btn btn-success btn-sm edit" data-identifier="{{ loop.index }}"><i class="far fa-edit"></i></button></a>
                                 <button type="button" class="btn btn-danger btn-sm delete" data-identifier="{{ loop.index }}"><i class="fas fa-trash-alt"></i></button>
                             </td>
                         </tr>

--- a/madmin/templates/settings_walkers.html
+++ b/madmin/templates/settings_walkers.html
@@ -13,7 +13,7 @@ $(document).ready(function () {
             var elem =  $(this);
             $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Deleting a {{ subtab }}...</h2>' });
             $.ajax({
-                url : $(this).data('identifier'),
+                url : '{{ base_uri }}/'+ $(this).data('identifier').substr($(this).data('identifier').lastIndexOf('/')+1),
                 type : 'DELETE',
                 success: function(data, status, xhr) {
                     if(xhr.status == 202) {
@@ -69,7 +69,7 @@ $(document).ready(function () {
         <tr>
           <th style="width: 40%" class="align-middle">Name</th>
           <th style="width: 40%" class="align-middle">Settings</th>
-          <th style="width: 20%" class= "text-right align-middle"><a href='{{ redirect }}?id=new'><button type="button" class="btn btn-sm btn-success"><i class="fas fa-plus"></i></button></a></th>
+          <th style="width: 20%" class= "text-right align-middle"><a href='{{ url_for('settings_walkers', id='new') }}'><button type="button" class="btn btn-sm btn-success"><i class="fas fa-plus"></i></button></a></th>
         </tr>
       </thead>
       {% if walker is none %}
@@ -84,7 +84,7 @@ $(document).ready(function () {
           <td>
             <p style="font-size: 65%; min-height: 40px; display: inline-box">
               Number of Areas: {{ walker.setup|length }}<br>
-            Areas: {% for walkerarea_uri in walker.setup %}{% if loop.index > 1 %}, {% endif %}<a href="/settings/areas?id={{walkerarea[walkerarea_uri]['walkerarea']}}&mode={{ areas[walkerarea[walkerarea_uri]['walkerarea']].mode }}">{{ areas[walkerarea[walkerarea_uri]['walkerarea']].name }}</a>{% endfor %}
+            Areas: {% for walkerarea_uri in walker.setup %}{% if loop.index > 1 %}, {% endif %}<a href="{{ url_for('settings_areas', id=walkerarea[walkerarea_uri]['walkerarea'], mode=areas[walkerarea[walkerarea_uri]['walkerarea']].mode) }}">{{ areas[walkerarea[walkerarea_uri]['walkerarea']].name }}</a>{% endfor %}
             </p>
           </td>
           <td class="text-right align-middle">


### PR DESCRIPTION
This change allows MADmin to work behind a reverse proxy if it is not contained in the root (for example, /madmin) and should resolve #442 .  To use the non-root document, you must specify the walker arg 'madmin_base_path'.