### PR TITLE
Fixed API returning empty list for resources

### DIFF
--- a/madmin/api/apiHandler.py
+++ b/madmin/api/apiHandler.py
@@ -248,7 +248,7 @@ class ResourceHandler(object):
                     valid = []
                     for elem in data[key]:
                         valid.append(uri % elem)
-                    data[key] = []
+                    data[key] = valid
                 elif type(data[key]) == str:
                     data[key] = uri % data[key]
             except KeyError as err:

--- a/tests/api/test_walker.py
+++ b/tests/api/test_walker.py
@@ -62,3 +62,10 @@ class APIWalker(api_base.APITestBase):
         self.delete_resource(walker_uri)
         response = self.api.get(walkerarea_uri)
         self.assertEqual(response.status_code, 404)
+
+    def test_walkerarea_response(self):
+        area_uri = super().create_valid_resource('area')
+        walkerarea_uri = super().create_valid_resource('walkerarea', walkerarea=area_uri)
+        walker_uri = super().create_valid_resource('walker', setup=[walkerarea_uri])
+        walker_data = self.api.get(walker_uri)
+        self.assertTrue(walkerarea_uri in walker_data.json()['setup'])


### PR DESCRIPTION
The API was always returning an empty list if it was a list of URIs.  This has been addressed and a unit test has been added to validate the issue moving forward.