### PR TITLE
Unit tests

### DIFF
--- a/madmin/api/apiRequest.py
+++ b/madmin/api/apiRequest.py
@@ -34,7 +34,7 @@ class APIRequest(object):
     def parse_data(self):
         """ Transform the incoming data into a dataset python can utilize """
         data = self._request.get_data()
-        self._logger.debug4('Incoming data: {}', data)
+        self._logger.debug5('Incoming data: {}', data)
         if data is None or len(data) == 0:
             self.data = None
         elif self.content_type == 'application/json':

--- a/madmin/api/apiResponse.py
+++ b/madmin/api/apiResponse.py
@@ -11,7 +11,9 @@ class APIResponse(object):
 
     def __call__(self, content, status_code, **kwargs):
         headers = kwargs.get('', self.headers)
-        resp = flask.Response(self.convert_to_format(content), mimetype=self.mimetype)
+        converted_data = self.convert_to_format(content)
+        self.logger.debug4('Return Data: {}', converted_data)
+        resp = flask.Response(converted_data, mimetype=self.mimetype)
         resp.status_code = status_code
         for key, val in kwargs.items():
             if key == 'headers':
@@ -19,6 +21,8 @@ class APIResponse(object):
                     resp.headers.add(header_key, header_val)
             else:
                 setattr(resp, key, val)
+        self.logger.debug5('Return Data: {}', converted_data)
+        self.logger.debug5('Return Headers: {}', resp.headers)
         return resp
 
     def convert_to_format(self, content):

