### PR TITLE
WalkerArea UI fix

### DIFF
--- a/madmin/templates/settings_walkerarea.html
+++ b/madmin/templates/settings_walkerarea.html
@@ -43,8 +43,9 @@
             return;
         }
         $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Saving {{ subtab }}...</h2>' });
-        save_data = {
-          'settings': {}
+        save_data = {};
+        if($(".form-control[setting]").length > 0) {
+            save_data['settings'] = {};
         }
       $(".form-control").each(function() {
           var obj = $(this);


### PR DESCRIPTION
The walkerarea template was passing in 'settings' when it was not required.  This was rejected by the API so you would be unable to create or update walkerareas.