### PR TITLE
Fix import and check for ADB support

### DIFF
--- a/utils/adb.py
+++ b/utils/adb.py
@@ -17,7 +17,11 @@ class ADBConnect(object):
                 from adb.client import Client as AdbClient
             except ImportError:
                 pass
-            self.check_adblib = 'adb.client' in sys.modules
+            try:
+                from ppadb.client import Client as AdbClient
+            except ImportError:
+                pass
+            self.check_adblib = 'adb.client' in sys.modules or 'ppadb.client' in sys.modules
             if not self.check_adblib:
                 logger.warning(
                     "Could not find pure-python-adb library - no support for ADB."


### PR DESCRIPTION
New import and fix check.

Reason:
The package name has been renamed from ‘adb’ to ‘ppadb’
From version v0.2.1-dev, the package name has been renamed from ‘adb’ to ‘ppadb’ to avoid conflit with Google google/python-adb