### PR TITLE
None supported for 2 additional device settings

### DIFF
--- a/madmin/api/modules/ftr_device.py
+++ b/madmin/api/modules/ftr_device.py
@@ -80,7 +80,7 @@ class APIDevice(apiHandler.ResourceHandler):
                 "settings": {
                     "type": "option",
                     "require": False,
-                    "values": [False, True],
+                    "values": [None, False, True],
                     "description": "Add extra cooldown after teleport",
                     "expected": bool
                 }
@@ -137,7 +137,7 @@ class APIDevice(apiHandler.ResourceHandler):
                 "settings": {
                     "type": "option",
                     "require": False,
-                    "values": [False, True],
+                    "values": [None, False, True],
                     "description": "Reboot device if reboot_thresh is reached (Default: false)",
                     "expected": bool
                 }

--- a/madmin/static/js/madmin_settings.js
+++ b/madmin/static/js/madmin_settings.js
@@ -1,4 +1,4 @@
-CONVERT_TO_NONE = ["geofence_excluded", "pool"];
+CONVERT_TO_NONE = ["geofence_excluded", "pool", "cool_down_sleep", "reboot"];
 
 function get_save_data() {
     save_data = {};


### PR DESCRIPTION
Device now supports None for reboot and cool_down_sleep.  Fixes #525 