### PR TITLE
Fix SQL in quest scan query (potential RAM eater)

### DIFF
--- a/db/rmWrapper.py
+++ b/db/rmWrapper.py
@@ -765,8 +765,8 @@ class RmWrapper(DbWrapperBase):
             "LEFT JOIN trs_quest ON pokestop.pokestop_id = trs_quest.GUID "
             "WHERE (pokestop.latitude >= {} AND pokestop.longitude >= {} "
             "AND pokestop.latitude <= {} AND pokestop.longitude <= {}) "
-            "AND DATE(from_unixtime(trs_quest.quest_timestamp,'%Y-%m-%d')) <> CURDATE() "
-            "OR trs_quest.GUID IS NULL"
+            "AND (DATE(from_unixtime(trs_quest.quest_timestamp,'%Y-%m-%d')) <> CURDATE() "
+            "OR trs_quest.GUID IS NULL)"
         ).format(minLat, minLon, maxLat, maxLon)
 
         if levelmode:


### PR DESCRIPTION
Fixes a bug which makes `stop_from_db_without_quests` query all ever-seen stops without a quest, instead of just those within the bounding box around the geofence. 

This mistake doesn't bubble up to the caller because afterwards the stops are filtered to be within the fenced area, but it might contribute to higher memory consumption on databases with many pokestops.