### PR TITLE
Track worker status per MAD instance

### DIFF
--- a/db/dbWrapperBase.py
+++ b/db/dbWrapperBase.py
@@ -84,6 +84,9 @@ class DbWrapperBase(ABC):
             .format(field["table"], field["column"], field["ctype"])
         )
 
+        if "modify_key" in field:
+            alter_query = alter_query + ", " + field["modify_key"]
+
         self.execute(alter_query, commit=True)
 
         if self.check_column_exists(field["table"], field["column"]) == 1:

--- a/db/dbWrapperBase.py
+++ b/db/dbWrapperBase.py
@@ -948,14 +948,14 @@ class DbWrapperBase(ABC):
 
         return
 
-    def save_status(self, data):
+    def save_status(self, instance, data):
         logger.debug("dbWrapper::save_status")
 
         query = (
-            "INSERT into trs_status (origin, currentPos, lastPos, routePos, routeMax, "
+            "INSERT into trs_status (instance, origin, currentPos, lastPos, routePos, routeMax, "
             "routemanager, rebootCounter, lastProtoDateTime, "
             "init, rebootingOption, restartCounter, currentSleepTime) values "
-            "(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"
+            "(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"
             "ON DUPLICATE KEY UPDATE currentPos=VALUES(currentPos), "
             "lastPos=VALUES(lastPos), routePos=VALUES(routePos), "
             "routeMax=VALUES(routeMax), routemanager=VALUES(routemanager), "
@@ -964,6 +964,7 @@ class DbWrapperBase(ABC):
             "currentSleepTime=VALUES(currentSleepTime)"
         )
         vals = (
+            instance,
             data["Origin"], str(data["CurrentPos"]), str(
                 data["LastPos"]), data["RoutePos"], data["RouteMax"],
             data["Routemanager"], data["RebootCounter"], data["LastProtoDateTime"],
@@ -972,42 +973,42 @@ class DbWrapperBase(ABC):
         self.execute(query, vals, commit=True)
         return
 
-    def save_last_reboot(self, origin):
+    def save_last_reboot(self, instance, origin):
         logger.debug("dbWrapper::save_last_reboot")
         now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         query = (
-            "insert into trs_status(origin, lastPogoReboot, globalrebootcount) "
-            "values (%s, %s, %s) "
+            "insert into trs_status(instance, origin, lastPogoReboot, globalrebootcount) "
+            "values (%s, %s, %s, %s) "
             "ON DUPLICATE KEY UPDATE lastPogoReboot=VALUES(lastPogoReboot), globalrebootcount=(globalrebootcount+1)"
 
         )
 
         vals = (
-            origin,  now, 1
+            instance, origin, now, 1
         )
 
         self.execute(query, vals, commit=True)
         return
 
-    def save_last_restart(self, origin):
+    def save_last_restart(self, instance, origin):
         logger.debug("dbWrapper::save_last_restart")
         now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         query = (
 
-            "insert into trs_status(origin, lastPogoRestart, globalrestartcount) "
-            "values (%s, %s, %s) "
+            "insert into trs_status(instance, origin, lastPogoRestart, globalrestartcount) "
+            "values (%s, %s, %s, %s) "
             "ON DUPLICATE KEY UPDATE lastPogoRestart=VALUES(lastPogoRestart), globalrestartcount=(globalrestartcount+1)"
 
         )
 
         vals = (
-            origin, now, 1
+            instance, origin, now, 1
         )
 
         self.execute(query, vals, commit=True)
         return
 
-    def download_status(self):
+    def download_status(self, instance):
         logger.debug("dbWrapper::download_status")
         workerstatus = []
 
@@ -1016,8 +1017,9 @@ class DbWrapperBase(ABC):
             "routemanager, rebootCounter, lastProtoDateTime, lastPogoRestart, "
             "init, rebootingOption, restartCounter, globalrebootcount, globalrestartcount, lastPogoReboot, "
             "currentSleepTime "
-            "FROM trs_status"
-        )
+            "FROM trs_status "
+            "WHERE instance = '{}'"
+        ).format(instance)
 
         result = self.execute(query)
         for (origin, currentPos, lastPos, routePos, routeMax, routemanager_id,
@@ -1402,7 +1404,7 @@ class DbWrapperBase(ABC):
 
         return res
 
-    def update_trs_status_to_idle(self, origin):
+    def update_trs_status_to_idle(self, instance, origin):
         query = "UPDATE trs_status SET routemanager = 'idle' WHERE origin = '" + origin + "'"
         logger.debug(query)
         self.execute(query, commit=True)

--- a/db/rmWrapper.py
+++ b/db/rmWrapper.py
@@ -53,6 +53,11 @@ class RmWrapper(DbWrapperBase):
                 "table": "pokestop",
                 "column": "incident_grunt_type",
                 "ctype": "smallint(1) NULL"
+            },
+            {
+                "table": "trs_status",
+                "column": "instance",
+                "ctype": "VARCHAR(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL FIRST"
             }
         ]
 

