### PR TITLE
Refactoring of quest level mode

### DIFF
--- a/db/DbWrapper.py
+++ b/db/DbWrapper.py
@@ -8,6 +8,7 @@ from functools import reduce
 import mysql
 from bitstring import BitArray
 
+from geofence.geofenceHelper import GeofenceHelper
 from utils.collections import Location, LocationWithVisits
 from utils.logging import logger
 from utils.s2Helper import S2Helper
@@ -413,32 +414,64 @@ class DbWrapper:
             "OR trs_quest.GUID IS NULL)"
         ).format(minLat, minLon, maxLat, maxLon)
 
-        if levelmode:
-            logger.info("Leveling mode, add info about visitation")
-            query = (
-                "SELECT pokestop.latitude, pokestop.longitude, GROUP_CONCAT(trs_visited.origin) as visited_by "
-                "FROM pokestop "
-                "LEFT JOIN trs_visited ON pokestop.pokestop_id = trs_visited.pokestop_id "
-                "WHERE (pokestop.latitude >= {} AND pokestop.longitude >= {} "
-                "AND pokestop.latitude <= {} AND pokestop.longitude <= {}) GROUP by pokestop.pokestop_id"
-            ).format(minLat, minLon, maxLat, maxLon)
-
         res = self.execute(query)
         list_of_coords: List[Location] = []
-        visited_by_workers: List[LocationWithVisits] = []
 
         for (latitude, longitude, visited_by) in res:
             list_of_coords.append(Location(latitude, longitude))
-            visited_by_workers.append(LocationWithVisits(latitude, longitude, visited_by))
 
         if geofence_helper is not None:
-            geofenced_coords = geofence_helper.get_geofenced_coordinates(
-                list_of_coords)
-            return geofenced_coords, visited_by_workers
+            geofenced_coords = geofence_helper.get_geofenced_coordinates(list_of_coords)
+            return geofenced_coords
         else:
-            return list_of_coords, visited_by_workers
+            return list_of_coords
 
+    def any_stops_unvisited(self, geofence_helper: GeofenceHelper, origin: str):
+        logger.debug("DbWrapper::any_stops_unvisited called")
+        minLat, minLon, maxLat, maxLon = geofence_helper.get_polygon_from_fence()
+        query = (
+            "SELECT pokestop.latitude, pokestop.longitude,GROUP_CONCAT(trs_visited.origin) AS vis "
+            "FROM pokestop "
+            "LEFT JOIN trs_visited ON pokestop.pokestop_id = trs_visited.pokestop_id "
+            "WHERE (pokestop.latitude >= {} AND pokestop.longitude >= {} "
+            "AND pokestop.latitude <= {} AND pokestop.longitude <= {}) "
+            "GROUP by pokestop.pokestop_id HAVING INSTR(vis,'{}') < 1 LIMIT 1 "
+        ).format(minLat, minLon, maxLat, maxLon, origin)
 