--- a/tests/api/api_base.py
+++ b/tests/api/api_base.py
@@ -1,0 +1,132 @@
+import copy
+import local_api
+from collections import namedtuple
+from unittest import TestCase
+import global_variables
+
+class APITestBase(TestCase):
+    generated_uris = []
+
+    def setUp(self):
+        madmin_args = namedtuple('madmin_args', 'madmin_ip madmin_port madmin_user madmin_password')
+        args = madmin_args('127.0.0.1', '5000', '', '')
+        self.api = local_api.LocalAPI(None, args)
+
+    def tearDown(self):
+        if self.generated_uris:
+            for uri in reversed(self.generated_uris):
+                self.delete_resource(uri)
+        self.api.close()
+
+    def add_created_resource(self, uri):
+        if uri not in self.generated_uris:
+            self.generated_uris.append(uri)
+
+    def create_resource(self, uri, payload, **kwargs):
+        response = self.api.post(uri, json=payload, **kwargs)
+        created_uri = response.headers['X-Uri']
+        self.add_created_resource(created_uri)
+        return response
+
+    def delete_resource(self, uri):
+        response = self.api.delete(uri)
+        if response.status_code == 202 and uri in self.generated_uris:
+            self.generated_uris.remove(uri)
+        return response
+
+    def create_valid(self, payload, uri=None, **kwargs):
+        uri = uri if uri else self.uri
+        return self.create_resource(uri, payload, **kwargs)
+
+    # ===========================
+    # ===== Basic Resources =====
+    # ===========================
+    def create_valid_resource(self, resource, **kwargs):
+        resource_def = global_variables.DEFAULT_OBJECTS[resource]
+        payload = copy.copy(resource_def['payload'])
+        def_kwargs = resource_def.get('kwargs', {})
+        if kwargs:
+            for key, val in kwargs.items():
+                payload[key] = val
+        response = self.create_resource(resource_def['uri'], payload, **def_kwargs)
+        return response.headers['X-Uri']
+
+    # ===========================
+    # ========== Tests ==========
+    # ===========================
+    def landing_page(self, test_resource=True):
+        response = self.api.get(self.uri)
+        self.assertEqual(response.status_code, 200)
+        json_data = response.json()
+        self.assertTrue('resource' in json_data)
+        self.assertTrue('results' in json_data)
+        if test_resource:
+            self.assertTrue(len(json_data['resource']['fields']) > 0)
+            if 'settings' in json_data['resource']:
+                self.assertTrue(len(json_data['resource']['settings']) > 0)
+        params = {
+            'hide_resource': 1
+        }
+        response = self.api.get(self.uri, params=params)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse('resource' in response.json())
+        self.assertTrue(type(response.json()) is dict)
+        params['fetch_all'] = 1
+        response = self.api.get(self.uri, params=params)
+        self.assertEqual(response.status_code, 200)
+        for key, val in response.json().items():
+            self.assertTrue(type(val) is dict)
+
+    def invalid_uri(self):
+        path = '%s/%s' % (self.uri, '-1')
+        response = self.api.get(path)
+        self.assertEqual(response.status_code, 404)
+
+    def invalid_post(self, payload, errors, error_code=422, **kwargs):
+        response = self.api.post(self.uri, json=payload, **kwargs)
+        self.assertEqual(response.status_code, error_code)
+        self.assertDictEqual(response.json(), errors)
+
+    def valid_post(self, payload, result, **kwargs):
+        response = self.create_valid(payload, **kwargs)
+        self.assertEqual(response.status_code, 201)
+        self.assertDictEqual(result, response.json())
+        uri = response.headers['X-Uri']
+        response = self.delete_resource(uri)
+        self.assertEqual(response.status_code, 202)
+
+    def invalid_put(self, payload, errors, error_code=422, **kwargs):
+        response = self.create_valid(self.base_payload)
+        uri = response.headers['X-Uri']
+        response = self.api.put(uri, json=payload, **kwargs)
+        self.assertEqual(response.status_code, error_code)
+        self.assertDictEqual(response.json(), errors)
+        response = self.delete_resource(uri)
+        self.assertEqual(response.status_code, 202)
+
+    def valid_put(self, payload, result, **kwargs):
+        response = self.create_valid(self.base_payload)
+        uri = response.headers['X-Uri']
+        response = self.api.put(uri, json=payload, **kwargs)
+        self.assertEqual(response.status_code, 204)
+        response = self.api.get(uri)
+        self.assertDictEqual(result, response.json())
+        response = self.delete_resource(uri)
+
+    def invalid_patch(self, payload, errors, error_code=422, **kwargs):
+        response = self.create_valid(self.base_payload)
+        uri = response.headers['X-Uri']
+        response = self.api.patch(uri, json=payload, **kwargs)
+        self.assertEqual(response.status_code, error_code)
+        self.assertDictEqual(errors, response.json())
+        response = self.delete_resource(uri)
+
+    def valid_patch(self, payload, result, original=None, **kwargs):
+        base_payload = original if original else self.base_payload
+        response = self.create_valid(base_payload)
+        uri = response.headers['X-Uri']
+        response = self.api.patch(uri, json=payload, **kwargs)
+        self.assertEqual(response.status_code, 204)
+        response = self.api.get(uri)
+        self.assertDictEqual(result, response.json())
+        response = self.delete_resource(uri)

--- a/tests/api/global_variables.py
+++ b/tests/api/global_variables.py
@@ -1,0 +1,69 @@
+DEFAULT_OBJECTS = {
+    'area': {
+        'uri': '/api/area',
+        'payload': {
+            "geofence_included": "test_geofence.txt",
+            "including_stops": True,
+            "init": False,
+            "name": "UnitTest Area",
+            "routecalc": "test_routecalc",
+            "settings": {
+                "starve_route": False
+            }
+        },
+        'kwargs': {
+            'headers': {
+                'X-Mode': 'raids_mitm'
+            }
+        }
+    },
+    'auth': {
+        'uri': '/api/auth',
+        'payload': {
+            'username': 'user',
+            'password': 'pass'
+        }
+    },
+    'device': {
+        'uri': '/api/device',
+        'payload': {
+            'origin': 'UnitTest Device',
+            'walker': None, # This must be populated
+            'settings': {
+                'screenshot_type': 'jpg'
+            }
+        }
+    },
+    'devicesetting': {
+        'uri': '/api/devicesetting',
+        'payload': {
+            'devicepool': 'UnitTest Pool',
+            'settings': {
+                'screenshot_type': 'jpg'
+            }
+        }
+    },
+    'monivlist': {
+        'uri': '/api/monivlist',
+        'payload': {
+            'monlist': 'Test MonIV List',
+            'mon_ids_iv': []
+        }
+    },
+    'walker': {
+        'uri': '/api/walker',
+        'payload': {
+            'walkername': 'UnitTest Walker',
+            'setup': [],
+        }
+    },
+    'walkerarea': {
+        'uri': '/api/walkerarea',
+        'payload': {
+            'walkerarea': 'UnitTest WalkerArea', # This must be populated with a valid area_uri
+            'walkertype': 'raids_mitm',
+            'walkervalue': '',
+            'walkermax': ''
+        }
+    }
+}

