### PR TITLE
Change route calculation to consider S2 cell level for viewing radius.

### DIFF
--- a/route/RouteManagerBase.py
+++ b/route/RouteManagerBase.py
@@ -49,12 +49,14 @@ class RouteManagerBase(ABC):
     def __init__(self, db_wrapper: DbWrapperBase, dbm: DataManager, uri: str, coords: List[Location], max_radius: float,
                  max_coords_within_radius: int, path_to_include_geofence: str, path_to_exclude_geofence: str,
                  routefile: str, mode=None, init: bool = False, name: str = "unknown", settings: dict = None,
-                 level: bool = False, calctype: str = "optimized", joinqueue = None):
+                 level: bool = False, calctype: str = "optimized", useS2: bool = False, S2level: int = 15, joinqueue = None):
         self.db_wrapper: DbWrapperBase = db_wrapper
         self.init: bool = init
         self.name: str = name
         self._data_manager = dbm
         self._uri = uri
+        self.useS2: bool = useS2
+        self.S2level: int = S2level
         self._coords_unstructured: List[Location] = coords
         self.geofence_helper: GeofenceHelper = GeofenceHelper(
             path_to_include_geofence, path_to_exclude_geofence)
@@ -281,7 +283,7 @@ class RouteManagerBase(ABC):
             logger.debug("Deleting routefile...")
             os.remove(str(routefile) + ".calc")
         new_route = getJsonRoute(coords, max_radius, max_coords_within_radius, num_processes=num_procs,
-                                 routefile=routefile, algorithm=calctype)
+                                 routefile=routefile, algorithm=calctype, useS2=self.useS2, S2level=self.S2level)
         if self._overwrite_calculation:
             self._overwrite_calculation = False
         return new_route

--- a/route/RouteManagerFactory.py
+++ b/route/RouteManagerFactory.py
@@ -5,18 +5,18 @@ from route.RouteManagerMon import RouteManagerMon
 from route.RouteManagerQuests import RouteManagerQuests
 from route.RouteManagerRaids import RouteManagerRaids
 
-
 class RouteManagerFactory:
     @staticmethod
     def get_routemanager(db_wrapper, dbm, uri, coords, max_radius, max_coords_within_radius, path_to_include_geofence,
                          path_to_exclude_geofence: Optional[str], routefile: str, mode: Optional[str] = None,
                          init: bool = False, name: str = "unknown", settings=None, coords_spawns_known: bool = False,
-                         level: bool = False, calctype: str = "optimized", joinqueue=None):
+                         level: bool = False, calctype: str = "optimized", useS2: bool = False, S2level: int = 15, joinqueue=None):
 
         if mode == "raids_mitm":
             route_manager = RouteManagerRaids(db_wrapper, dbm, uri, coords, max_radius, max_coords_within_radius,
                                               path_to_include_geofence, path_to_exclude_geofence, routefile,
-                                              mode=mode, settings=settings, init=init, name=name, joinqueue=joinqueue
+                                              mode=mode, settings=settings, init=init, name=name, joinqueue=joinqueue,
+                                              useS2=useS2, S2level=S2level
                                               )
         elif mode == "mon_mitm":
             route_manager = RouteManagerMon(db_wrapper, dbm, uri, coords, max_radius, max_coords_within_radius,

--- a/route/RouteManagerRaids.py
+++ b/route/RouteManagerRaids.py
@@ -17,13 +17,13 @@ class RouteManagerRaids(RouteManagerBase):
 
     def __init__(self, db_wrapper, dbm, uri, coords, max_radius, max_coords_within_radius, path_to_include_geofence,
                  path_to_exclude_geofence, routefile, mode=None, settings=None, init=False,
-                 name="unknown", joinqueue=None):
+                 name="unknown", joinqueue=None, useS2: bool = False, S2level: int = 15):
         RouteManagerBase.__init__(self, db_wrapper=db_wrapper, dbm=dbm, uri=uri, coords=coords, max_radius=max_radius,
                                   max_coords_within_radius=max_coords_within_radius,
                                   path_to_include_geofence=path_to_include_geofence,
                                   path_to_exclude_geofence=path_to_exclude_geofence,
                                   routefile=routefile, init=init,
-                                  name=name, settings=settings, mode=mode, joinqueue=joinqueue
+                                  name=name, settings=settings, mode=mode, useS2=True, S2level=S2level, joinqueue=joinqueue
                                   )
 
     def _retrieve_latest_priority_queue(self):

--- a/route/routecalc/calculate_route.py
+++ b/route/routecalc/calculate_route.py
@@ -11,7 +11,7 @@ from utils.logging import logger
 from .util import *
 
 
