### PR TITLE
Change logging to error on building quest webhook

### DIFF
--- a/webhook/webhookworker.py
+++ b/webhook/webhookworker.py
@@ -158,7 +158,7 @@ class WebhookWorker:
                 entire_payload = {"type": "quest", "message": quest_payload}
                 ret.append(entire_payload)
             except Exception as e:
-                logger.warning(
+                logger.error(
                     "Exception occured while generating quest webhook: {}", str(e)
                 )
 


### PR DESCRIPTION
Lack of item in files stops generation of quest webhook - this should be an error, not a warning. It stops from sending it to the receiver.