--- a/tests/api/local_api.py
+++ b/tests/api/local_api.py
@@ -1,0 +1,63 @@
+import requests
+import time
+
+class LocalAPI(requests.Session):
+    def __init__(self, logger, args, **kwargs):
+        super(LocalAPI, self).__init__()
+        self.__logger = logger
+        self.__hostname = args.madmin_ip
+        self.__port = args.madmin_port
+        self.__retries = kwargs.get('retries', 1)
+        self.__timeout = kwargs.get('timeout', 1)
+        self.__protocol = 'http' # madmin only runs on http unless behind a proxy so we can force http
+        self.auth = (args.madmin_user, args.madmin_password)
+
+    def prepare_request(self, request):
+        """ Override the class function to create the URL with the URI and any other processing required """
+        # Update the URL
+        if request.url[0] == "/":
+            request.url = request.url[1:]
+        request.url = "%s://%s:%s/%s" % (self.__protocol, self.__hostname, self.__port, request.url)
+        # We are logging this before calling super.prepare_request because the function will merge existing data
+        # with the new request data.  This can cause a security risk where the authentication will be saved in
+        # plain text on the filesystem in the log.
+        if self.__logger:
+            self.__logger.debug("Requests data: {}", str(request.__dict__))
+        return super(LocalAPI, self).prepare_request(request)
+    
+    def send(self, request, **kwargs):
+        """ Override the class function to handle retries and specific error codes """
+        attempt = 0
+        finished = False
+        last_err = None
+        # Apply the timeout to the send request
+        if "timeout" not in kwargs or ("timeout" in kwargs and kwargs["timeout"] is None):
+            kwargs["timeout"] = self.__timeout
+        # Try the send until it finishes or we reach our maximum attempts
+        while not finished and attempt < self.__retries:
+            try:
+                r = super(LocalAPI, self).send(request, **kwargs)
+                if self.__logger:
+                    self.__logger.debug("API Call completed in {}", str(r.elapsed))
+                    self.__logger.debug("Status code: {}", str(r.status_code))
+                # If we receive Bad Gateway the call is not completed and should be retried
+                if r.status_code == 502:
+                    if self.__logger:
+                        self.__logger.debug("Bad Gateway received.")
+                else:
+                    return r
+            except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as err:
+                if self.__logger:
+                    self.__logger.warning(err)
+                last_err = err
+            except Exception as err:
+                if self.__logger:
+                    self.__logger.warning("Unknown exception, {}", str(err))
+                last_err = err
+            # We did not finish successfully so sleep and increment the attempt
+            attempt += 1
+            # Only sleep if there are still retries left
+            if attempt < self.__retries:
+                time.sleep(self.__sleep_time)
+        # We were unable to complete the call successfully so raise the last error
+        raise last_err

