### PR TITLE
Correct Cofagrigus spelling in en/pokemon.json

### DIFF
--- a/locale/en/pokemon.json
+++ b/locale/en/pokemon.json
@@ -6863,7 +6863,7 @@
     ]
   },
   "563":{
-    "name": "Cohagrigus",
+    "name": "Cofagrigus",
     "rarity":"",
     "types": [
       {


### PR DESCRIPTION
Correct spelling of Cofagrigus in en/pokemon.json

resolves #518

Thanks madBeavis