### PR TITLE
Fix "Last mon seen" in MAdmin

### DIFF
--- a/madmin/static/js/madmin.js
+++ b/madmin/static/js/madmin.js
@@ -1198,9 +1198,9 @@ new Vue({
       var last_non_scanned = moment(spawn["lastnonscan"])
 
       if (last_scanned.isBefore(last_non_scanned)) {
-        var last_mon = last_scanned
-      } else {
         var last_mon = last_non_scanned
+      } else {
+        var last_mon = last_scanned
       }
 
       return `

--- a/madmin/static/js/madmin.js
+++ b/madmin/static/js/madmin.js
@@ -1194,15 +1194,6 @@ new Vue({
         var spawntiming = ""
       }
 
-      var last_scanned = moment(spawn["lastscan"])
-      var last_non_scanned = moment(spawn["lastnonscan"])
-
-      if (last_scanned.isBefore(last_non_scanned)) {
-        var last_mon = last_non_scanned
-      } else {
-        var last_mon = last_scanned
-      }
-
       return `
         <div class="content">
           <div  class="id"><i class="fa fa-fingerprint"></i> <span>${spawn["id"]}</span></div>
@@ -1213,7 +1204,7 @@ new Vue({
          <br>
           <div cla ss="spawnContent">
             <div class="spawnFirstDetection"><i class="fas fa-baby"></i> First seen: <strong>${spawn["first_detection"]}</strong></div>
-            <div class="timestamp"><i class="fas fa-eye"></i> <abbr title="This is the time a mon has been seen on this spawnpoint.">Last mon seen</abbr>: <strong>${last_mon.format(timeformat)}</strong></div>
+            <div class="timestamp"><i class="fas fa-eye"></i> <abbr title="This is the time a mon has been seen on this spawnpoint.">Last mon seen</abbr>: <strong>${spawn["lastnonscan"]}</strong></div>
             <div class="timestamp"><i class="fa fa-clock"></i> <abbr title="The timestamp of the last time this spawnpoint's despawn time has been confirmed.">Last confirmation</abbr>: <strong>${spawn["lastscan"]}</strong></div>
             <div class="spawnType"><i class="fa fa-wrench"></i> Type: <strong>${type || "Unknown despawn time"}</strong></div>
             <div class="spawnTiming">${spawntiming}</div>


### PR DESCRIPTION
Currently on the map in MAdmin the "Last mon seen" is showing the last confirmation (last_non_scanned) even if MAD has seen a spawn more recently (last_scanned). Variables have been swapped. Better explained in my Discord screenshot below.

![discordexplanation](https://user-images.githubusercontent.com/58304668/69820834-a86b7480-11c7-11ea-8c25-e0de99ec6038.PNG)
