### PR TITLE
Fix upgrade issue around non-instanced devices

### DIFF
--- a/utils/version.py
+++ b/utils/version.py
@@ -542,7 +542,12 @@ class MADVersion(object):
                 }
                 # We dont want to mess with collations so just pull in and compare
                 sql = "SELECT `instance`, `origin` FROM `trs_status`"
-                devs = self.dbwrapper.autofetch_all(sql)
+                try:
+                    devs = self.dbwrapper.autofetch_all(sql)
+                    if devs is None:
+                        devs = []
+                except:
+                    devs = []
                 for dev in devs:
                     if dev['instance'] not in instances:
                         tmp_instance = self.dbwrapper.get_instance_id(instance_name=dev['instance'])


### PR DESCRIPTION
During the upgrade process for v19 it alters trs_status to use instance_id versus instance.  If the same device exists twice (one with and one without an instance) it will cause an error during the upgrade.  This change addresses that issue to notify it is removing non-instanced devices prior to altering the table