### PR TITLE
Ui pages not rendering

### DIFF
--- a/madmin/api/apiHandler.py
+++ b/madmin/api/apiHandler.py
@@ -86,7 +86,10 @@ class ResourceHandler(object):
             except KeyError:
                 try:
                     if entry_def['settings']['require'] == True and operation in ['POST', 'PUT']:
-                        missing_fields.append(key)
+                        if 'empty' in entry_def['settings']:
+                            save_data[key] = entry_def['settings']['empty']
+                        else:
+                            missing_fields.append(key)
                 except:
                     pass
                 continue

--- a/madmin/api/modules/ftr_area.py
+++ b/madmin/api/modules/ftr_area.py
@@ -33,7 +33,6 @@ class APIArea(apiHandler.ResourceHandler):
                     "settings": {
                         "type": "geofence",
                         "require": True,
-                        "empty": None,
                         "description": "Including geofence for scanarea",
                         "expected": str
                     }
@@ -173,7 +172,6 @@ class APIArea(apiHandler.ResourceHandler):
                     "settings": {
                         "type": "geofence",
                         "require": True,
-                        "empty": None,
                         "description": "Including geofence for scanarea",
                         "expected": str
                     }
@@ -296,7 +294,6 @@ class APIArea(apiHandler.ResourceHandler):
                     "settings": {
                         "type": "geofence",
                         "require": True,
-                        "empty": None,
                         "description": "Including geofence for scanarea",
                         "expected": str
                     }
@@ -412,7 +409,6 @@ class APIArea(apiHandler.ResourceHandler):
                     "settings": {
                         "type": "geofence",
                         "require": True,
-                        "empty": None,
                         "description": "Including geofence for scanarea",
                         "expected": str
                     }
@@ -541,7 +537,6 @@ class APIArea(apiHandler.ResourceHandler):
                     "settings": {
                         "type": "geofence",
                         "require": True,
-                        "empty": None,
                         "description": "Including geofence for scanarea",
                         "expected": str
                     }

