### PR TITLE
Fix for preventing 500's when querying walkerareas

### DIFF
--- a/utils/data_manager.py
+++ b/utils/data_manager.py
@@ -117,7 +117,7 @@ class DataManager(object):
         else:
             sorted_keys = list(data.keys())
         for key in sorted_keys:
-            if fetch_all:
+            if fetch_all or display is None:
                 ordered_data[self.generate_uri(location, key)] = data[key]
             else:
                 ordered_data[self.generate_uri(location, key)] = data[key][display]


### PR DESCRIPTION
default_sort was not defined for walkerarea causing a 500 when querying /api/walkerarea.  This change validates the key exists so we do not lookup a NoneType.