--- a/tests/api/test_area.py
+++ b/tests/api/test_area.py
@@ -1,0 +1,108 @@
+import copy
+from unittest import TestCase
+import api_base
+import global_variables
+
+class APIArea(api_base.APITestBase):
+    uri = copy.copy(global_variables.DEFAULT_OBJECTS['area']['uri'])
+    base_payload = copy.copy(global_variables.DEFAULT_OBJECTS['area']['payload'])
+
+    def test_landing_page(self):
+        super().landing_page(test_resource=False)
+
+    def test_landing_page_resource(self):
+        headers = {
+            'X-Mode': 'idle'
+        }
+        response = self.api.get(self.uri, headers=headers)
+        self.assertEqual(response.status_code, 200)
+        json_data = response.json()
+        self.assertTrue('resource' in json_data)
+        self.assertTrue('results' in json_data)
+        self.assertTrue(len(json_data['resource']['fields']) > 0)
+        if 'settings' in json_data['resource']:
+            self.assertTrue(len(json_data['resource']['settings']) > 0)
+
+    def test_invalid_uri(self):
+        super().invalid_uri()
+
+    def test_get_modes(self):
+        # Create an idle area
+        # perform a get against /api/area and verify it comes back
+        # perform a get against /api/area?mode=raids_mitm and verify it does not come back
+        # perform a get against /api/area/<created_elem> and validate the mode is returned
+        payload = {
+            "name": "Idle Area",
+            "geofence_included": "idle.txt",
+            "routecalc": "test_idle"
+        }
+        headers = {
+            'X-Mode': 'idle'
+        }
+        area = self.create_valid(payload, headers=headers)
+        area_uri = area.headers['X-Uri']
+        res = self.api.get(self.uri)
+        resource_resp = 'Resource is not available unless a mode is specified'
+        self.assertEqual(res.json()['resource'], resource_resp)
+        self.assertTrue(area_uri in res.json()['results'])
+        params = {
+            'mode': 'idle'
+        }
+        res = self.api.get(self.uri, params=params)
+        self.assertTrue(area_uri in res.json()['results'])
+        params = {
+            'mode': 'raids_mitm'
+        }
+        res = self.api.get(self.uri, params=params)
+        self.assertFalse(area_uri in res.json()['results'])
+
+    def test_invalid_post_mode(self):
+        payload = {}
+        errors = {'error': 'Please specify a mode for resource information.  Valid modes: mon_mitm,iv_mitm,pokestops,raids_mitm,idle'}
+        super().invalid_post(payload, errors, error_code=400)
+        headers = {
+            'X-Mode': 'fake-mode'
+        }
+        errors = {'errors': 'Invalid mode specified [fake-mode].  Valid modes: mon_mitm,iv_mitm,pokestops,raids_mitm,idle'}
+        super().invalid_post(payload, errors, error_code=400, headers=headers)
+
+    def test_invalid_post(self):
+        payload = {
+            "geofence_included": "test_geofence.txt",
+            "including_stops": True,
+            "init": False,
+            "name": "UnitTest Area",
+            "routecalc": "test_calc",
+            "username": "ya",
+            "settings": {
+                "starve_route": False
+            }
+        }
+        headers = {
+            'X-Mode': 'raids_mitm'
+        }
+        errors = {'unknown': ['username']}
+        super().invalid_post(payload, errors, headers=headers)
+
+    def test_valid_post(self):
+        headers = {
+            'X-Mode': 'raids_mitm'
+        }
+        results = {
+            "name": "UnitTest Area",
+            "init": False,
+            "geofence_included": "test_geofence.txt",
+            "routecalc": "test_routecalc",
+            "including_stops": True,
+            "settings": {
+                "starve_route": False
+            },
+            "mode": "raids_mitm"
+        }
+        super().valid_post(self.base_payload, results, headers=headers)
+
+    def test_walkerarea_dependency(self):
+        area_uri = super().create_valid_resource('area')
+        walkerarea_uri = super().create_valid_resource('walkerarea', walkerarea=area_uri)
+        response = self.delete_resource(area_uri)
+        self.assertEqual(response.status_code, 412)

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,0 +1,56 @@
+import copy
+from unittest import TestCase
+import api_base
+import global_variables
+
+class APIAuth(api_base.APITestBase):
+    uri = copy.copy(global_variables.DEFAULT_OBJECTS['auth']['uri'])
+    base_payload = copy.copy(global_variables.DEFAULT_OBJECTS['auth']['payload'])
+
+    def test_landing_page(self):
+        super().landing_page()
+
+    def test_invalid_uri(self):
+        super().invalid_uri()
+
+    def test_invalid_post(self):
+        payload = {
+            'username': '',
+        }
+        errors = {"missing": ["username", 'password']}
+        super().invalid_post(payload, errors)
+
+    def test_valid_post(self):
+        super().valid_post(self.base_payload, self.base_payload)
+
+    def test_invalid_put(self):
+        payload = {
+            'username': '',
+            'password': 'pass'
+        }
+        errors = {"missing": ["username"]}
+        super().invalid_put(payload, errors)
+
+    def test_valid_put(self):
+        payload = {
+            'username': 'update',
+            'password': 'pass'
+        }
+        super().valid_put(payload, payload)
+
+    def test_invalid_patch(self):
+        payload = {
+            'usernamez': 'update',
+            'password': 'pass'
+        }
+        errors = {"unknown": ["usernamez"]}
+        super().invalid_patch(payload, errors)
+
+    def test_valid_patch(self):
+        payload = {
+            'username': 'update',
+        }
+        result = copy.copy(self.base_payload)
+        result.update(payload)
+        resp = self.create_valid(self.base_payload)
+        self.valid_patch(payload, result)