--- a/madmin/api/modules/ftr_auth.py
+++ b/madmin/api/modules/ftr_auth.py
@@ -13,7 +13,6 @@ class APIAuth(apiHandler.ResourceHandler):
                 "settings": {
                     "type": "text",
                     "require": True,
-                    "empty": None,
                     "description": "Username of device",
                     "lockonedit": True,
                 "expected": str
@@ -23,7 +22,6 @@ class APIAuth(apiHandler.ResourceHandler):
                 "settings": {
                     "type": "text",
                     "require": True,
-                    "empty": None,
                     "description": "Password of device",
                 "expected": str
                 }

--- a/madmin/api/modules/ftr_device.py
+++ b/madmin/api/modules/ftr_device.py
@@ -12,7 +12,6 @@ class APIDevice(apiHandler.ResourceHandler):
                 "settings": {
                     "type": "text",
                     "require": True,
-                    "empty": None,
                     "description": "Name of device (from RGC settings)",
                     "lockonedit": True,
                     "expected": str
@@ -22,7 +21,6 @@ class APIDevice(apiHandler.ResourceHandler):
                 "settings": {
                     "type": "walkerselect",
                     "require": True,
-                    "empty": None,
                     "description": "Walker of this area",
                     "expected": str,
                     "uri": True,

--- a/madmin/api/modules/ftr_devicesetting.py
+++ b/madmin/api/modules/ftr_devicesetting.py
@@ -12,7 +12,6 @@ class APIDeviceSetting(apiHandler.ResourceHandler):
                 "settings": {
                     "type": "text",
                     "require": True,
-                    "empty": None,
                     "description": "Name for the global device settings",
                     "lockonedit": True,
                 "expected": str

--- a/madmin/api/modules/ftr_monlist.py
+++ b/madmin/api/modules/ftr_monlist.py
@@ -12,7 +12,6 @@ class APIMonList(apiHandler.ResourceHandler):
                 "settings": {
                     "type": "text",
                     "require": True,
-                    "empty": None,
                     "description": "Name of global Monlist",
                     "lockonedit": True,
                     'expected': str

--- a/madmin/api/modules/ftr_walker.py
+++ b/madmin/api/modules/ftr_walker.py
@@ -12,7 +12,6 @@ class APIWalker(apiHandler.ResourceHandler):
                 "settings": {
                     "type": "text",
                     "require": True,
-                    "empty": None,
                     "description": "Name of walker",
                     "lockonedit": True,
                     "expected": str
@@ -21,7 +20,7 @@ class APIWalker(apiHandler.ResourceHandler):
             "setup": {
                 "settings": {
                     "type": "list",
-                    "require": False,
+                    "require": True,
                     "empty": [],
                     "description": "Order of areas",
                     "lockonedit": False,

--- a/madmin/api/modules/ftr_walkerarea.py
+++ b/madmin/api/modules/ftr_walkerarea.py
@@ -13,7 +13,6 @@ class APIWalkerArea(apiHandler.ResourceHandler):
                 "settings": {
                     "type": "text",
                     "require": True,
-                    "empty": None,
                     "description": "Configured area for the walkerarea",
                     "lockonedit": False,
                     "expected": str,
@@ -26,7 +25,6 @@ class APIWalkerArea(apiHandler.ResourceHandler):
                 "settings": {
                     "type": "text",
                     "require": True,
-                    "empty": None,
                     "description": "Mode for the walker",
                     "lockonedit": False,
                     "expected": str

--- a/madmin/routes/config.py
+++ b/madmin/routes/config.py
@@ -85,7 +85,7 @@ class config(object):
         identifier = request.args.get(kwargs.get('identifier'))
         base_uri = kwargs.get('base_uri')
         data_source = kwargs.get('data_source')
-        redirect = url_for(kwargs.get('redirect'))
+        redirect_uri = url_for(kwargs.get('redirect'))
         html_single = kwargs.get('html_single')
         html_all = kwargs.get('html_all')
         subtab = kwargs.get('subtab')
@@ -114,17 +114,20 @@ class config(object):
                 included_data[key] = val
             # Mode was required for this operation but was not present.  Return the base element
             if mode_required and mode is None:
-                req = self._data_manager.get_data(data_source, identifier=identifier)
-                element = req
-                included_data[subtab] = element
-                return render_template(html_all,
-                                       subtab=subtab,
-                                       **included_data
-                                       )
+                try:
+                    req = self._data_manager.get_data(data_source, identifier=identifier)
+                    element = req
+                    included_data[subtab] = element
+                    return render_template(html_all,
+                                           subtab=subtab,
+                                           **included_data
+                                           )
+                except:
+                    return redirect(redirect_uri, code=302)
             if identifier and identifier == 'new':
                 return render_template(html_single,
                                        uri=included_data['base_uri'],
-                                       redirect=redirect,
+                                       redirect=redirect_uri,
                                        element={'settings':{}},
                                        subtab=subtab,
                                        method='POST',
@@ -136,7 +139,7 @@ class config(object):
             if identifier is not None:
                 return render_template(html_single,
                                        uri='%s/%s' % (included_data['base_uri'], identifier),
-                                       redirect=redirect,
+                                       redirect=redirect_uri,
                                        element=element,
                                        subtab=subtab,
                                        method='PATCH',

--- a/madmin/templates/settings_singledevice.html
+++ b/madmin/templates/settings_singledevice.html
@@ -57,7 +57,7 @@ $(document).ready(function () {
   <div class="col-sm">
     <div class="form-group">
       <label for="walker">walker</label>
-      <select class="form-control" name="walker" data-default="{{ url_for('api_walker') + '/'+ element.walker }}">
+      <select class="form-control" name="walker" data-default="{{ url_for('api_walker') + '/'+ element.walker if element.walker else '' }}">
         {% for walker_id, walker in walkers.items() %}
          <option value="{{ url_for('api_walker') + '/'+ walker_id }}" {{ 'selected=selected' if element.walker == walker_id else "" }}>{{ walker.walkername }}</option>
         {% endfor %}

--- a/madmin/templates/settings_singledevice.html
+++ b/madmin/templates/settings_singledevice.html
@@ -29,7 +29,7 @@ $(document).ready(function () {
 <h1 class="display-4">{{ element.origin }}</h1>
 
 {% if walkers.items()|length == 0 %}
-<div class="alert alert-warning">Couldn't find any walker configurations. Please <a href="/settings/walker?id=new">create</a> one first.</div>
+<div class="alert alert-warning">Couldn't find any walker configurations. Please <a href="{{ url_for('settings_walkers', id='new') }}">create</a> one first.</div>
 {% else %}
 <div class="row">
   <div class="col-sm">

--- a/madmin/templates/settings_walkerarea.html
+++ b/madmin/templates/settings_walkerarea.html
@@ -114,6 +114,9 @@
 {% block content %}
 {{ super() }}
 
+{% if areas.items()|length == 0 %}
+<div class="alert alert-warning">Couldn't find any area configurations. Please <a href="{{ url_for('settings_areas') }}">create</a> one first.</div>
+{% else %}
 {% if element %}
   <h1 class="display-4">Edit {{ walker.walkername }} ({{ areas[element.walkerarea].name }}) </h1>
 {% else %}
@@ -167,4 +170,5 @@
     <button type="button" id="submit" class="btn btn-success btn-lg btn-block">Save</button>
   </div>
 </div>
+{% endif %}
 {% endblock %}

--- a/madmin/templates/settings_walkerarea.html
+++ b/madmin/templates/settings_walkerarea.html
@@ -124,7 +124,7 @@
     <div class="form-group">
       <label for='walkerarea'>Area</label><br>
       <small class="form-text text-muted">Select the Area</small>
-      <select class="form-control" name="walkerarea" required="" aria-invalid="false" data-default="{{ url_for('api_area') +'/'+ element.walkerarea }}">
+      <select class="form-control" name="walkerarea" required="" aria-invalid="false" data-default="{{ url_for('api_area') +'/'+ element.walkerarea if element.walkerarea else '' }}">
         {% for uri, area in areas.items() %}
           <option value="{{ url_for('api_area') +'/'+ uri }}" {{'selected="selected"' if uri == element.walkerarea }}>{{ area.name }}</option>
         {% endfor %}

--- a/tests/api/test_walker.py
+++ b/tests/api/test_walker.py
@@ -69,3 +69,11 @@ class APIWalker(api_base.APITestBase):
         walker_uri = super().create_valid_resource('walker', setup=[walkerarea_uri])
         walker_data = self.api.get(walker_uri)
         self.assertTrue(walkerarea_uri in walker_data.json()['setup'])
+
+    def test_missing_required_variable_with_empty(self):
+        payload = {
+            'walkername': 'UnitTest Walker'
+        }
+        walker_uri = super().create_valid(payload).headers['X-Uri']
+        walker_data = self.api.get(walker_uri)
+        self.assertTrue('setup' in walker_data.json())


### PR DESCRIPTION
Device and WalkerArea were not correctly rendering on an empty configuration
Usability enhancement when creating walkerareas with no areas defined
Fixed an issue where API was not using the 'empty' value if it was a required field
Fixed an issue creating a new area where a 500 was returned if mode was not specified