### PR TITLE
Show all stops on the madmin map

### DIFF
--- a/db/rmWrapper.py
+++ b/db/rmWrapper.py
@@ -1381,7 +1381,9 @@ class RmWrapper(DbWrapperBase):
 
         # base query to fetch stops
         query = (
-            "SELECT * "
+            "SELECT pokestop_id, enabled, latitude, longitude, last_modified, lure_expiration, "
+            "active_fort_modifier, last_updated, name, image, incident_start, incident_expiration, "
+            "incident_grunt_type "
             "FROM pokestop "
         )
 

--- a/db/rmWrapper.py
+++ b/db/rmWrapper.py
@@ -1375,3 +1375,53 @@ class RmWrapper(DbWrapperBase):
         logger.debug('Final query for shiny_stats_global_v2: {}', query)
         res = self.execute(query, data)
         return res
+
+    def get_stops_in_rectangle(self, neLat, neLon, swLat, swLon, oNeLat=None, oNeLon=None, oSwLat=None, oSwLon=None, timestamp=None):
+        stops = {}
+
+        # base query to fetch stops
+        query = (
+            "SELECT * "
+            "FROM pokestop "
+        )
+
+        query_where = (
+            " WHERE (latitude >= {} AND longitude >= {} "
+            " AND latitude <= {} AND longitude <= {}) "
+        ).format(swLat, swLon, neLat, neLon)
+
+        if oNeLat is not None and oNeLon is not None and oSwLat is not None and oSwLon is not None:
+            oquery_where = (
+                " AND NOT (latitude >= {} AND longitude >= {} "
+                " AND latitude <= {} AND longitude <= {}) "
+            ).format(oSwLat, oSwLon, oNeLat, oNeLon)
+
+            query_where = query_where + oquery_where
+
+        elif timestamp is not None:
+            tsdt = datetime.utcfromtimestamp(int(timestamp)).strftime("%Y-%m-%d %H:%M:%S")
+            oquery_where = " AND last_updated >= '{}' ".format(tsdt)
+            query_where = query_where + oquery_where
+
+        res = self.execute(query + query_where)
+
+        for (stop_id, enabled, latitude, longitude, last_modified, lure_expiration,
+                active_fort_modifier, last_updated, name, image, incident_start,
+                incident_expiration, incident_grunt_type) in res:
+
+            stops[stop_id] = {
+                "enabled": enabled,
+                "latitude": latitude,
+                "longitude": longitude,
+                "last_modified": int(last_modified.replace(tzinfo=timezone.utc).timestamp()),
+                "lure_expiration": int(lure_expiration.replace(tzinfo=timezone.utc).timestamp()) if lure_expiration is not None else None,
+                "active_fort_modifier": active_fort_modifier,
+                "last_updated": int(last_updated.replace(tzinfo=timezone.utc).timestamp()) if last_updated is not None else None,
+                "name": name,
+                "image": image,
+                "incident_start": int(incident_start.replace(tzinfo=timezone.utc).timestamp()) if incident_start is not None else None,
+                "incident_expiration": int(incident_expiration.replace(tzinfo=timezone.utc).timestamp()) if incident_expiration is not None else None,
+                "incident_grunt_type": incident_grunt_type
+            }
+
+        return stops

--- a/madmin/routes/map.py
+++ b/madmin/routes/map.py
@@ -45,6 +45,7 @@ class map(object):
             ("/get_quests", self.get_quests),
             ("/get_map_mons", self.get_map_mons),
             ("/get_cells", self.get_cells),
+            ("/get_stops", self.get_stops),
             ("/savefence", self.savefence)
         ]
         for route, view_func in routes:
@@ -356,6 +357,44 @@ class map(object):
             })
 
         return jsonify(ret)
+
+    @auth_required
+    def get_stops(self):
+        neLat, neLon, swLat, swLon, oNeLat, oNeLon, oSwLat, oSwLon = getBoundParameter(request)
+        timestamp = request.args.get("timestamp", None)
+
+        coords = []
+
+        data = self._db.get_stops_in_rectangle(
+            neLat,
+            neLon,
+            swLat,
+            swLon,
+            oNeLat=oNeLat,
+            oNeLon=oNeLon,
+            oSwLat=oSwLat,
+            oSwLon=oSwLon,
+            timestamp=timestamp
+        )
+
+        for stopid in data:
+            stop = data[str(stopid)]
+
+            coords.append({
+                "id": stopid,
+                "name": stop["name"],
+                "url": stop["image"],
+                "lat": stop["latitude"],
+                "lon": stop["longitude"],
+                "active_fort_modifier": stop["active_fort_modifier"],
+                "last_updated": stop["last_updated"],
+                "lure_expiration": stop["lure_expiration"],
+                "incident_start": stop["incident_start"],
+                "incident_expiration": stop["incident_expiration"],
+                "incident_grunt_type": stop["incident_grunt_type"]
+            })
+
+        return jsonify(coords)
 
     @logger.catch()
     @auth_required

