### PR TITLE
UX for route recalulation

### DIFF
--- a/configmode.py
+++ b/configmode.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
 
     instance_id = db_wrapper.get_instance_id()
     data_manager = utils.data_manager.DataManager(db_wrapper, instance_id)
-    db_wrapper, db_pool_manager = DbFactory.get_wrapper(args)
+    data_manager.clear_on_boot()
     version = MADVersion(args, data_manager)
     version.get_version()
 

--- a/db/DbWrapper.py
+++ b/db/DbWrapper.py
@@ -71,9 +71,8 @@ class DbWrapper:
     def autoexec_insert(self, table, keyvals, literals=[], optype="INSERT"):
         return self._db_exec.autoexec_insert(table, keyvals, literals=literals, optype=optype)
 
-    def autoexec_update(self, table, set_keyvals, set_literals=[], where_keyvals={}, where_literals=[]):
-        return self._db_exec.autoexec_update(table, set_keyvals, set_literals=set_literals,
-                                             where_keyvals=where_keyvals, where_literals=where_literals)
+    def autoexec_update(self, table, set_keyvals, **kwargs):
+        return self._db_exec.autoexec_update(table, set_keyvals, **kwargs)
 
 
     def __db_timestring_to_unix_timestamp(self, timestring):

--- a/db/PooledQueryExecutor.py
+++ b/db/PooledQueryExecutor.py
@@ -328,7 +328,7 @@ class PooledQueryExecutor:
             column_values += ondupe_values
         return self.execute(query, args=tuple(column_values), commit=True, get_id=True, raise_exc=True)
 
-    def autoexec_update(self, table, set_keyvals, set_literals=[], where_keyvals={}, where_literals=[]):
+    def autoexec_update(self, table, set_keyvals, literals=[], where_keyvals={}, where_literals=[]):
         """ Auto-updates into a table and handles all escaping
         Args:
             table (str): Table to run the query against
@@ -339,13 +339,13 @@ class PooledQueryExecutor:
         """
         if type(set_keyvals) is not dict:
             raise Exception("Set Keyvals must be a dictionary")
-        if type(set_literals) is not list:
+        if type(literals) is not list:
             raise Exception("Literals must be a list")
         if type(where_keyvals) is not dict:
             raise Exception("Where Keyvals must be a dictionary")
         if type(where_literals) is not list:
             raise Exception("Literals must be a list")
-        parsed_set = self.__process_literals("SET", set_keyvals, set_literals)
+        parsed_set = self.__process_literals("SET", set_keyvals, literals)
         (set_col_names, set_col_sub, set_val, set_literal_val, _) = parsed_set
         parsed_where = self.__process_literals("UPDATE", where_keyvals, where_literals)
         (where_col_names, where_col_sub, where_val, where_literal_val, _) = parsed_where

--- a/db/madmin_conversion.py
+++ b/db/madmin_conversion.py
@@ -4,6 +4,16 @@ COLUMNS = [
         "column": "screendetection",
         "ctype": "tinyint(1) DEFAULT NULL"
     },