+        res = self.execute(query)
+        unvisited: List[Location] = []
+        if geofence_helper is not None:
+            for (latitude, longitude, vis) in res:
+                unvisited.append(Location(latitude, longitude))
+
+            geofenced_coords = geofence_helper.get_geofenced_coordinates(unvisited)
+            return len(geofenced_coords) > 0
+        else:
+            return len(res) > 0
+
+    def stops_from_db_unvisited(self, geofence_helper: GeofenceHelper, origin: str):
+        logger.debug("DbWrapper::stops_from_db_unvisited called")
+        minLat, minLon, maxLat, maxLon = geofence_helper.get_polygon_from_fence()
+        query = (
+            "SELECT pokestop.latitude, pokestop.longitude,GROUP_CONCAT(trs_visited.origin) AS vis "
+            "FROM pokestop "
+            "LEFT JOIN trs_visited ON pokestop.pokestop_id = trs_visited.pokestop_id "
+            "WHERE (pokestop.latitude >= {} AND pokestop.longitude >= {} "
+            "AND pokestop.latitude <= {} AND pokestop.longitude <= {}) "
+            "GROUP by pokestop.pokestop_id HAVING INSTR(vis,'{}') < 1"
+        ).format(minLat, minLon, maxLat, maxLon, origin)
+
+        res = self.execute(query)
+        unvisited: List[Location] = []
+
+        for (latitude, longitude, vis) in res:
+            unvisited.append(Location(latitude, longitude))
+
+        if geofence_helper is not None:
+            geofenced_coords = geofence_helper.get_geofenced_coordinates(unvisited)
+            return geofenced_coords
+        else:
+            return unvisited
 
     def get_gyms_in_rectangle(self, neLat, neLon, swLat, swLon, oNeLat=None, oNeLon=None, oSwLat=None, oSwLon=None, timestamp=None):
         """

--- a/mitm_receiver/MitmMapper.py
+++ b/mitm_receiver/MitmMapper.py
@@ -176,6 +176,12 @@ class MitmMapper(object):
         else:
             return -1
 
+    def get_poke_stop_visits(self, origin: str):
+        if self.__playerstats.get(origin, None) is not None:
+            return self.__playerstats.get(origin).get_poke_stop_visits()
+        else:
+            return -1
+
     def collect_raid_stats(self, origin: str, gym_id: str):
         if self.__playerstats.get(origin, None) is not None:
             self.__playerstats.get(origin).stats_collect_raid(gym_id)

--- a/route/RouteManagerBase.py
+++ b/route/RouteManagerBase.py
@@ -535,7 +535,7 @@ class RouteManagerBase(ABC):
                 logger.debug("No subroute/routepool entry of {} present, creating it", origin)
                 self._routepool[origin] = RoutePoolEntry(time.time(), collections.deque(), [],
                                                          time_added=time.time())
-                if not self.__worker_changed_update_routepools():
+                if not self.worker_changed_update_routepools():
                     logger.info("Failed updating routepools after adding a worker to it")
                     return None
 
@@ -646,7 +646,7 @@ class RouteManagerBase(ABC):
                         logger.info("No more coords available - dont update routepool")
                         return None
 
-                if not self.__worker_changed_update_routepools():
+                if not self.worker_changed_update_routepools():
                     logger.info("Failed updating routepools ...")
                     return None
 
@@ -779,7 +779,7 @@ class RouteManagerBase(ABC):
                 if origin in self._routepool:
                     self._routepool[origin].worker_sleeping = sleep_duration
 
-    def __worker_changed_update_routepools(self):
+    def worker_changed_update_routepools(self):
         less_coords: bool = False
         if not self._is_started:
             return True

--- a/route/RouteManagerLeveling.py
+++ b/route/RouteManagerLeveling.py
@@ -1,4 +1,6 @@
 import collections
+
+import numpy as np
 import time
 from typing import List
 from db.DbWrapper import DbWrapper
@@ -9,45 +11,61 @@ from utils.collections import LocationWithVisits, Location
 
 
 class RouteManagerLeveling(RouteManagerQuests):
-    def generate_stop_list(self):
-        time.sleep(5)
-        stops, stops_with_visits = self.db_wrapper.stop_from_db_without_quests(
-            self.geofence_helper, True)
 
-        logger.info('Detected stops without quests: {}', str(len(stops_with_visits)))
-        logger.debug('Detected stops without quests: {}', str(stops_with_visits))
-        self._stoplist: List[Location] = stops
-        self._stops_with_visits: List[LocationWithVisits] = stops_with_visits
-
-    def __worker_changed_update_routepools(self):
+    def worker_changed_update_routepools(self):
         with self._manager_mutex:
-            logger.debug("Updating all routepools")
+            logger.info("Updating all routepools in levelmode for {} origins", len(self._routepool))
             if len(self._workers_registered) == 0:
                 logger.info("No registered workers, aborting __worker_changed_update_routepools...")
                 return False
 
-        _, stops_with_visits = self.db_wrapper.stop_from_db_without_quests(
-            self.geofence_helper, True)
-        any_at_all = False
-        for origin in self._routepool:
-            origin_local_list = []
-            entry: RoutePoolEntry = self._routepool[origin]
+            any_at_all = False
+            for origin in self._routepool:
+                origin_local_list = []
+                entry: RoutePoolEntry = self._routepool[origin]
 
-            for coord in stops_with_visits:
-                if origin not in str(coord.visited_by):
-                    origin_local_list.append(Location(coord.lat, coord.lng))
+                if len(entry.queue) > 0:
+                    logger.debug("origin {} already has a queue, do not touch...", origin)
+                    continue
 
-            # subroute is all stops unvisited
-            entry.subroute = origin_local_list
-            # let's clean the queue just to make sure
-            entry.queue.clear()
-            any_at_all = len(origin_local_list) > 0 or any_at_all
-        return any_at_all
+                unvisited_stops = self.db_wrapper.stops_from_db_unvisited(self.geofence_helper, origin)
+                if len(self._route) > 0:
+                    logger.info("Making a subroute of unvisited stops..")
+                    for coord in self._route:
+                        coord_location = Location(coord.lat, coord.lng)
+                        if coord_location in self._coords_to_be_ignored:
+                            logger.info('Already tried this Stop but it failed spinnable test, skip it')
+                            continue
+                        if coord_location in unvisited_stops:
+                            origin_local_list.append(coord_location)
+                if len(origin_local_list) == 0:
+                    logger.info("None of the stops in original route was unvisited, recalc a route")
+                    new_route = self._local_recalc_subroute(unvisited_stops)
+                    for coord in new_route:
+                        origin_local_list.append(Location(coord["lat"], coord["lng"]))
+
+                # subroute is all stops unvisited
+                logger.info("Origin {} has {} unvisited stops for this route", origin, len(origin_local_list))
+                entry.subroute = origin_local_list
+                # let's clean the queue just to make sure
+                entry.queue.clear()
+                [entry.queue.append(i) for i in origin_local_list]
+                any_at_all = len(origin_local_list) > 0 or any_at_all
+            return any_at_all
+
+    def _local_recalc_subroute(self, unvisited_stops):
+        to_be_route = np.zeros(shape=(len(unvisited_stops), 2))
+        for i in range(len(unvisited_stops)):
+            to_be_route[i][0] = float(unvisited_stops[i].lat)
+            to_be_route[i][1] = float(unvisited_stops[i].lng)
+        new_route = self.calculate_new_route(to_be_route, self._max_radius, self._max_coords_within_radius, False, 1,
+                                             True)
+        return new_route
 
     def __init__(self, db_wrapper: DbWrapper, dbm, area_id, coords: List[Location], max_radius: float,
                  max_coords_within_radius: int, path_to_include_geofence: str, path_to_exclude_geofence: str,
                  routefile: str, mode=None, init: bool = False, name: str = "unknown", settings: dict = None,
-                 level: bool = False, calctype: str = "optimized", joinqueue=None):
+                 level: bool = False, calctype: str = "quick", joinqueue=None):
         RouteManagerQuests.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id, coords=coords,
                                     max_radius=max_radius, max_coords_within_radius=max_coords_within_radius,
                                     path_to_include_geofence=path_to_include_geofence,
@@ -56,7 +74,163 @@ class RouteManagerLeveling(RouteManagerQuests):
                                     name=name, settings=settings, mode=mode, level=level, calctype=calctype,
                                     joinqueue=joinqueue
                                     )
-        self._stops_with_visits: List[LocationWithVisits] = []
+
+    def generate_stop_list(self):
+        time.sleep(5)
+        stops_in_fence = self.db_wrapper.stops_from_db(self.geofence_helper)
+
+        logger.info('Detected stops without quests: {}', str(len(stops_in_fence)))
+        logger.debug('Detected stops without quests: {}', str(stops_in_fence))
+        self._stoplist: List[Location] = stops_in_fence
+
+    def _retrieve_latest_priority_queue(self):
+        return None
+
+    def _get_coords_post_init(self):
+        return self.db_wrapper.stops_from_db(self.geofence_helper)
+
+    def _cluster_priority_queue_criteria(self):
+        pass
+
+    def _priority_queue_update_interval(self):
+        return 0
+
+    def _recalc_route_workertype(self):
+        self.recalc_route(self._max_radius, self._max_coords_within_radius, 1, delete_old_route=False, in_memory=True)
+        self._init_route_queue()
+
+    def _get_coords_after_finish_route(self) -> bool:
+        self._manager_mutex.acquire()
+        try:
+
+            if self._shutdown_route:
+                logger.info('Other worker shutdown route {} - leaving it', str(self.name))
+                return False
+
+            if self._start_calc:
+                logger.info("Another process already calculate the new route")
+                return True
+            self._start_calc = True
+            self._restore_original_route()
+
+            any_unvisited = False
+            for origin in self._routepool:
+                any_unvisited = self.db_wrapper.any_stops_unvisited(self.geofence_helper, origin)
+                if any_unvisited:
+                    break
+
+            if not any_unvisited:
+                logger.info("Not getting any stops - leaving now.")
+                self._shutdown_route = True
+                self._start_calc = False
+                return False
+
+            # Redo individual routes
+            self.worker_changed_update_routepools()
+            self._start_calc = False
+            return True
+        finally:
+            self._manager_mutex.release()
+
+    def _restore_original_route(self):
+        if not self._tempinit:
+            logger.info("Restoring original route")
+            self._route = self._routecopy.copy()
+
+    def _check_unprocessed_stops(self):
+        self._manager_mutex.acquire()
+
+        try:
+            # We finish routes on a per walker/origin level, so the route itself is always the same as long as at
+            # least one origin is connected to it.
+            return self._stoplist
+        finally:
+            self._manager_mutex.release()
+
+    def _start_routemanager(self):
+        self._manager_mutex.acquire()
+        try:
+            if not self._is_started:
+                self._is_started = True
+                logger.info("Starting routemanager {}", str(self.name))
+
+                if self._shutdown_route:
+                    logger.info('Other worker shutdown route {} - leaving it', str(self.name))
+                    return False
+
+                self.generate_stop_list()
+                stops = self._stoplist
+                self._prio_queue = None
+                self.delay_after_timestamp_prio = None
+                self.starve_route = False
+                self._first_round_finished = False
+                self._start_check_routepools()
+
+                if not self._first_started:
+                    logger.info(
+                        "First starting quest route - copying original route {} for later use", str(self.name))
+                    self._routecopy = self._route.copy()
+                    self._first_started = True
+                else:
+                    logger.info("Restoring original route {} ", str(self.name))
+                    self._route = self._routecopy.copy()
+
+                new_stops = list(set(stops) - set(self._route))
+                if len(new_stops) > 0:
+                    logger.info("There's {} new stops not in route", len(new_stops))
+
+                if len(stops) == 0:
+                    logger.info('No  Stops detected in route {} - quit worker', str(self.name))
+                    self._shutdown_route = True
+                    self._restore_original_route()
+                    self._route: List[Location] = []
+                    return False
+
+                if 0 < len(stops) < len(self._route) \
+                        and len(stops) / len(self._route) <= 0.3:
+                    # Calculating new route because 70 percent of stops are processed
+                    logger.info('There are less stops without quest than routepositions - recalc')
+                    self._recalc_stop_route(stops)
+                elif len(self._route) == 0 and len(stops) > 0:
+                    logger.warning("Something wrong with area {}: it have many new stops "
+                                   "- you should delete routefile!!",
+                                   str(self.name))
+                    logger.info("Recalc new route for area {}", str(self.name))
+                    self._recalc_stop_route(stops)
+                else:
+                    self._init_route_queue()
+
+                logger.info('Getting {} positions in route {}'.format(len(self._route), str(self.name)))
+                return True
+
+        finally:
+            self._manager_mutex.release()
+
+        return True
+
+    def _recalc_stop_route(self, stops):
+        self._clear_coords()
+        self.add_coords_list(stops)
+        self._overwrite_calculation = True
+        self._recalc_route_workertype()
+        self._init_route_queue()
+
+    def _delete_coord_after_fetch(self) -> bool:
+        return False
+
+    def _quit_route(self):
+        logger.info('Shutdown Route {}', str(self.name))
+        if self._is_started:
+            self._is_started = False
+            self._round_started_time = None
+            if self.init: self._first_started = False
+            self._restore_original_route()
+            self._shutdown_route = False
+
+        # clear not processed stops
+        self._stops_not_processed.clear()
+        self._coords_to_be_ignored.clear()
+        self._stoplist.clear()
 
     def _check_coords_before_returning(self, lat, lng, origin):
         if self.init:
@@ -64,18 +238,8 @@ class RouteManagerLeveling(RouteManagerQuests):
             return True
         stop = Location(lat, lng)
         logger.info('Checking Stop with ID {}', str(stop))
-        if stop not in self._stoplist:
-            logger.info('Stop is not in stoplist, either no longer in route or spun already...')
+        if stop in self._coords_to_be_ignored:
+            logger.info('Already tried this Stop and failed it')
             return False
-
-        if self._stops_with_visits is None or len(self._stops_with_visits) == 0:
-            logger.info('no visit info so lets go')
-            return True
-
-        for stop in self._stops_with_visits:
-            if stop.lat == lat and stop.lng == lng and stop.visited_by is not None and origin in stop.visited_by:
-                logger.info("DB says we Already spun stop, ignore it...")
-                return False
-
-        logger.info('Getting new Stop')
+        logger.info('DB knows nothing of this stop for {} lets try and go there', origin)
         return True

--- a/route/RouteManagerQuests.py
+++ b/route/RouteManagerQuests.py
@@ -12,7 +12,7 @@ Location = collections.namedtuple('Location', ['lat', 'lng'])
 class RouteManagerQuests(RouteManagerBase):
     def generate_stop_list(self):
         time.sleep(5)
-        stops, _ = self.db_wrapper.stop_from_db_without_quests(self.geofence_helper, False)
+        stops = self.db_wrapper.stop_from_db_without_quests(self.geofence_helper)
 
         logger.info('Detected stops without quests: {}', str(len(stops)))
         logger.debug('Detected stops without quests: {}', str(stops))
@@ -41,7 +41,7 @@ class RouteManagerQuests(RouteManagerBase):
     def __init__(self, db_wrapper: DbWrapper, dbm, area_id, coords: List[Location], max_radius: float,
                  max_coords_within_radius: int, path_to_include_geofence: str, path_to_exclude_geofence: str,
                  routefile: str, mode=None, init: bool = False, name: str = "unknown", settings: dict = None,
-                 level: bool = False, calctype: str = "optimized", joinqueue = None):
+                 level: bool = False, calctype: str = "quick", joinqueue = None):
         RouteManagerBase.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id, coords=coords, max_radius=max_radius,
                                   max_coords_within_radius=max_coords_within_radius,
                                   path_to_include_geofence=path_to_include_geofence,

--- a/route/routecalc/calculate_route_quick.py
+++ b/route/routecalc/calculate_route_quick.py
@@ -16,19 +16,24 @@ def route_calc_impl(coords, route_name, num_processes=1):
 
 
 def tsp(data):
+    logger.info("building the graph for a route of {}", len(data))
     # build a graph
     graph_data = build_graph(data)
 
     # build a minimum spanning tree
+    logger.info("Building a min span tree..")
     min_span_tree = minimum_spanning_tree(graph_data)
 
     # find odd vertexes
+    logger.info("Finidng odd vertexes...")
     odd_vertexes = find_odd_vertexes(min_span_tree)
 
     # add minimum weight matching edges to MST
+    logger.info("Adding minimum weight mathcing edges to MST...")
     minimum_weight_matching(min_span_tree, graph_data, odd_vertexes)
 
     # find an eulerian tour
+    logger.info("Finding and Eulerian tour...")
     eulerian_tour = find_eulerian_tour(min_span_tree)
 
     current = eulerian_tour[0]
@@ -38,6 +43,7 @@ def tsp(data):
 
     length = 0
 
+    logger.info("Visiting each node in our eulerian tour and making a route")
     for v in eulerian_tour[1:]:
         if not visited[v]:
             path.append(v)
@@ -46,6 +52,7 @@ def tsp(data):
             length += graph_data[current][v]
             current = v
 
+    logger.info("Done making a route!")
     return length, path
 
 

--- a/worker/WorkerQuests.py
+++ b/worker/WorkerQuests.py
@@ -247,7 +247,8 @@ class WorkerQuests(MITMBase):
             logger.debug(
                     "Need more sleep after Teleport: {} seconds!", str(int(delay_used)))
         else:
-            logger.info("main: Walking...")
+            delay_used = distance / speed
+            logger.info("main: Walking {} m, this will take {} seconds", distance, delay_used)
             self._transporttype = 1
             self._communicator.walkFromTo(self.last_location.lat, self.last_location.lng,
                                           self.current_location.lat,


### PR DESCRIPTION
Should make quest level mode be more memory friendly, especially for large routes.

Changes:

- Each worker will get their own list based on what has been visited before
- A worker will use the saved routecalc as long as there are more or equal unvisited stops in db
- If there's fewer unvisited than the routecalc a recalc of route WILL happen. This might have negative impact on very large routes with a low number of stops in the routefile. Make sure you're on quick calc mode for those cases.

**Note**
- There's only one list of stops considered to ignored. This means if more than one worker is in the area and one worker fails the spinnable check, it will be added to the ignore list for everyone.
- Whenever a worker joins an area, all worker routes will be recalculated. 