### PR TITLE
Stop Overwriting lastProtoDateTime with Null values

### DIFF
--- a/db/dbWrapperBase.py
+++ b/db/dbWrapperBase.py
@@ -959,7 +959,7 @@ class DbWrapperBase(ABC):
             "ON DUPLICATE KEY UPDATE currentPos=VALUES(currentPos), "
             "lastPos=VALUES(lastPos), routePos=VALUES(routePos), "
             "routeMax=VALUES(routeMax), routemanager=VALUES(routemanager), "
-            "rebootCounter=VALUES(rebootCounter), lastProtoDateTime=VALUES(lastProtoDateTime), "
+            "rebootCounter=VALUES(rebootCounter), lastProtoDateTime=IF(LENGTH(VALUES(lastProtoDateTime))=0, lastProtoDateTime, VALUES(lastProtoDateTime)), "
             "init=VALUES(init), rebootingOption=VALUES(rebootingOption), restartCounter=VALUES(restartCounter), "
             "currentSleepTime=VALUES(currentSleepTime)"
         )


### PR DESCRIPTION
Stop overwriting lastProtoDateTime with Null value.

Added an If so that if the new value has à 0 lenght, it doesn't get updated.

This way we keep the real lastProtoDateTime in the trs_status table.