### PR TITLE
Add config options to clear inventory items

### DIFF
--- a/madmin/api/modules/ftr_device.py
+++ b/madmin/api/modules/ftr_device.py
@@ -117,6 +117,22 @@ class APIDevice(apiHandler.ResourceHandler):
                     "expected": float
                 }
             },
+            "inventory_clear_rounds": {
+                "settings": {
+                    "type": "text",
+                    "require": False,
+                    "description": "Number of rounds to clear the inventory. (Default: 10)",
+                    "expected": int
+                }
+            },
+            "inventory_clear_item_amount_tap_duration": {
+                "settings": {
+                    "type": "text",
+                    "require": False,
+                    "description": "Number of seconds to tap the + button when clearing an inventory item. (Default: 3)",
+                    "expected": float
+                }
+            },
             "mitm_wait_timeout": {
                 "settings": {
                     "type": "text",

--- a/madmin/api/modules/ftr_devicesetting.py
+++ b/madmin/api/modules/ftr_devicesetting.py
@@ -84,6 +84,22 @@ class APIDeviceSetting(apiHandler.ResourceHandler):
                 "expected": float
                 }
             },
+            "inventory_clear_rounds": {
+                "settings": {
+                    "type": "text",
+                    "require": False,
+                    "description": "Number of rounds to clear the inventory. (Default: 10)",
+                    "expected": int
+                }
+            },
+            "inventory_clear_item_amount_tap_duration": {
+                "settings": {
+                    "type": "text",
+                    "require": False,
+                    "description": "Number of seconds to tap the + button when clearing an inventory item. (Default: 3)",
+                    "expected": float
+                }
+            },
             "mitm_wait_timeout": {
                 "settings": {
                     "type": "text",

--- a/worker/WorkerQuests.py
+++ b/worker/WorkerQuests.py
@@ -485,12 +485,13 @@ class WorkerQuests(MITMBase):
         click_x1, click_x2, click_y = self._resocalc.get_swipe_item_amount(self)[0], \
                                       self._resocalc.get_swipe_item_amount(self)[1], \
                                       self._resocalc.get_swipe_item_amount(self)[2]
-        delrounds = 0
+        click_duration = int(self.get_devicesettings_value("inventory_clear_item_amount_tap_duration", 3)) * 1000
+        delrounds_remaining = int(self.get_devicesettings_value("inventory_clear_rounds", 10))
         first_round = True
         delete_allowed = False
         error_counter = 0
 
-        while int(delrounds) <= 10 and not stop_inventory_clear.is_set():
+        while delrounds_remaining > 0 and not stop_inventory_clear.is_set():
 
             trash = 0
             if not first_round and not delete_allowed:
@@ -534,7 +535,7 @@ class WorkerQuests(MITMBase):
                         time.sleep(1 + int(delayadd))
 
                         self._communicator.touchandhold(
-                            click_x1, click_y, click_x2, click_y)
+                            click_x1, click_y, click_x2, click_y, click_duration)
                         time.sleep(1)
 
                         delx, dely = self._resocalc.get_confirm_delete_item_coords(self)[0], \
@@ -547,7 +548,7 @@ class WorkerQuests(MITMBase):
 
                         if data_received != LatestReceivedType.UNDEFINED:
                             if data_received == LatestReceivedType.CLEAR:
-                                delrounds += 1
+                                delrounds_remaining -= 1
                                 stop_screen_clear.set()
                                 delete_allowed = True
                         else:


### PR DESCRIPTION
Depending on the performance of the scanner device, a single inventory cleanup routine (clicking trashcan, tap&hold the plus symbol for 3000 ms, confirming item deletion) may just delete as little as 20 items, and there's a hard limit of 10 cycles of the routine, usually leaving Pinap berrys piling up.

This pull request introduces two options on device/shared settings level:

* `inventory_clear_item_amount_tap_duration` to set the duration for tapping the plus symbol
* `inventory_clear_rounds` to change the number of attempts

This is just a quick remedy to the problem. A better approach would OCR the number of items and then press the plus symbol until the number is actually reached.