### PR TITLE
Better null handling for incoming API values

### DIFF
--- a/madmin/api/apiHandler.py
+++ b/madmin/api/apiHandler.py
@@ -121,7 +121,10 @@ class ResourceHandler(object):
                             formated_val = self.format_value(val, expected, none_val)
                     elif val is None:
                         if entry_def['settings']['require'] == True:
-                            missing_fields.append(key)
+                            if 'empty' in entry_def['settings']:
+                                save_data[key] = entry_def['settings']['empty']
+                            else:
+                                missing_fields.append(key)
                             continue
                         formated_val = none_val
                     else:

--- a/tests/api/test_walker.py
+++ b/tests/api/test_walker.py
@@ -77,3 +77,11 @@ class APIWalker(api_base.APITestBase):
         walker_uri = super().create_valid(payload).headers['X-Uri']
         walker_data = self.api.get(walker_uri)
         self.assertTrue('setup' in walker_data.json())
+
+    def test_empty_setup(self):
+        walker_uri = super().create_valid_resource('walker')
+        payload = {
+            'setup': None
+        }
+        response = self.api.patch(walker_uri, json=payload)
+        self.assertEqual(response.status_code, 204)


### PR DESCRIPTION
The issue that is addressed by this change is being unable to save 'required' values that have an 'empty' string in their definition if a None / Null value is sent.  For example, you were unable to update a walker if you sent a null 'setup' value