### PR TITLE
Added screendetection to device pools

### DIFF
--- a/db/DbSchemaUpdater.py
+++ b/db/DbSchemaUpdater.py
@@ -189,7 +189,12 @@ class DbSchemaUpdater:
             "column": "instance",
             "ctype": "VARCHAR(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL FIRST",
             "modify_key": "DROP PRIMARY KEY, ADD PRIMARY KEY (`instance`, `origin`)"
-        }
+        },
+        {
+            "table": "settings_devicepool",
+            "column": "screendetection",
+            "ctype": "tinyint(1) DEFAULT NULL"
+        },
     ]
 
 

--- a/utils/data_manager/modules/devicepool.py
+++ b/utils/data_manager/modules/devicepool.py
@@ -192,6 +192,15 @@ class DevicePool(resource.Resource):
                     "expected": str
                 }
             },
+            "screendetection": {
+                "settings": {
+                    "type": "option",
+                    "values": [None, False, True],
+                    "require": False,
+                    "description": "Use this argument if there are login/logout problems with this device or you want to levelup accounts  (Default: False)",
+                    "expected": bool
+                }
+            },
             "injection_thresh_reboot": {
                  "settings": {
                     "type": "text",


### PR DESCRIPTION
This feature was requested in the mad-dev channel.  The user would like to be able to set this via device pools as there is a 'none' option on the device.