--- a/tests/api/test_device.py
+++ b/tests/api/test_device.py
@@ -1,0 +1,61 @@
+import copy
+from unittest import TestCase
+import api_base
+import global_variables
+
+class APIDevice(api_base.APITestBase):
+    uri = copy.copy(global_variables.DEFAULT_OBJECTS['device']['uri'])
+    base_payload = copy.copy(global_variables.DEFAULT_OBJECTS['device']['payload'])
+
+    def test_landing_page(self):
+        super().landing_page()
+
+    def test_invalid_uri(self):
+        super().invalid_uri()
+
+    def test_invalid_post(self):
+        payload = copy.copy(self.base_payload)
+        errors = {"missing": ["walker"]}
+        super().invalid_post(self.base_payload, errors)
+
+    def test_valid_post(self):
+        walker_uri = super().create_valid_resource('walker')
+        payload = copy.copy(self.base_payload)
+        payload['walker'] = walker_uri
+        super().valid_post(payload, payload)
+
+    def test_invalid_put(self):
+        walker_uri = super().create_valid_resource('walker')
+        payload = copy.copy(self.base_payload)
+        payload['walker'] = walker_uri
+        device_uri = super().create_valid_resource('device', walker=walker_uri)
+        del payload['origin']
+        errors = {"missing": ["origin"]}
+        response = self.api.put(device_uri, json=payload)
+        self.assertEqual(response.status_code, 422)
+        self.assertDictEqual(response.json(), errors)
+
+    def test_valid_put(self):
+        walker_uri = super().create_valid_resource('walker')
+        payload = copy.copy(self.base_payload)
+        payload['walker'] = walker_uri
+        device_uri = super().create_valid_resource('device', walker=walker_uri)
+        response = self.api.put(device_uri, json=payload)
+        self.assertEqual(response.status_code, 204)
+
+    def test_invalid_patch(self):
+        walker_uri = super().create_valid_resource('walker')
+        payload = copy.copy(self.base_payload)
+        payload['origin'] = ''
+        device_uri = super().create_valid_resource('device', walker=walker_uri)
+        response = self.api.patch(device_uri, json=payload)
+        self.assertEqual(response.status_code, 422)
+
+    def test_valid_patch(self):
+        walker_uri = super().create_valid_resource('walker')
+        payload = {
+            'origin': 'Updated UnitTest'
+        }
+        device_uri = super().create_valid_resource('device', walker=walker_uri)
+        response = self.api.patch(device_uri, json=payload)
+        self.assertEqual(response.status_code, 204)