--- a/db/rmWrapper.py
+++ b/db/rmWrapper.py
@@ -57,7 +57,8 @@ class RmWrapper(DbWrapperBase):
             {
                 "table": "trs_status",
                 "column": "instance",
-                "ctype": "VARCHAR(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL FIRST"
+                "ctype": "VARCHAR(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL FIRST",
+                "modify_key": "DROP PRIMARY KEY, ADD PRIMARY KEY (`instance`, `origin`)"
             }
         ]
 

--- a/madmin/routes/statistics.py
+++ b/madmin/routes/statistics.py
@@ -493,7 +493,7 @@ class statistics(object):
 
     @auth_required
     def get_status(self):
-        device_status = self._db.download_status()
+        device_status = self._db.download_status(self._args.status_name)
         areas = self._mapping_manager.get_areas()
 
         data = []

--- a/worker/MITMBase.py
+++ b/worker/MITMBase.py
@@ -270,4 +270,4 @@ class MITMBase(WorkerBase):
             'CurrentSleepTime': str(self._current_sleep_time)
         }
 
-        self._db_wrapper.save_status(dataToSave)
+        self._db_wrapper.save_status(self._applicationArgs.status_name, dataToSave)

--- a/worker/WorkerBase.py
+++ b/worker/WorkerBase.py
@@ -759,7 +759,7 @@ class WorkerBase(ABC):
             mitm_mapper.collect_location_stats(self._id, self.current_location, 1, time.time(), 3, 0,
                                                self._mapping_manager.routemanager_get_mode(self._routemanager_name),
                                                99)
-        self._db_wrapper.save_last_reboot(self._id)
+        self._db_wrapper.save_last_reboot(self._applicationArgs.status_name, self._id)
         self.stop_worker()
         return start_result
 
@@ -774,7 +774,7 @@ class WorkerBase(ABC):
 
     def _restart_pogo(self, clear_cache=True, mitm_mapper: Optional[MitmMapper] = None):
         successful_stop = self._stop_pogo()
-        self._db_wrapper.save_last_restart(self._id)
+        self._db_wrapper.save_last_restart(self._applicationArgs.status_name, self._id)
         logger.debug("restartPogo: stop game resulted in {}",
                      str(successful_stop))
         if successful_stop:

--- a/worker/WorkerConfigmode.py
+++ b/worker/WorkerConfigmode.py
@@ -16,6 +16,7 @@ from utils.madGlobals import (WebsocketWorkerRemovedException, WebsocketWorkerTi
 class WorkerConfigmode(object):
     def __init__(self, args, id, websocket_handler, walker, mapping_manager,
                  mitm_mapper: MitmMapper, db_wrapper: DbWrapperBase, routemanager_name: str):
+        self._args = args
         self._communicator = Communicator(
             websocket_handler, id, self, args.websocket_command_timeout)
         self._stop_worker_event = Event()
@@ -43,7 +44,7 @@ class WorkerConfigmode(object):
         logger.info("Worker {} started in configmode", str(self._id))
         self._mapping_manager.register_worker_to_routemanager(self._routemanager_name, self._id)
         logger.debug("Setting device to idle for routemanager")
-        self._db_wrapper.update_trs_status_to_idle(self._id)
+        self._db_wrapper.update_trs_status_to_idle(self._args.status_name, self._id)
         logger.debug("Device set to idle for routemanager {}", str(self._id))
         while self.check_walker() and not self._stop_worker_event.is_set():
             position_type = self._mapping_manager.routemanager_get_position_type(self._routemanager_name, self._id)
@@ -129,7 +130,7 @@ class WorkerConfigmode(object):
                 self._stop_pogo()
                 killpogo = True
                 logger.debug("Setting device to idle for routemanager")
-                self._db_wrapper.update_trs_status_to_idle(self._id)
+                self._db_wrapper.update_trs_status_to_idle(self._args.status_name, self._id)
                 logger.debug("Device set to idle for routemanager {}", str(self._id))
             while check_walker_value_type(sleeptime) and not self._stop_worker_event.isSet():
                 time.sleep(1)
@@ -214,7 +215,7 @@ class WorkerConfigmode(object):
                 "Could not reboot due to client already having disconnected")
             start_result = False
         time.sleep(5)
-        self._db_wrapper.save_last_reboot(self._id)
+        self._db_wrapper.save_last_reboot(self._args.status_name, self._id)
         self.stop_worker()
         return start_result
 


### PR DESCRIPTION
Fixes  one of the issues mentioned in https://github.com/Map-A-Droid/MAD/issues/444#issue-509615654 and tracks the worker status in `trs_status` per running MAD instance.

It requires `ALTER TABLE trs_status DROP PRIMARY KEY, ADD PRIMARY KEY (instance, origin);` to span the primary key over `instance` and `origin`. I haven't added this particular automation yet, but I propose to extend `DbWrapperBase._check_create_column` to modify keys along with a column.
