### PR TITLE
Skip rocketstops in levelmode

### DIFF
--- a/worker/WorkerQuests.py
+++ b/worker/WorkerQuests.py
@@ -669,7 +669,7 @@ class WorkerQuests(MITMBase):
             data_received = self._wait_for_data(
                     timestamp=self._stop_process_time, proto_to_wait_for=104, timeout=35)
             if data_received == LatestReceivedType.GYM:
-                logger.info('Clicking GYM')
+                logger.info('Clicked gym instead of stop')
                 time.sleep(10)
                 x, y = self._resocalc.get_close_main_button_coords(
                     self)[0], self._resocalc.get_close_main_button_coords(self)[1]
@@ -679,7 +679,7 @@ class WorkerQuests(MITMBase):
                 time.sleep(1)
             elif data_received == LatestReceivedType.MON:
                 time.sleep(1)
-                logger.info('Clicking MON')
+                logger.info('Clicked mon instead of stop')
                 time.sleep(.5)
                 self._turn_map(self._delay_add)
                 time.sleep(1)

--- a/worker/WorkerQuests.py
+++ b/worker/WorkerQuests.py
@@ -639,7 +639,6 @@ class WorkerQuests(MITMBase):
         return False
 
     def _open_pokestop(self, timestamp: float):
-        to = 0
         data_received = LatestReceivedType.UNDEFINED
 
         # let's first check the GMO for the stop we intend to visit and abort if it's disabled, a gym, whatsoever
@@ -660,7 +659,9 @@ class WorkerQuests(MITMBase):
                                                                                 self.current_location.lat,
                                                                                 self.current_location.lng)
                     return None
-        while data_received != LatestReceivedType.STOP and int(to) < 3:
+        retries = 3
+        while data_received != LatestReceivedType.STOP and retries > 0:
+            retries -= 1
             self._stop_process_time = math.floor(time.time())
             self._waittime_without_delays = self._stop_process_time
             self._open_gym(self._delay_add)
@@ -687,7 +688,6 @@ class WorkerQuests(MITMBase):
                 if not self._checkPogoButton():
                     self._checkPogoClose(takescreen=False)
 
-            to += 1
         if data_received in [LatestReceivedType.STOP, LatestReceivedType.UNDEFINED] and self._rocket:
             logger.info('Check for Team Rocket Dialog or other open window')
             self.process_rocket()


### PR DESCRIPTION
Handling rocket stops during quest/level walks can cost a lot of time. Occasionally the "exit strategy" doesn't work and the account gets into the rocket fight, causing MAD to reboot the device due to a timeout waiting for proper stop data.

This pull request simply skip stops with a rocket incident in level mode. Despite such skipped stops *could* be visited safely when the incident is over, it's generally more favorable to simply go on with the planned route. Therefore, skipped rocket stops are added to the list of already visited stops (#422).