+    {
+        "table": "settings_routecalc",
+        "column": "recalc_status",
+        "ctype": "tinyint(1) DEFAULT 0 AFTER `instance_id`"
+    },
+    {
+        "table": "settings_routecalc",
+        "column": "last_updated",
+        "ctype": "DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER `recalc_status`;"
+    },
 ]
 TABLES = [
     """CREATE TABLE IF NOT EXISTS `madmin_instance` (

--- a/madmin/api/resources/ftr_area.py
+++ b/madmin/api/resources/ftr_area.py
@@ -21,18 +21,25 @@ class APIArea(ResourceHandler):
                 args = self.api_req.data.get('args', {})
                 if call == 'recalculate':
                     resource = self._data_manager.get_resource('area', identifier=identifier)
-                    mode = resource['mode']
+                    mode = resource.area_type
+                    # iv_mitm is PrioQ driven and idle does not have a route.  This are not recalcable and the returned
+                    # status should be representative of that
                     if mode in ['iv_mitm', 'idle']:
-                        return apiResponse.APIResponse(self._logger, self.api_req)('Unable to recalc mode %s' % (mode,), 422)
+                        return ('Unable to recalc mode %s' % (mode,), 422)
                     if resource.recalc_status == 0:
+                        # Start the recalculation.  This can take a little bit if the routemanager needs to be started
                         status = self._mapping_manager.routemanager_recalcualte(resource.identifier)
                         if status:
                             return (None, 204)
                         else:
+                            # Unable to turn on the routemanager.  Probably should use another error code
                             return (None, 409)
                     else:
+                        # Do not allow another recalculation if one is already running.  This value is reset on startup
+                        # so it will not be stuck in this state
                         return ('Recalc is already running on this Area', 422)
                 else:
+                    # RPC not implemented
                     return (call, 501)
             except KeyError:
                 return (call, 501)

--- a/madmin/api/resources/ftr_area.py
+++ b/madmin/api/resources/ftr_area.py
@@ -21,11 +21,14 @@ class APIArea(ResourceHandler):
                 args = self.api_req.data.get('args', {})
                 if call == 'recalculate':
                     resource = self._data_manager.get_resource('area', identifier=identifier)
-                    status = self._mapping_manager.routemanager_recalcualte(resource.identifier)
-                    if status:
-                        return (None, 204)
+                    if resource.recalc_status == 0:
+                        status = self._mapping_manager.routemanager_recalcualte(resource.identifier)
+                        if status:
+                            return (None, 204)
+                        else:
+                            return (None, 409)
                     else:
-                        return (None, 409)
+                        return ('Recalc is already running on this Area', 422)
                 else:
                     return (call, 501)
             except KeyError:

--- a/madmin/api/resources/ftr_area.py
+++ b/madmin/api/resources/ftr_area.py
@@ -21,6 +21,9 @@ class APIArea(ResourceHandler):
                 args = self.api_req.data.get('args', {})
                 if call == 'recalculate':
                     resource = self._data_manager.get_resource('area', identifier=identifier)
+                    mode = resource['mode']
+                    if mode in ['iv_mitm', 'idle']:
+                        return apiResponse.APIResponse(self._logger, self.api_req)('Unable to recalc mode %s' % (mode,), 422)
                     if resource.recalc_status == 0:
                         status = self._mapping_manager.routemanager_recalcualte(resource.identifier)
                         if status:

--- a/madmin/routes/config.py
+++ b/madmin/routes/config.py
@@ -48,6 +48,7 @@ class config(object):
             ("/settings/routecalc", self.settings_routecalc),
             ("/settings/walker", self.settings_walkers),
             ("/settings/walker/areaeditor", self.settings_walker_area),
+            ("/recalc_status", self.recalc_status),
             ("/reload", self.reload)
         ]
         for route, view_func in routes:
@@ -164,6 +165,15 @@ class config(object):
             return config[mode]
         except KeyError:
             return config
+    @logger.catch
+    @auth_required
+    def recalc_status(self):
+        recalc = []
+        areas = self._data_manager.get_root_resource('area')
+        for area_id, area in areas.items():
+            if area.recalc_status:
+                recalc.append(area_id)
+        return Response(json.dumps(recalc), mimetype='application/json')
 
     @logger.catch
     @auth_required

--- a/madmin/templates/settings_areas.html
+++ b/madmin/templates/settings_areas.html
@@ -151,6 +151,10 @@ $(document).ready(function () {
             <td><button type="button" class="btn btn-info btn-sm"><i class="fa fa-sync"></i></button></td>
             <td>Recalculate route</td>
           </tr>
+          <tr>
+            <td><img src="{{ url_for('static', filename='loading.gif') }}" width="32px" height="32px"/></td>
+            <td>Route recalculation in progress</td>
+          </tr>
           {% endif %}
           <tr>
             <td><button type="button" class="btn btn-success btn-sm"><i class="far fa-edit"></i></button></td>

--- a/madmin/templates/settings_areas.html
+++ b/madmin/templates/settings_areas.html
@@ -20,6 +20,7 @@ $(document).ready(function () {
                         elem.parent().parent().remove();
                         toggleConfiguredElement();
                     }
+                    $.unblockUI();
                 },
                 error: function(data, status, xhr) {
                     if(data.status == 412) {
@@ -32,31 +33,6 @@ $(document).ready(function () {
                     } else {
                         alert('Unable to save the {{ subtab }}.  An unknown error occurred');
                     }
-                }
-            });
-            $.unblockUI();
-        }
-    });
-    $(".recalculate").click(function() {
-        if(confirm('Are you sure you want to recalculate this route?')) {
-            var elem =  $(this);
-            $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Recalculating routefile...</h2>' });
-            rpc_call = {
-              'call': 'recalculate'
-            }
-            $.ajax({
-                url : '{{ url_for('api_area') }}/'+ $(this).data('area'),
-                contentType : 'application/json-rpc',
-                data: JSON.stringify(rpc_call),
-                type : 'POST',
-                success: function(data, status, xhr) {
-                    if(xhr.status == 204) {
-                      alert('Recalculation successfully started');
-                    }
-                    $.unblockUI();
-                },
-                error: function(data, status, xhr) {
-                    alert('Unable to recalculate the area.  Please look at server logs');
                     $.unblockUI();
                 }
             });
@@ -64,7 +40,84 @@ $(document).ready(function () {
     });
     // Toggle on boot
     toggleConfiguredElement();
+    check_recalc_status();
+    setInterval(check_recalc_status, 5000);
   });
+
+  function recalculate_route() {
+    if(confirm('Are you sure you want to recalculate this route?')) {
+        var elem = $(this);
+        $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Recalculating routefile...</h2>' });
+        rpc_call = {
+          'call': 'recalculate'
+        }
+        $.ajax({
+            url : '{{ url_for('api_area') }}/'+ $(this).data('area'),
+            contentType : 'application/json-rpc',
+            data: JSON.stringify(rpc_call),
+            type : 'POST',
+            success: function(data, status, xhr) {
+                if(xhr.status == 204) {
+                  alert('Recalculation successfully started');
+                }
+                $.unblockUI();
+                check_recalc_status();
+            },
+            error: function(data, status, xhr) {
+                alert('Unable to recalculate the area.  Please look at server logs');
+                $.unblockUI();
+                check_recalc_status();
+            }
+        });
+    }
+  }
+
+  function check_recalc_status() {
+    $.ajax({
+        url : '{{ url_for('recalc_status') }}',
+        type : 'GET',
+        success: function(data, status, xhr) {
+            if(xhr.status == 200) {
+              var in_recalc = xhr.responseJSON;
+              $.each($(".area_container"), function () {
+                var area_id = $(this).data('area');
+                var recalc_div = $(this).find(".recalc_div");
+                var recalc_elem = $(this).find(".recalc_disp");
+                var recalc_status = $(recalc_elem).data('recalc');
+                var elem;
+                if(in_recalc.includes(area_id)) {
+                  if(recalc_status == 0 || recalc_status == undefined) {
+                    elem = $(document.createElement("img")).attr({
+                      'src': "{{ url_for('static', filename='loading.gif') }}",
+                      'class': 'recalc_disp',
+                      'data-recalc': 1,
+                      'width': '32px',
+                      'heigth': '30px'
+                    });
+                  }
+                } else {
+                  if(recalc_status == '1' || recalc_status == undefined) {
+                    var fa_img = $(document.createElement("i")).attr({
+                      'class': "fa fa-sync"
+                    });
+                    elem = $(document.createElement("button")).attr({
+                      'class': 'recalc_disp btn btn-info btn-sm',
+                      'data-area': area_id,
+                      'data-recalc': 0,
+                    }).bind('click', recalculate_route).append(fa_img);
+                  }
+                }
+                if(elem) {
+                  recalc_div.empty().append(elem);
+                }
+              });
+            }
+        },
+        error: function(data, status, xhr) {
+            alert('Unable to get recalc status.  Can you reach the server?');
+        }
+    });
+  }
 
   function toggleConfiguredElement() {
     if($(".delete").length == 0) {
@@ -72,7 +125,7 @@ $(document).ready(function () {
     } else {
         $('#no-configured-elements').hide();
     }
-}
+  }
 </script>
 {% endblock %}
 
@@ -141,7 +194,7 @@ $(document).ready(function () {
       {% else %}
       <tbody>
         {% for area_id, area in area.items() %}
-        <tr>
+        <tr class="area_container" data-area='{{area_id}}'>
           <td class="align-middle">
             <a href="{{ url_for('settings_areas', id=area_id, mode=area.area_type) }}">{{ area.name }}</a>
           </td>
@@ -166,7 +219,7 @@ $(document).ready(function () {
           <td class="text-right align-middle">
             <a href="{{ url_for('settings_routecalc') }}?id={{ area.routecalc }}&area_id={{ area_id }}"><button type="button" class="btn btn-success btn-sm edit"><i class="fas fa-route"></i></button></a>
             {% if config_mode == False %}
-              <button data-area='{{ area_id }}' type="button" class="recalculate btn btn-info btn-sm"><i class="fa fa-sync"></i></button>
+              <div class='recalc_div' style='display:inline;'></div>
             {% endif %}
             <a href="{{ redirect }}?id={{ area_id }}&mode={{ area.area_type }}"><button type="button" class="btn btn-success btn-sm edit" data-identifier="{{ loop.index }}"><i class="far fa-edit"></i></button></a>
             <button data-identifier='{{ area_id }}' type="button" class="delete btn btn-danger btn-sm"><i class="fas fa-trash-alt"></i>

--- a/madmin/templates/settings_areas.html
+++ b/madmin/templates/settings_areas.html
@@ -219,7 +219,9 @@ $(document).ready(function () {
           <td class="text-right align-middle">
             <a href="{{ url_for('settings_routecalc') }}?id={{ area.routecalc }}&area_id={{ area_id }}"><button type="button" class="btn btn-success btn-sm edit"><i class="fas fa-route"></i></button></a>
             {% if config_mode == False %}
-              <div class='recalc_div' style='display:inline;'></div>
+              {% if area.area_type not in ['idle', 'iv_mitm'] %}
+                <div class='recalc_div' style='display:inline;'></div>
+              {% endif %}
             {% endif %}
             <a href="{{ redirect }}?id={{ area_id }}&mode={{ area.area_type }}"><button type="button" class="btn btn-success btn-sm edit" data-identifier="{{ loop.index }}"><i class="far fa-edit"></i></button></a>
             <button data-identifier='{{ area_id }}' type="button" class="delete btn btn-danger btn-sm"><i class="fas fa-trash-alt"></i>

--- a/start.py
+++ b/start.py
@@ -151,6 +151,7 @@ if __name__ == "__main__":
     db_wrapper, db_pool_manager = DbFactory.get_wrapper(args)
     instance_id = db_wrapper.get_instance_id()
     data_manager = utils.data_manager.DataManager(db_wrapper, instance_id)
+    data_manager.clear_on_boot()
     version = MADVersion(args, data_manager)
     version.get_version()
 

--- a/utils/data_manager/__init__.py
+++ b/utils/data_manager/__init__.py
@@ -11,6 +11,15 @@ class DataManager(object):
         self.instance_id = instance_id
         self.__paused_devices = []
 
+    def clear_on_boot(self):
+        # This function should handle any on-boot clearing.  It is not initiated by __init__ on the off-chance that
+        # a third-party integration has triggered the data_manager
+        # Clear any route calcs because that thread is not active
+        clear_recalcs = {
+            'recalc_status': 0
+        }
+        self.dbc.autoexec_update('settings_routecalc', clear_recalcs)
+
     def get_resource(self, section, identifier=None, **kwargs):
         if section == 'area':
             return modules.AreaFactory(self, identifier=identifier)

--- a/utils/data_manager/modules/area.py
+++ b/utils/data_manager/modules/area.py
@@ -34,6 +34,9 @@ class Area(resource.Resource):
                 self._data['settings'][field] = val
             else:
                 continue
+        # get route-calc status
+        routecalc = self._data_manager.get_resource('routecalc', self._data['fields']['routecalc'])
+        self.recalc_status = routecalc.recalc_status
 
     def save(self, force_insert=False, ignore_issues=[]):
         has_identifier = True if self.identifier else False

--- a/utils/data_manager/modules/resource.py
+++ b/utils/data_manager/modules/resource.py
@@ -403,7 +403,6 @@ class Resource(object):
 
     @classmethod
     def search(cls, dbc, res_obj, instance_id, *args, **kwargs):
-
         sql = "SELECT `%s`\n"\
               "FROM `%s`\n"\
               "WHERE `instance_id` = %%s"

--- a/utils/data_manager/modules/routecalc.py
+++ b/utils/data_manager/modules/routecalc.py
@@ -98,18 +98,17 @@ class RouteCalc(resource.Resource):
                             route_name: str = 'Unknown'):
         if overwrite_calculation:
             calc_type = 'quick'
+        self.recalc_status = 1
         if in_memory is False:
-            self.recalc_status = 1
             if delete_old_route:
                 self.new_calc = True
                 logger.debug("Deleting routefile...")
                 self._data['fields']['routefile'] = []
-            self.save()
+        self.save()
         new_route = self.getJsonRoute(coords, max_radius, max_coords_within_radius, in_memory, num_processes=num_procs,
                                       algorithm=calc_type, useS2=useS2, S2level=S2level, route_name=route_name)
-        if in_memory is False:
-            self.recalc_status = 0
-            self.save()
+        self.recalc_status = 0
+        self.save()
         return new_route
 
     def getJsonRoute(self, coords, maxRadius, maxCoordsInRadius, in_memory, num_processes=1, algorithm='optimized',


### PR DESCRIPTION
During route recalcuation the UI now displays an icon showing that it is being being recalculated.  The 'areas' page now checks the status every 5 seconds to determine the status of all recalcuatlions fro all areas.  If the route is being recalculated it cannot be triggered again.

The schema for routecalcs has been updated to include the status (recalc_status) which states if the recalculation is running and when the last time the route was re-calculated.  These values are reset on boot since any previously running thread has been ended