### PR TITLE
Move RPC method for route recalculation

### DIFF
--- a/madmin/api/apiHandler.py
+++ b/madmin/api/apiHandler.py
@@ -244,6 +244,8 @@ class ResourceHandler(object):
                     return self.get_resource_data_root(resource_def, resource_info)
                 else:
                     return self.get(identifier, resource_def, resource_info)
+            if flask.request.method == 'POST' and self.api_req.content_type == 'application/json-rpc':
+                return self.post(identifier, self.api_req.data, resource_def, resource_info)
             translated_data = self.translate_data_for_datamanager(self.api_req.data, resource_def)
             if flask.request.method == 'PATCH':
                 return self.patch(identifier, translated_data, resource_def, resource_info)

--- a/madmin/api/modules/ftr_area.py
+++ b/madmin/api/modules/ftr_area.py
@@ -1,16 +1,35 @@
-from .. import apiHandler, apiException
-import copy
+from .. import apiHandler, apiResponse, apiException
+import threading
 
 class APIArea(apiHandler.ResourceHandler):
     component = 'area'
     default_sort = 'name'
     description = 'Add/Update/Delete Areas used for Walkers'
+    has_rpc_calls = True
 
     def get_resource_info(self, resource_def):
         if self.mode is None:
             return 'Please specify a mode for resource information.  Valid modes: %s' % (','.join(self.configuration.keys()))
         else:
             return super().get_resource_info(resource_def)
+
+    def post(self, identifier, data, resource_def, resource_info, *args, **kwargs):
+        if self.api_req.content_type == 'application/json-rpc':
+            try:
+                call = self.api_req.data['call']
+                args = self.api_req.data.get('args', {})
+                if call == 'recalculate':
+                    resource = self._data_manager.get_resource('area', identifier=identifier)
+                    print(resource)
+                    t = threading.Thread(target=self._mapping_manager.routemanager_recalcualte,args=(resource.identifier,))
+                    t.start()
+                    return apiResponse.APIResponse(self._logger, self.api_req)(None, 204)
+                else:
+                    return apiResponse.APIResponse(self._logger, self.api_req)(call, 501)
+            except KeyError:
+                return apiResponse.APIResponse(self._logger, self.api_req)(call, 501)
+        else:
+            return super().post(identifier, data, resource_def, resource_info, *args, **kwargs)
 
     def populate_mode(self, identifier, method):
         self.mode = self.api_req.headers.get('X-Mode', None)
@@ -23,5 +42,8 @@ class APIArea(apiHandler.ResourceHandler):
                 data = self._data_manager.get_resource(self.component, identifier=identifier)
                 if data:
                     self.mode = data.area_type
-        elif method in ['POST', 'PUT']:
+        elif method == 'POST':
+            if self.api_req.content_type != 'application/json-rpc':
+                raise apiException.NoModeSpecified()
+        elif method == 'PUT':
             raise apiException.NoModeSpecified()

--- a/madmin/api/modules/ftr_routecalc.py
+++ b/madmin/api/modules/ftr_routecalc.py
@@ -1,24 +1,5 @@
-from .. import apiHandler, apiResponse, apiRequest, apiException
-import threading
+from .. import apiHandler
 
 class APIRouteCalc(apiHandler.ResourceHandler):
     component = 'routecalc'
     description = 'Add/Update/Delete routecalcs'
-    has_rpc_calls = True
-
-    def post(self, identifier, data, resource_def, resource_info, *args, **kwargs):
-        resource = resource_def(self._data_manager)
-        if self.api_req.content_type == 'application/json-rpc':
-            try:
-                call = self.api_req.data['call']
-                args = self.api_req.data.get('args', {})
-                if call == 'recalculate':
-                    t = threading.Thread(target=self._mapping_manager.routemanager_recalcualte,args=(args['area_id'],))
-                    t.start()
-                    return apiResponse.APIResponse(self._logger, self.api_req)(None, 204)
-                else:
-                    return apiResponse.APIResponse(self._logger, self.api_req)(call, 501)
-            except KeyError:
-                return apiResponse.APIResponse(self._logger, self.api_req)(call, 501)
-        else:
-            return super().post(identifier, data, resource_def, resource_info, *args, **kwargs)

--- a/madmin/templates/settings_areas.html
+++ b/madmin/templates/settings_areas.html
@@ -42,13 +42,10 @@ $(document).ready(function () {
             var elem =  $(this);
             $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Recalculating routefile...</h2>' });
             rpc_call = {
-              'call': 'recalculate',
-              'args': {
-                'area_id': $(this).data('area')
-              }
+              'call': 'recalculate'
             }
             $.ajax({
-                url : '{{ url_for('api_routecalc') }}/'+ $(this).data('identifier'),
+                url : '{{ url_for('api_area') }}/'+ $(this).data('area'),
                 contentType : 'application/json-rpc',
                 data: JSON.stringify(rpc_call),
                 type : 'POST',
@@ -141,7 +138,7 @@ $(document).ready(function () {
             </p>
           </td>
           <td class="text-right align-middle">
-            <button data-identifier='{{ area['routecalc'] }}' data-area='{{ area_id }}' type="button" class="recalculate btn btn-info btn-sm"><i class="fa fa-sync"></i></button>
+            <button data-area='{{ area_id }}' type="button" class="recalculate btn btn-info btn-sm"><i class="fa fa-sync"></i></button>
             <a href="{{ redirect }}?id={{ area_id }}&mode={{ area.area_type }}"><button type="button" class="btn btn-success btn-sm edit" data-identifier="{{ loop.index }}"><i class="far fa-edit"></i></button></a>
             <button data-identifier='{{ area_id }}' type="button" class="delete btn btn-danger btn-sm"><i class="fas fa-trash-alt"></i>
           </td>

--- a/utils/data_manager/modules/area_pokestops.py
+++ b/utils/data_manager/modules/area_pokestops.py
@@ -98,7 +98,7 @@ class AreaPokestops(area.Area):
                     "type": "option",
                     "values": [None, True, False],
                     "require": False,
-                    "description": "Do not spinn stops already made in the past (for levelmode) (Default: True)",
+                    "description": "Do not spin stops already made in the past (for levelmode) (Default: True)",
                     "expected": bool
                 }
             },
@@ -107,7 +107,7 @@ class AreaPokestops(area.Area):
                     "type": "option",
                     "values": [None, False, True],
                     "require": False,
-                    "description": "Cleanup quest inventory every spinned stop (Default: False)",
+                    "description": "Cleanup quest inventory after every stop (Default: False)",
                     "expected": bool
                 }
             }

--- a/utils/data_manager/modules/device.py
+++ b/utils/data_manager/modules/device.py
@@ -297,7 +297,7 @@ class Device(resource.Resource):
                 }
             },
             "injection_thresh_reboot": {
-                 "settings": {
+                "settings": {
                     "type": "text",
                     "require": False,
                     "description": "Reboot (if enabled) device after not injecting for X times in a row (Default: 20)",


### PR DESCRIPTION
Moved the RPC method for route recalculation from /api/routecalc to /api/area.  This is a more logical place as the old method required you to know the routecalc_id and the area_id while the new method is only the area_id