### PR TITLE
Walkervalue fix

### DIFF
--- a/madmin/api/apiHandler.py
+++ b/madmin/api/apiHandler.py
@@ -90,6 +90,7 @@ class ResourceHandler(object):
                             save_data[key] = entry_def['settings']['empty']
                         else:
                             missing_fields.append(key)
+                        continue
                 except:
                     pass
                 continue
@@ -107,7 +108,10 @@ class ResourceHandler(object):
                     if (type(val) in [str]):
                         if len(val) == 0:
                             if entry_def['settings']['require'] == True:
-                                missing_fields.append(key)
+                                if 'empty' in entry_def['settings']:
+                                    save_data[key] = entry_def['settings']['empty']
+                                else:
+                                    missing_fields.append(key)
                                 continue
                             elif keep_empty_values:
                                 formated_val = none_val

--- a/madmin/api/modules/ftr_walkerarea.py
+++ b/madmin/api/modules/ftr_walkerarea.py
@@ -33,7 +33,7 @@ class APIWalkerArea(apiHandler.ResourceHandler):
             "walkervalue": {
                 "settings": {
                     "type": "text",
-                    "require": False,
+                    "require": True,
                     "empty": "",
                     "description": "Value for walkermode.    Please see above how to configure value",
                     "lockonedit": False,

--- a/tests/api/test_walkerarea.py
+++ b/tests/api/test_walkerarea.py
@@ -32,11 +32,13 @@ class APIWalkerArea(api_base.APITestBase):
 
     def test_valid_post_missing_fields(self):
         area_uri = super().create_valid_resource('area')
-        payload = copy.copy(self.base_payload)
-        result = copy.copy(payload)
+        payload = copy.deepcopy(self.base_payload)
+        result = copy.deepcopy(payload)
+        result['walkertype'] = 'raids_mitm'
+        result['walkerarea'] = area_uri
         payload['walkerarea'] = area_uri
         del payload['walkervalue']
-        super().valid_post(payload, payload)
+        super().valid_post(payload, result)
 
     def test_invalid_put(self):
         area_uri = super().create_valid_resource('area')


### PR DESCRIPTION
Fixed the walkervalue unittest that did not catch the issue from the previous change.  The required change for walkervalue to be an empty string and required has been implemented (again...).

Fixing the unittest should make sure this regression does not happen again