### PR TITLE
Fix Decimal interpretation ending in TypeError - so cast to float

### DIFF
--- a/madmin/routes/statistics.py
+++ b/madmin/routes/statistics.py
@@ -371,13 +371,13 @@ class statistics(object):
         utc = datetime.datetime.utcnow()
         now = datetime.datetime.now()
         offset = time.mktime(now.timetuple()) - time.mktime(utc.timetuple())
-        return ts + offset
+        return float(ts) + offset
 
     def local2utc(self, ts):
         utc = datetime.datetime.utcnow()
         now = datetime.datetime.now()
         offset = time.mktime(now.timetuple()) - time.mktime(utc.timetuple())
-        return ts - offset
+        return float(ts) - offset
 
     @auth_required
     def statistics_detection_worker_data(self):


### PR DESCRIPTION
Fixing type mismatching, maybe from mysql client. This will bringt back the mons statistic working with mysql 8