--- a/tests/api/test_devicesetting.py
+++ b/tests/api/test_devicesetting.py
@@ -1,0 +1,56 @@
+import copy
+from unittest import TestCase
+import api_base
+import global_variables
+
+class APIDevicePool(api_base.APITestBase):
+    uri = copy.copy(global_variables.DEFAULT_OBJECTS['devicesetting']['uri'])
+    base_payload = copy.copy(global_variables.DEFAULT_OBJECTS['devicesetting']['payload'])
+
+    def test_landing_page(self):
+        super().landing_page()
+
+    def test_invalid_uri(self):
+        super().invalid_uri()
+
+    def test_invalid_post(self):
+        payload = copy.copy(self.base_payload)
+        del payload['devicepool']
+        errors = {"missing": ["devicepool"]}
+        super().invalid_post(payload, errors)
+
+    def test_valid_post(self):
+        super().valid_post(self.base_payload, self.base_payload)
+
+    def test_invalid_put(self):
+        payload = copy.copy(self.base_payload)
+        del payload['devicepool']
+        errors = {"missing": ["devicepool"]}
+        super().invalid_put(payload, errors)
+
+    def test_valid_put(self):
+        super().valid_put(self.base_payload, self.base_payload)
+
+    def test_invalid_patch(self):
+        base_payload = {
+            'devicepool': ''
+        }
+        errors = {"missing": ["devicepool"]}
+        super().invalid_patch(base_payload, errors)
+
+    def test_valid_patch(self):
+        payload = {
+            'settings': {
+                'screenshot_type': 'png'
+            }
+        }
+        result = copy.copy(self.base_payload)
+        result.update(payload)
+        self.valid_patch(payload, result)
+
+    def test_pool_dependecy(self):
+        walker_uri = super().create_valid_resource('walker')
+        pool_uri = super().create_valid_resource('devicesetting')
+        device_uri = super().create_valid_resource('device', walker=walker_uri, pool=pool_uri)
+        response = self.delete_resource(pool_uri)
+        self.assertEqual(response.status_code, 412)

--- a/tests/api/test_monlist.py
+++ b/tests/api/test_monlist.py
@@ -1,0 +1,91 @@
+import copy
+from unittest import TestCase
+import api_base
+import global_variables
+
+class APIMonIVList(api_base.APITestBase):
+    uri = copy.copy(global_variables.DEFAULT_OBJECTS['monivlist']['uri'])
+    base_payload = copy.copy(global_variables.DEFAULT_OBJECTS['monivlist']['payload'])
+
+    def test_landing_page(self):
+        super().landing_page()
+
+    def test_invalid_uri(self):
+        super().invalid_uri()
+
+    def test_invalid_post(self):
+        payload = {
+            'monlist': 'Test',
+        }
+        errors = {"missing": ['mon_ids_iv']}
+        super().invalid_post(payload, errors)
+
+    def test_valid_post(self):
+        super().valid_post(self.base_payload, self.base_payload)
+
+    def test_invalid_put(self):
+        payload = {
+            'monlist': 'Test',
+        }
+        errors = {"missing": ["mon_ids_iv"]}
+        super().invalid_put(payload, errors)
+
+    def test_valid_put(self):
+        payload = {
+            'monlist': 'Test MonIV List',
+            'mon_ids_iv': [1,2,3]
+        }
+        super().valid_put(payload, payload)
+
+    def test_invalid_patch(self):
+        payload = {
+            'usernamez': 'update'
+        }
+        errors = {"unknown": ["usernamez"]}
+        super().invalid_patch(payload, errors)
+
+    def test_valid_patch(self, **kwargs):
+        payload = {
+            'monlist': 'update',
+        }
+        result = copy.copy(self.base_payload)
+        result.update(payload)
+        resp = self.create_valid(self.base_payload)
+        self.valid_patch(payload, result)
+
+    def test_append(self, **kwargs):
+        original = {
+            'monlist': 'Test MonIV List',
+            'mon_ids_iv': [1]
+        }
+        payload = {
+            'mon_ids_iv': [2]
+        }
+        result = {
+            'monlist': 'Test MonIV List',
+            'mon_ids_iv': [1,2]
+        }
+        headers = {
+            'X-Append': '1'
+        }
+        self.valid_patch(payload, result, original=original, headers=headers)
+
+    def test_area_dependency(self):
+        monivlist_uri = super().create_valid_resource('monivlist')
+        payload = {
+            "coords_spawns_known": True,
+            "geofence_included": "unit_test.txt",
+            "init": False,
+            "name": "Unit Test Area",
+            "routecalc": "unit_test",
+            "settings": {
+                "starve_route": False,
+                'mon_ids_iv': monivlist_uri
+            }
+        }
+        headers = {
+            'X-Mode': 'mon_mitm'
+        }
+        self.create_resource('/api/area', payload, headers=headers)
+        response = super().delete_resource(monivlist_uri)
+        self.assertEqual(response.status_code, 412)

