### PR TITLE
Possibly fix dropping settings for /status and /quest page

### DIFF
--- a/madmin/templates/quests.html
+++ b/madmin/templates/quests.html
@@ -61,7 +61,7 @@
                 $("img.lazy").lazyload();
             },
             "autoWidth": false,
-	    "stateSave": true,
+            "stateSave": true,
             "stateDuration": 0  
         });
 	}

--- a/madmin/templates/quests.html
+++ b/madmin/templates/quests.html
@@ -60,7 +60,9 @@
             "drawCallback": function () {
                 $("img.lazy").lazyload();
             },
-            "autoWidth": false
+            "autoWidth": false,
+	    "stateSave": true,
+            "stateDuration": 0  
         });
 	}
 

--- a/madmin/templates/status.html
+++ b/madmin/templates/status.html
@@ -89,6 +89,7 @@
             "responsive": {{ responsive }},
             "autoWidth": false,
             "stateSave": true,
+            "stateDuration": 0,                                    
             "stateSaveCallback": function(settings,data) {
             localStorage.setItem( 'MAD_STATUS_' + settings.sInstance, JSON.stringify(data) )
             },


### PR DESCRIPTION
stateDuration is set to two hours by default. Randomly (never could get pattern, those 2 hours seems like a fit) the /status page would forgot how many devices I wanted to show and it will switch back to default 10 devices. 0 means infinity.

Also fix (enable it) for /quest page. @Expl0dingBanana will give feedback, he is actively using it.

Someone please test and if the problem of /status randomly switching back to 10 devices will be fixed I will edit PR for all datatables we have there in other subpages.

