### PR TITLE
prioQ fixes for mon_mitm, little improvements, logging

### DIFF
--- a/db/DbWrapper.py
+++ b/db/DbWrapper.py
@@ -802,9 +802,6 @@ class DbWrapper:
             "FROM trs_spawn "
             "WHERE calc_endminsec IS NOT NULL "
             "AND (latitude >= {} AND longitude >= {} AND latitude <= {} AND longitude <= {}) "
-            "AND DATE_FORMAT(STR_TO_DATE(calc_endminsec,'%i:%s'),'%i:%s') BETWEEN DATE_FORMAT(DATE_ADD(NOW(), "
-            " INTERVAL if(spawndef=15,60,30) MINUTE),'%i:%s') "
-            "AND DATE_FORMAT(DATE_ADD(NOW(), INTERVAL if(spawndef=15,70,40) MINUTE),'%i:%s')"
         ).format(minLat, minLon, maxLat, maxLon)
 
         res = self.execute(query)

--- a/db/madmin_conversion.py
+++ b/db/madmin_conversion.py
@@ -14,6 +14,11 @@ COLUMNS = [
         "column": "last_updated",
         "ctype": "DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER `recalc_status`;"
     },
+       {
+        "table": "settings_area_mon_mitm",
+        "column": "max_clustering",
+        "ctype": "int DEFAULT NULL"
+    },
 ]
 TABLES = [
     """CREATE TABLE IF NOT EXISTS `madmin_instance` (

--- a/route/RouteManagerBase.py
+++ b/route/RouteManagerBase.py
@@ -247,8 +247,15 @@ class RouteManagerBase(ABC):
                 self._stop_update_thread.clear()
             self._prio_queue = []
             if self.mode not in ["iv_mitm", "pokestops"]:
+                if self.mode == "mon_mitm" and self.settings is not None:
+                    max_clustering = self.settings.get(
+                        "max_clustering", self._max_coords_within_radius)
+                    if max_clustering == 0:
+                        max_clustering = self._max_coords_within_radius
+                else:
+                    max_clustering = self._max_coords_within_radius
                 self.clustering_helper = ClusteringHelper(self._max_radius,
-                                                          self._max_coords_within_radius,
+                                                          max_clustering,
                                                           self._cluster_priority_queue_criteria())
             self._update_prio_queue_thread = Thread(name="prio_queue_update_" + self.name,
                                                     target=self._update_priority_queue_loop)
@@ -503,7 +510,7 @@ class RouteManagerBase(ABC):
         delete_seconds_passed = 0
         if self.settings is not None:
             delete_seconds_passed = self.settings.get(
-                "remove_from_queue_backlog", 0)
+                "remove_from_queue_backlog", 900)
 
         if delete_seconds_passed is not None:
             delete_before = time.time() - delete_seconds_passed
@@ -595,7 +602,7 @@ class RouteManagerBase(ABC):
                 next_readableTime = datetime.fromtimestamp(next_timestamp).strftime('%Y-%m-%d %H:%M:%S')
                 if self.settings is not None:
                     delete_seconds_passed = self.settings.get(
-                            "remove_from_queue_backlog", 0)
+                            "remove_from_queue_backlog", 900)
                     if delete_seconds_passed is not None:
                         delete_before = time.time() - delete_seconds_passed
                     else:

--- a/route/RouteManagerBase.py
+++ b/route/RouteManagerBase.py
@@ -512,6 +512,13 @@ class RouteManagerBase(ABC):
             if self.mode == "mon_mitm":
                 delete_seconds_passed = self.settings.get(
                         "remove_from_queue_backlog", 300)
+                if delete_seconds_passed == 0:
+                    logger.error("You are running area {} in mon_mitm mode with "
+                            "priority queue enabled and remove_from_queue_backlog "
+                            "set to 0. This may result in building up a significant "
+                            "queue backlog and reduced scanning performance. "
+                            "Please review this setting or set it to the default "
+                            "of 300.", self.name)
             else:
                 delete_seconds_passed = self.settings.get(
                         "remove_from_queue_backlog", 0)
@@ -618,8 +625,10 @@ class RouteManagerBase(ABC):
                             delete_before = 0
                     if next_timestamp < delete_before:
                         logger.warning("Prio event for route {} surpassed the "
-                                       "maximum backlog time and will be skipped "
-                                       "(was scheduled for {})",
+                                       "maximum backlog time and will be skipped. "
+                                       "Make sure you run enough workers or reduce "
+                                       "the size of the area! "
+                                       "(event was scheduled for {})",
                                        self.name, next_readableTime)
                         return self.get_next_location(origin)
                 if self._other_worker_closer_to_prioq(next_coord, origin):

--- a/route/RouteManagerBase.py
+++ b/route/RouteManagerBase.py
@@ -509,7 +509,7 @@ class RouteManagerBase(ABC):
             return latest
         delete_seconds_passed = 0
         if self.settings is not None:
-            if self.mode = "mon_mitm":
+            if self.mode == "mon_mitm":
                 delete_seconds_passed = self.settings.get(
                         "remove_from_queue_backlog", 300)
             else:
@@ -608,7 +608,7 @@ class RouteManagerBase(ABC):
                 # Problem: delete_seconds_passed = 0 makes sense in _filter_priority_queue_internal,
                 # because it will remove past events only at the moment of prioQ calculation,
                 # but here it would skip ALL events, because events can only be due when they are in the past
-                if self.mode = "mon_mitm":
+                if self.mode == "mon_mitm":
                     if self.settings is not None:
                         delete_seconds_passed = self.settings.get(
                                 "remove_from_queue_backlog", 300)

--- a/route/RouteManagerMon.py
+++ b/route/RouteManagerMon.py
@@ -4,7 +4,7 @@ from utils.logging import logger
 
 class RouteManagerMon(RouteManagerBase):
     def _priority_queue_update_interval(self):
-        return 180
+        return 3540
 
     def _get_coords_after_finish_route(self) -> bool:
         self._init_route_queue()

--- a/utils/data_manager/modules/area_mon_mitm.py
+++ b/utils/data_manager/modules/area_mon_mitm.py
@@ -100,11 +100,19 @@ class AreaMonMITM(area.Area):
                     "expected": float
                 }
             },
+            "max_clustering": {
+                "settings": {
+                    "type": "text",
+                    "require": False,
+                    "description": "Maximum number of prioQ events to cluster (default: unlimited, 0 or empty to set unlimited)",
+                    "expected": int
+                }
+            },
             "remove_from_queue_backlog": {
                 "settings": {
                     "type": "text",
                     "require": False,
-                    "description": "Remove any events in priority queue that have been due for scanning before NOW - given time in seconds (Default: 0)",
+                    "description": "Remove any events in priority queue that have been due for scanning before NOW - given time in seconds (Default: 900)",
                     "expected": float
                 }
             },
@@ -138,14 +146,6 @@ class AreaMonMITM(area.Area):
                     "uri": True,
                     "data_source": "monivlist",
                     "uri_source": "api_monivlist"
-                }
-            },
-            "min_time_left_seconds": {
-                "settings": {
-                    "type": "text",
-                    "require": False,
-                    "description": "Ignore mons with less spawntime in seconds",
-                    "expected": int
                 }
             }
         }

--- a/utils/data_manager/modules/area_mon_mitm.py
+++ b/utils/data_manager/modules/area_mon_mitm.py
@@ -112,7 +112,7 @@ class AreaMonMITM(area.Area):
                 "settings": {
                     "type": "text",
                     "require": False,
-                    "description": "Remove any events in priority queue that have been due for scanning before NOW - given time in seconds (Default: 900)",
+                    "description": "Remove any events in priority queue that have been due for scanning before NOW - given time in seconds (Default: 300)",
                     "expected": float
                 }
             },

--- a/utils/data_manager/modules/area_mon_mitm.py
+++ b/utils/data_manager/modules/area_mon_mitm.py
@@ -112,7 +112,7 @@ class AreaMonMITM(area.Area):
                 "settings": {
                     "type": "text",
                     "require": False,
-                    "description": "Remove any events in priority queue that have been due for scanning before NOW - given time in seconds (Default: 300)",
+                    "description": "Remove any events from priority queue that have been due for scanning more than the given number of seconds ago. Setting this to 0 can cause a significant backlog buildup, leading to reduced scanning performance. (Default: 300)",
                     "expected": float
                 }
             },


### PR DESCRIPTION
fixes https://github.com/Map-A-Droid/MAD/issues/579 by not dropping the prio q on recalculation for mon_mitm, but also reducing recalculation to one per 59 minutes,
fixes https://github.com/Map-A-Droid/MAD/issues/596 by ditching the complicated database query and just fetching all spawns for the next hour instead.

Both of these changes are feasible, because once all spawn / despawn times are known, the prioQ for mon_mitm actually just becomes a line sorting the spawn points by their spawn times. No actual prioQ flexibility is needed in this mode. It should lead to more robust and humanly understandable scanning behaviour. Also, I added a little code to check each prioQ event against the `remove_from_queue_backlog` threshold, because otherwise this would only happen during prioQ recalculation. It makes more sense this way imo, but it is also needed with hourly recalculations only, or the prioQ might fall very far behind. If an event is over the threshold, a loglevel warning message will be logged.

I limited changes of behaviour to mon_mitm mode for now because it might have unintended side effects on other modes.

I also added a couple of log lines and a little detail to existing lines to make it more understandable what is happening with prioQ.