### PR TITLE
Flawed version check

### DIFF
--- a/start.py
+++ b/start.py
@@ -1,6 +1,6 @@
 import sys
 py_version = sys.version_info
-if py_version.major < 3 or (py_version.major < 3 and py_version.minor < 6):
+if py_version.major < 3 or (py_version.major == 3 and py_version.minor < 6):
     print("MAD requires at least python 3.6! Your version: {}.{}"
           .format(py_version.major, py_version.minor))
     sys.exit(1)


### PR DESCRIPTION
Currently it doesn't quit on Python 3.5 - 3.0 because `py_version.major < 3` evaluates to false and so the minor version isn't checked at all