--- a/tests/api/test_walker.py
+++ b/tests/api/test_walker.py
@@ -1,0 +1,64 @@
+import copy
+from unittest import TestCase
+import api_base
+import global_variables
+
+class APIWalker(api_base.APITestBase):
+    uri = copy.copy(global_variables.DEFAULT_OBJECTS['walker']['uri'])
+    base_payload = copy.copy(global_variables.DEFAULT_OBJECTS['walker']['payload'])
+
+    def test_landing_page(self):
+        super().landing_page()
+
+    def test_invalid_uri(self):
+        super().invalid_uri()
+
+    def test_invalid_post(self):
+        payload = copy.copy(self.base_payload)
+        del payload['walkername']
+        errors = {"missing": ["walkername"]}
+        super().invalid_post(payload, errors)
+
+    def test_valid_post(self):
+        super().valid_post(self.base_payload, self.base_payload)
+
+    def test_invalid_put(self):
+        payload = copy.copy(self.base_payload)
+        del payload['walkername']
+        errors = {"missing": ["walkername"]}
+        super().invalid_put(payload, errors)
+
+    def test_valid_put(self):
+        payload = copy.copy(self.base_payload)
+        super().valid_put(payload, payload)
+
+    def test_invalid_patch(self):
+        payload = {
+            'setup': 'String'
+        }
+        errors = {'Invalid URIs': ['String']}
+        super().invalid_patch(payload, errors)
+
+    def test_valid_patch(self):
+        super().valid_patch(self.base_payload, self.base_payload)
+
+    def test_device_dependency(self):
+        walker_uri = super().create_valid_resource('walker')
+        device_uri = super().create_valid_resource('device', walker=walker_uri)
+        response = self.api.delete(walker_uri)
+        self.assertEqual(response.status_code, 412)
+
+    def test_walker_dependency(self):
+        area_uri = super().create_valid_resource('area')
+        walkerarea_uri = super().create_valid_resource('walkerarea', walkerarea=area_uri)
+        walker_uri = super().create_valid_resource('walker', setup=[walkerarea_uri])
+        response = self.api.delete(walkerarea_uri)
+        self.assertEqual(response.status_code, 412)
+
+    def test_walkerarea_cleanup(self):
+        area_uri = super().create_valid_resource('area')
+        walkerarea_uri = super().create_valid_resource('walkerarea', walkerarea=area_uri)
+        walker_uri = super().create_valid_resource('walker', setup=[walkerarea_uri])
+        self.delete_resource(walker_uri)
+        response = self.api.get(walkerarea_uri)
+        self.assertEqual(response.status_code, 404)

