### PR TITLE
Fix update order for devicepools

### DIFF
--- a/db/DbSchemaUpdater.py
+++ b/db/DbSchemaUpdater.py
@@ -187,7 +187,7 @@ class DbSchemaUpdater:
         {
             "table": "trs_status",
             "column": "instance",
-            "ctype": "VARCHAR(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL FIRST",
+            "ctype": "VARCHAR(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL FIRST",
             "modify_key": "DROP PRIMARY KEY, ADD PRIMARY KEY (`instance`, `origin`)"
         }
     ]

--- a/db/DbSchemaUpdater.py
+++ b/db/DbSchemaUpdater.py
@@ -189,12 +189,7 @@ class DbSchemaUpdater:
             "column": "instance",
             "ctype": "VARCHAR(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL FIRST",
             "modify_key": "DROP PRIMARY KEY, ADD PRIMARY KEY (`instance`, `origin`)"
-        },
-        {
-            "table": "settings_devicepool",
-            "column": "screendetection",
-            "ctype": "tinyint(1) DEFAULT NULL"
-        },
+        }
     ]
 
 
@@ -301,6 +296,15 @@ class DbSchemaUpdater:
         logger.debug("DbWrapperBase::create_madmin_databases_if_not_exists called")
         for table in madmin_conversion.TABLES:
             self._db_exec.execute(table, commit=True)
+
+    def ensure_unversioned_madmin_columns_exist(self):
+        try:
+            for column_mod in madmin_conversion.COLUMNS:
+                self.check_create_column(column_mod)
+        except SchemaUpdateError as e:
+            column_mod = e.schema_mod
+            logger.error("Couldn't create required column {}.{}'", column_mod["table"], column_mod["column"])
+            sys.exit(1)
 
 class SchemaUpdateError(Exception):
 

--- a/db/DbWrapper.py
+++ b/db/DbWrapper.py
@@ -31,6 +31,7 @@ class DbWrapper:
         self.schema_updater.ensure_unversioned_tables_exist()
         self.schema_updater.ensure_unversioned_columns_exist()
         self.schema_updater.create_madmin_databases_if_not_exists()
+        self.schema_updater.ensure_unversioned_madmin_columns_exist()
         self.proto_submit: DbPogoProtoSubmit = DbPogoProtoSubmit(db_exec, args.lure_duration)
         self.stats_submit: DbStatsSubmit = DbStatsSubmit(db_exec)
         self.stats_reader: DbStatsReader = DbStatsReader(db_exec)

--- a/db/madmin_conversion.py
+++ b/db/madmin_conversion.py
@@ -1,3 +1,10 @@
+COLUMNS = [
+    {
+        "table": "settings_devicepool",
+        "column": "screendetection",
+        "ctype": "tinyint(1) DEFAULT NULL"
+    },
+]
 TABLES = [
     """CREATE TABLE IF NOT EXISTS `madmin_instance` (
         `instance_id` INT UNSIGNED NOT NULL AUTO_INCREMENT,

--- a/utils/version.py
+++ b/utils/version.py
@@ -12,7 +12,7 @@ import copy
 from db.DbWrapper import DbWrapper
 from db.DbSchemaUpdater import DbSchemaUpdater
 
-current_version = 17
+current_version = 18
 
 class MADVersion(object):
 
@@ -511,6 +511,15 @@ class MADVersion(object):
                              'were not converted.')
                 for (section, identifier, issue) in conversion_issues:
                     logger.error('{} {}: {}', section, identifier, issue)
+        if self._version < 18:
+            query = (
+                "ALTER TABLE `trs_status` CHANGE `instance` `instance` VARCHAR(50) CHARACTER "
+                "SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;"
+            )
+            try:
+                self.dbwrapper.execute(query, commit=True)
+            except Exception as e:
+                logger.exception("Unexpected error: {}", e)
 
         self.set_version(current_version)
 


### PR DESCRIPTION
In #594 the alter table was being applied prior to the tables being created.  This did not allow the tables to be correctly initialized prior to the alter table and causing the update to fail