--- a/madmin/static/js/madmin.js
+++ b/madmin/static/js/madmin.js
@@ -134,7 +134,8 @@ var leaflet_data = {
   workers: {},
   mons: {},
   monicons: {},
-  cellupdates: {}
+  cellupdates: {},
+  stops: {}
 };
 
 new Vue({
@@ -143,6 +144,7 @@ new Vue({
     raids: {},
     gyms: {},
     quests: {},
+    stops: {},
     spawns: {},
     mons: {},
     cellupdates: {},
@@ -151,6 +153,7 @@ new Vue({
         spawns: false,
         gyms: false,
         quests: false,
+        stops: false,
         workers: false,
         mons: false,
         cellupdates: false
@@ -242,6 +245,13 @@ new Vue({
 
       this.changeStaticLayer("quests", oldVal, newVal);
     },
+    "layers.stat.stops": function(newVal, oldVal) {
+      if (newVal && !init) {
+        this.map_fetch_stops(this.buildUrlFilter(true));
+      }
+
+      this.changeStaticLayer("stops", oldVal, newVal);
+    },
     "layers.stat.mons": function(newVal, oldVal) {
       if (newVal && !init) {
         this.map_fetch_mons(this.buildUrlFilter(true));
@@ -330,6 +340,7 @@ new Vue({
       this.map_fetch_geofences();
       this.map_fetch_spawns(urlFilter);
       this.map_fetch_quests(urlFilter);
+      this.map_fetch_stops(urlFilter);
       this.map_fetch_mons(urlFilter);
       this.map_fetch_prioroutes();
       this.map_fetch_cells(urlFilter);
@@ -717,12 +728,45 @@ new Vue({
             id: quest["pokestop_id"],
             virtual: true,
             icon: $this.build_quest_small(quest['quest_reward_type_raw'], quest['item_id'], quest['pokemon_id'])
-          }).bindPopup($this.build_stop_popup, { "className": "questpopup"});
+          }).bindPopup($this.build_quest_popup, { "className": "questpopup"});
 
           $this.addMouseEventPopup(leaflet_data["quests"][quest["pokestop_id"]]);
 
           if ($this.layers.stat.quests) {
             leaflet_data["quests"][quest["pokestop_id"]].addTo(map);
+          }
+        });
+      });
+    },
+    map_fetch_stops(urlFilter) {
+      var $this = this;
+
+      if (!$this.layers.stat.stops) {
+        return;
+      }
+
+      axios.get("get_stops" + urlFilter).then(function (res) {
+        res.data.forEach(function(stop) {
+          if ($this.stops[stop["id"]]) {
+            return;
+          }
+
+          $this.stops[stop["id"]] = stop;
+
+          leaflet_data["stops"][stop["id"]] = L.circle([stop["lat"], stop["lon"]], {
+            radius: 8,
+            color: 'blue',
+            fillColor: 'blue',
+            weight: 1,
+            opacity: 0.7,
+            fillOpacity: 0.5,
+            id: stop["id"]
+          }).bindPopup($this.build_stop_popup, { "className": "stoppopup"});
+
+          $this.addMouseEventPopup(leaflet_data["stops"][stop["id"]]);
+
+          if ($this.layers.stat.stops) {
+            leaflet_data["stops"][stop["id"]].addTo(map);
           }
         });
       });
@@ -991,22 +1035,52 @@ new Vue({
           <div class="rewardImg" style="background-image: url(${image}); background-size: ${size}"></div>
         </div>`;
     },
-    build_stop_popup(marker) {
-      var quest = this.quests[marker.options.id];
+    build_stop_base_popup(id, image, name, latitude, longitude) {
+      return `
+          <div class="image" style="background: url(${image}) center center no-repeat;"></div>
+          <div class="name"><strong>${name}</strong></div>
+          <div class="id"><i class="fa fa-fingerprint"></i> <span>${id}</span></div>
+          <div class="coords">
+            <i class="fa fa-map-pin"></i>
+            <a href="https://maps.google.com/?q=${latitude},${longitude}">${latitude}, ${longitude}</a>
+            <a onclick=copyClipboard("${latitude.toFixed(6)}|${longitude.toFixed(6)}") href="#"><i class="fa fa-clipboard" aria-hidden="true"></i></a>
+          </div>`
+    },
+    build_quest_popup(marker) {
+      var quest = this.quests[marker.options.id]
+      var base_popup = this.build_stop_base_popup(quest["pokestop_id"], quest["url"], quest["name"], quest["latitude"], quest["longitude"])
 
       return `
         <div class="content">
-          <div class="image" style="background: url(${quest["url"]}) center center no-repeat;"></div>
-          <div class="name"><strong>${quest["name"]}</strong></div>
-          <div class="id"><i class="fa fa-fingerprint"></i> <span>${quest["pokestop_id"]}</span></div>
-          <div class="coords">
-            <i class="fa fa-map-pin"></i>
-            <a href="https://maps.google.com/?q=${quest["latitude"]},${quest["longitude"]}">${quest["latitude"]}, ${quest["longitude"]}</a>
-            <a onclick=copyClipboard("${quest["latitude"].toFixed(6)}|${quest["longitude"].toFixed(6)}") href="#"><i class="fa fa-clipboard" aria-hidden="true"></i></a>
-          </div>
-          <div id="questTimestamp"><i class="fa fa-clock"></i> Scanned: ${moment(quest['timestamp']*1000).format("YYYY-MM-DD HH:mm:ss")}</div>
+          ${base_popup}
+          <div id="questTimestamp"><i class="fa fa-clock"></i> Scanned: <strong>${moment(quest['timestamp']*1000).format("YYYY-MM-DD HH:mm:ss")}</strong></div>
           <br>
           ${this.build_quest(quest['quest_reward_type_raw'], quest['quest_task'], quest['pokemon_id'], quest['item_id'], quest['item_amount'], quest['pokemon_name'], quest['item_type'])}
+        </div>`;
+    },
+    build_stop_popup(marker) {
+      var stop = this.stops[marker.options.id]
+      var base_popup = this.build_stop_base_popup(stop["id"], stop["url"], stop["name"], stop["lat"], stop["lon"])
+
+      var incident = "";
+      var incident_expiration = moment(stop["incident_expiration"]*1000);
+      if (incident_expiration.isAfter(moment())) {
+        incident = `<div class="incident"><i class="fa fa-user-secret"></i> Incident ends: <strong>${incident_expiration.format("YYYY-MM-DD HH:mm:ss")}</strong></div>`
+      }
+
+      var lure = "";
+      var lure_expiration = moment(stop["lure_expiration"]*1000);
+      if (lure_expiration.isAfter(moment())) {
+        lure = `<div class="incident"><i class="fa fa-drumstick-bite"></i> Lure ends: <strong>${lure_expiration.format("YYYY-MM-DD HH:mm:ss")}</strong></div>`
+      }
+
+      return `
+        <div class="content">
+          ${base_popup}
+          <br>
+          <div class="timestamp"><i class="fa fa-clock"></i> Scanned: <strong>${moment(stop["last_updated"]*1000).format("YYYY-MM-DD HH:mm:ss")}</strong></div>
+          ${incident}
+          ${lure}
         </div>`;
     },
     build_gym_popup(marker) {

--- a/madmin/static/style/madmin.css
+++ b/madmin/static/style/madmin.css
@@ -27,6 +27,7 @@ div.container[role="main"] {
 .cellpopup .leaflet-popup-content,
 .questpopup .leaflet-popup-content,
 .gympopup .leaflet-popup-content,
+.stoppopup .leaflet-popup-content,
 .monpopup .leaflet-popup-content {
   width: 400px !important;
   margin: 13px !important;
@@ -36,6 +37,7 @@ div.container[role="main"] {
   font-size: 13px;
 }
 
+.stoppopup .leaflet-popup-content .content,
 .gympopup .leaflet-popup-content .content,
 .questpopup .leaflet-popup-content .content {
   margin-left: 100px;

--- a/madmin/templates/map.html
+++ b/madmin/templates/map.html
@@ -4,7 +4,7 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.4/dist/leaflet.css" integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA==" crossorigin="" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet-sidebar-v2@3.0.6/css/leaflet-sidebar.min.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet-easybutton@2/src/easy-button.css">
-<link rel="stylesheet" href="static/style/madmin.css?1561125653674" />
+<link rel="stylesheet" href="static/style/madmin.css?1571785075" />
 <link rel="stylesheet" href="https://unpkg.com/leaflet-draw@1.0.2/dist/leaflet.draw.css" />
 {% endblock %}
 


### PR DESCRIPTION
As requested in #453 this PR will add an extra option to view all stops in the current view on the MADmin map. This is still highly WIP and requires some finetuning here and there. 

Their color does not change based on the lure or incident but at least the popup will show the current event without the actual type