--- a/tests/api/test_walkerarea.py
+++ b/tests/api/test_walkerarea.py
@@ -1,0 +1,92 @@
+import copy
+from unittest import TestCase
+import api_base
+import global_variables
+
+class APIWalkerArea(api_base.APITestBase):
+    uri = copy.copy(global_variables.DEFAULT_OBJECTS['walkerarea']['uri'])
+    base_payload = copy.copy(global_variables.DEFAULT_OBJECTS['walkerarea']['payload'])
+
+    def test_landing_page(self):
+        super().landing_page()
+
+    def test_invalid_uri(self):
+        super().invalid_uri()
+
+    def test_invalid_post(self):
+        payload = copy.copy(self.base_payload)
+        del payload['walkerarea']
+        errors = {"missing": ["walkerarea"]}
+        super().invalid_post(payload, errors)
+
+    def test_invalid_area(self):
+        payload = copy.copy(self.base_payload)
+        errors = {'Invalid URIs': ['UnitTest WalkerArea']}
+        super().invalid_post(payload, errors)
+
+    def test_valid_post(self):
+        area_uri = super().create_valid_resource('area')
+        payload = copy.copy(self.base_payload)
+        payload['walkerarea'] = area_uri
+        super().valid_post(payload, payload)
+
+    def test_valid_post_missing_fields(self):
+        area_uri = super().create_valid_resource('area')
+        payload = copy.copy(self.base_payload)
+        result = copy.copy(payload)
+        payload['walkerarea'] = area_uri
+        del payload['walkervalue']
+        super().valid_post(payload, payload)
+
+    def test_invalid_put(self):
+        area_uri = super().create_valid_resource('area')
+        walkerarea_uri = super().create_valid_resource('walkerarea', walkerarea=area_uri)
+        payload = copy.copy(self.base_payload)
+        del payload['walkerarea']
+        errors = {"missing": ["walkerarea"]}
+        response = self.api.put(walkerarea_uri, json=payload)
+        self.assertEqual(response.status_code, 422)
+        self.assertDictEqual(response.json(), errors)
+
+    def test_valid_put(self):
+        area_uri = super().create_valid_resource('area')
+        walkerarea_uri = super().create_valid_resource('walkerarea', walkerarea=area_uri)
+        payload = copy.copy(self.base_payload)
+        payload['walkerarea'] = area_uri
+        response = self.api.put(walkerarea_uri, json=payload)
+        self.assertEqual(response.status_code, 204)
+
+    def test_invalid_patch(self):
+        area_uri = super().create_valid_resource('area')
+        walkerarea_uri = super().create_valid_resource('walkerarea', walkerarea=area_uri)
+        payload = {
+            'walkerarea': ''
+        }
+        errors = {"missing": ["walkerarea"]}
+        response = self.api.patch(walkerarea_uri, json=payload)
+        self.assertEqual(response.status_code, 422)
+        self.assertDictEqual(response.json(), errors)
+
+    def test_valid_patch(self):
+        area_uri = super().create_valid_resource('area')
+        walkerarea_uri = super().create_valid_resource('walkerarea', walkerarea=area_uri)
+        payload = {
+            'walkertext': 'Updated UnitTest'
+        }
+        response = self.api.patch(walkerarea_uri, json=payload)
+        self.assertEqual(response.status_code, 204)
+
+    def test_walker_dependency(self):
+        area_uri = super().create_valid_resource('area')
+        walkerarea_uri = super().create_valid_resource('walkerarea', walkerarea=area_uri)
+        walker_uri = super().create_valid_resource('walker', setup=[walkerarea_uri])
+        response = self.api.delete(walkerarea_uri)
+        self.assertEqual(response.status_code, 412)
+
+    def test_walkerarea_cleanup(self):
+        area_uri = super().create_valid_resource('area')
+        walkerarea_uri = super().create_valid_resource('walkerarea', walkerarea=area_uri)
+        walker_uri = super().create_valid_resource('walker', setup=[walkerarea_uri])
+        self.delete_resource(walker_uri)
+        response = self.api.get(walkerarea_uri)
+        self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
Created basic unit tests for the API.  It is not the most elegant method, but to test navigate to tests/api and run '<your_python_interpreter> -m unittest'.  It is currently not configured to read from the configi.ini so you must update the file if you have a password and are not running on port 5000.