-def getLessCoords(npCoordinates, maxRadius, maxCountPerCircle):
+def getLessCoords(npCoordinates, maxRadius, maxCountPerCircle, useS2: bool=False, S2level: int=15):
     coordinates = []
     for coord in npCoordinates:
         coordinates.append(
@@ -19,7 +19,7 @@ def getLessCoords(npCoordinates, maxRadius, maxCountPerCircle):
         )
 
     clustering_helper = ClusteringHelper(max_radius=maxRadius, max_count_per_circle=maxCountPerCircle,
-                                         max_timedelta_seconds=0)
+                                         max_timedelta_seconds=0, useS2=useS2, S2level=S2level)
     clustered_events = clustering_helper.get_clustered(coordinates)
     # relations = __getRelationsInRange(coordinates, maxRadius)
     # summedUp = __sumUpRelations(relations, maxCountPerCircle, maxRadius)
@@ -33,8 +33,9 @@ def getLessCoords(npCoordinates, maxRadius, maxCountPerCircle):
     return coords_cleaned_up
 
 
-def getJsonRoute(coords, maxRadius, maxCoordsInRadius, routefile, num_processes=1, algorithm='optimized'):
+def getJsonRoute(coords, maxRadius, maxCoordsInRadius, routefile, num_processes=1, algorithm='optimized', useS2: bool = False, S2level: int=15):
     export_data = []
+    if useS2: logger.debug("Using S2 method for calculation with S2 level: {}", S2level)
     if routefile is not None and os.path.isfile(routefile + '.calc'):
         logger.debug('Found existing routefile {}', routefile)
         with open(routefile + '.calc', 'r') as route:
@@ -52,7 +53,7 @@ def getJsonRoute(coords, maxRadius, maxCoordsInRadius, routefile, num_processes=
     if len(coords) > 1 and maxRadius and maxCoordsInRadius:
         logger.info("Calculating...")
 
-        newCoords = getLessCoords(coords, maxRadius, maxCoordsInRadius)
+        newCoords = getLessCoords(coords, maxRadius, maxCoordsInRadius, useS2, S2level)
         lessCoordinates = np.zeros(shape=(len(newCoords), 2))
         for i in range(len(lessCoordinates)):
             lessCoordinates[i][0] = newCoords[i][0]

--- a/utils/MappingManager.py
+++ b/utils/MappingManager.py
@@ -18,7 +18,7 @@ from utils.s2Helper import S2Helper
 
 mode_mapping = {
     "raids_mitm": {
-        "s2_cell_level": 13,
+        "s2_cell_level": 15,
         "range": 490,
         "range_init": 490,
         "max_count": 100000
@@ -361,7 +361,8 @@ class MappingManager:
                                                                  coords_spawns_known=area.get("coords_spawns_known", False),
                                                                  routefile=area["routecalc"],
                                                                  calctype=area.get("route_calc_algorithm", "optimized"),
-                                                                 joinqueue=self.join_routes_queue
+                                                                 joinqueue=self.join_routes_queue,
+                                                                 S2level=mode_mapping.get(mode, {}).get("s2_cell_level", 30)
                                                                  )
 
             if mode not in ("iv_mitm", "idle"):

--- a/utils/s2Helper.py
+++ b/utils/s2Helper.py
@@ -282,3 +282,16 @@ class S2Helper:
         #     origin, bearing)
         # return Location(destination.latitude, destination.longitude)
         return Location(destination.lat, destination.lon)
+
+    @staticmethod
+    # Returns a set of S2 cells within circle around position
+    def get_S2cells_from_circle(lat, lng, radius, level=15):
+        EARTH = 6371000
+        region = s2sphere.Cap.from_axis_angle(\
+            s2sphere.LatLng.from_degrees(lat, lng).to_point(), \
+            s2sphere.Angle.from_degrees(360*radius/(2*math.pi*EARTH)))
+        coverer = s2sphere.RegionCoverer()
+        coverer.min_level = level
+        coverer.max_level = level
+        cells = coverer.get_covering(region)
+        return cells 


### PR DESCRIPTION
This is an update of PR #315. Previous PR was based on dev branch and needed some manual merge wich was applied in the current.

Standard way to cluster is to pick a coordinate, find one coordinate furthest away but within visual radius. Then take a circle around the center of the two coordinates and remove coordinates within the circle from the list of coordinates to cluster.
This PR just changes the circle to a region of S2 cells that are touched by the circle. This way removing all coordinates that are actually seen from the list.

The effect is of course dependent on the density of gyms. For me it reduced the number of coordinates from 100 to 84, I still scan all gyms.


-added facilities to pass S2 cell information from utils/MappingManager.py to actual route calculation
Old algorithm for calculation is kept, to compare route based on S2 cells with old algorithm change route/RouteManagerRaids.py in line 26 from useS2=True to useS2=False
-visible range could be adjusted in utils/MappingManager.py - for Germany a value of 520 instead of 490 would be ok
-crucial change is in route/routecalc/ClusteringHelper.py in class ClusteringHelper (see lines with if 'self.useS2')