### PR TITLE
New Instance Setup + Multi-Instance Conversion

### DIFF
--- a/configmode.py
+++ b/configmode.py
@@ -37,10 +37,6 @@ if __name__ == "__main__":
             'config.ini file not found. Check configs folder and copy example config')
         sys.exit(1)
 
-    filename = args.mappings
-    if not os.path.exists(filename):
-        generate_mappingjson(args.mappings)
-
     create_folder(args.file_path)
     create_folder(args.upload_path)
 

--- a/db/PooledQueryExecutor.py
+++ b/db/PooledQueryExecutor.py
@@ -257,6 +257,8 @@ class PooledQueryExecutor:
         """ get one field for 0, 1, or more rows in a query and return the result in a list
         """
         data = self.execute(sql, args=args, raise_exc=True)
+        if data is None:
+            data = []
         returned_vals = []
         for row in data:
             returned_vals.append(row[0])

--- a/start.py
+++ b/start.py
@@ -145,10 +145,6 @@ def check_dependencies():
 if __name__ == "__main__":
     check_dependencies()
 
-    if not os.path.exists(args.mappings):
-        logger.error("Couldn't find configuration file. Please run 'configmode.py' instead, if this is the first time starting MAD.")
-        sys.exit(1)
-
     # TODO: globally destroy all threads upon sys.exit() for example
     install_thread_excepthook()
 
@@ -193,58 +189,47 @@ if __name__ == "__main__":
         mapping_manager_manager.start()
         mapping_manager: MappingManager = mapping_manager_manager.MappingManager(db_wrapper, args, data_manager, ws_server, False)
         filename = args.mappings
-        if not os.path.exists(filename):
-            logger.error(
-                "No mappings.json found - start madmin with with_madmin in config or copy example")
-            sys.exit(1)
+        if args.only_routes:
+            logger.info("Done calculating routes!")
+            # TODO: shutdown managers properly...
+            sys.exit(0)
 
-            logger.error(
-                "No mappings.json found - starting setup mode with madmin.")
-            logger.error("Open Madmin (ServerIP with Port " +
-                         str(args.madmin_port) + ") - 'Mapping Editor' and restart.")
-            generate_mappingjson()
-        else:
-            if args.only_routes:
-                logger.info("Done calculating routes!")
-                # TODO: shutdown managers properly...
-                sys.exit(0)
+        pogoWindowManager = None
+        jobstatus: dict = {}
+        MitmMapperManager.register('MitmMapper', MitmMapper)
+        mitm_mapper_manager = MitmMapperManager()
+        mitm_mapper_manager.start()
+        mitm_mapper: MitmMapper = mitm_mapper_manager.MitmMapper(mapping_manager, db_wrapper.stats_submit)
 
-            pogoWindowManager = None
-            jobstatus: dict = {}
-            MitmMapperManager.register('MitmMapper', MitmMapper)
-            mitm_mapper_manager = MitmMapperManager()
-            mitm_mapper_manager.start()
-            mitm_mapper: MitmMapper = mitm_mapper_manager.MitmMapper(mapping_manager, db_wrapper.stats_submit)
+        from ocr.pogoWindows import PogoWindows
+        pogoWindowManager = PogoWindows(args.temp_path, args.ocr_thread_count)
 
-            from ocr.pogoWindows import PogoWindows
-            pogoWindowManager = PogoWindows(args.temp_path, args.ocr_thread_count)
+        mitm_receiver_process = MITMReceiver(args.mitmreceiver_ip, int(args.mitmreceiver_port),
+                                             mitm_mapper, args, mapping_manager, db_wrapper)
+        mitm_receiver_process.start()
 
-            mitm_receiver_process = MITMReceiver(args.mitmreceiver_ip, int(args.mitmreceiver_port),
-                                                 mitm_mapper, args, mapping_manager, db_wrapper)
-            mitm_receiver_process.start()
+        logger.info('Starting websocket server on port {}'.format(str(args.ws_port)))
+        ws_server = WebsocketServer(args, mitm_mapper, db_wrapper, mapping_manager, pogoWindowManager)
+        t_ws = Thread(name='scanner', target=ws_server.start_server)
+        t_ws.daemon = False
+        t_ws.start()
 
-            logger.info('Starting websocket server on port {}'.format(str(args.ws_port)))
-            ws_server = WebsocketServer(args, mitm_mapper, db_wrapper, mapping_manager, pogoWindowManager, data_manager)
-            t_ws = Thread(name='scanner', target=ws_server.start_server)
-            t_ws.daemon = False
-            t_ws.start()
+        # init jobprocessor
+        device_Updater = deviceUpdater(ws_server, args, jobstatus)
 
-            # init jobprocessor
-            device_Updater = deviceUpdater(ws_server, args, jobstatus)
+        webhook_worker = None
+        if args.webhook:
+            from webhook.webhookworker import WebhookWorker
 
-            webhook_worker = None
-            if args.webhook:
-                from webhook.webhookworker import WebhookWorker
+            rarity = Rarity(args, db_wrapper)
+            rarity.start_dynamic_rarity()
 
-                rarity = Rarity(args, db_wrapper)
-                rarity.start_dynamic_rarity()
-
-                webhook_worker = WebhookWorker(
-                    args, data_manager, mapping_manager, rarity, db_wrapper.webhook_reader)
-                t_whw = Thread(name="webhook_worker",
-                               target=webhook_worker.run_worker)
-                t_whw.daemon = True
-                t_whw.start()
+            webhook_worker = WebhookWorker(
+                args, data_manager, mapping_manager, rarity, db_wrapper.webhook_reader)
+            t_whw = Thread(name="webhook_worker",
+                           target=webhook_worker.run_worker)
+            t_whw.daemon = True
+            t_whw.start()
 
     if args.statistic:
         if args.only_scan:

--- a/start.py
+++ b/start.py
@@ -209,7 +209,7 @@ if __name__ == "__main__":
         mitm_receiver_process.start()
 
         logger.info('Starting websocket server on port {}'.format(str(args.ws_port)))
-        ws_server = WebsocketServer(args, mitm_mapper, db_wrapper, mapping_manager, pogoWindowManager)
+        ws_server = WebsocketServer(args, mitm_mapper, db_wrapper, mapping_manager, pogoWindowManager, data_manager)
         t_ws = Thread(name='scanner', target=ws_server.start_server)
         t_ws.daemon = False
         t_ws.start()

--- a/utils/convert_mapping.py
+++ b/utils/convert_mapping.py
@@ -11,58 +11,64 @@ save_mapping_file = args.mappings.replace('.json', '_org.json')
 
 def convert_mappings():
 
-    with open(mapping_file) as f:
-        __raw_json = json.load(f)
+    try:
+        with open(mapping_file) as f:
+            __raw_json = json.load(f)
 
-    walker = []
-    walkersetup = []
-    if "walker" not in __raw_json:
-        logger.info("Unconverted mapping file found")
-        logger.info("Saving current file")
-        shutil.copy(mapping_file, save_mapping_file)
-        __raw_json['walker'] = []
-        count = 0
         walker = []
-        exist = {}
+        walkersetup = []
+        if "walker" not in __raw_json:
+            logger.info("Unconverted mapping file found")
+            logger.info("Saving current file")
+            shutil.copy(mapping_file, save_mapping_file)
+            __raw_json['walker'] = []
+            count = 0
+            walker = []
+            exist = {}
 
-        for dev in __raw_json['devices']:
-            logger.info("Converting device {}", str(dev['origin']))
+            for dev in __raw_json['devices']:
+                logger.info("Converting device {}", str(dev['origin']))
 
-            walkersetup = []
-            daytime_area = dev.get('daytime_area', False)
-            nightime_area = dev.get('nighttime_area', False)
-            walkername = str(daytime_area)
-            timer_invert = ""
-            if nightime_area:
-                if (dev.get('switch', False)):
-                    timer_old = dev.get('switch_interval', "['0:00','23:59']")
-                    walkername = walkername + '-' + str(nightime_area)
-                    timer_normal = str(timer_old[0]) + '-' + str(timer_old[1])
-                    timer_invert = str(timer_old[1]) + '-' + str(timer_old[0])
-                    del __raw_json['devices'][count]['switch_interval']
-                    del __raw_json['devices'][count]['switch']
+                walkersetup = []
+                daytime_area = dev.get('daytime_area', False)
+                nightime_area = dev.get('nighttime_area', False)
+                walkername = str(daytime_area)
+                timer_invert = ""
+                if nightime_area:
+                    if (dev.get('switch', False)):
+                        timer_old = dev.get('switch_interval', "['0:00','23:59']")
+                        walkername = walkername + '-' + str(nightime_area)
+                        timer_normal = str(timer_old[0]) + '-' + str(timer_old[1])
+                        timer_invert = str(timer_old[1]) + '-' + str(timer_old[0])
+                        del __raw_json['devices'][count]['switch_interval']
+                        del __raw_json['devices'][count]['switch']
 
-            if len(timer_invert) > 0:
-                walkersetup.append(
-                    {'walkerarea': daytime_area, "walkertype": "period", "walkervalue": timer_invert})
-                walkersetup.append(
-                    {'walkerarea': nightime_area, "walkertype": "period", "walkervalue": timer_normal})
-            else:
-                walkersetup.append(
-                    {'walkerarea': daytime_area, "walkertype": "coords", "walkervalue": ""})
+                if len(timer_invert) > 0:
+                    walkersetup.append(
+                        {'walkerarea': daytime_area, "walkertype": "period", "walkervalue": timer_invert})
+                    walkersetup.append(
+                        {'walkerarea': nightime_area, "walkertype": "period", "walkervalue": timer_normal})
+                else:
+                    walkersetup.append(
+                        {'walkerarea': daytime_area, "walkertype": "coords", "walkervalue": ""})
 
-            if walkername not in exist:
-                walker.append({'walkername': walkername, "setup": walkersetup})
-                exist[walkername] = True
+                if walkername not in exist:
+                    walker.append({'walkername': walkername, "setup": walkersetup})
+                    exist[walkername] = True
 
-            del __raw_json['devices'][count]['daytime_area']
-            del __raw_json['devices'][count]['nighttime_area']
+                del __raw_json['devices'][count]['daytime_area']
+                del __raw_json['devices'][count]['nighttime_area']
 
-            __raw_json['devices'][count]['walker'] = str(walkername)
+                __raw_json['devices'][count]['walker'] = str(walkername)
 
-            count += 1
-        __raw_json['walker'] = walker
+                count += 1
+            __raw_json['walker'] = walker
 
-        with open(mapping_file, 'w') as outfile:
-            json.dump(__raw_json, outfile, indent=4, sort_keys=True)
-            logger.info('Finished converting mapping file')
+            with open(mapping_file, 'w') as outfile:
+                json.dump(__raw_json, outfile, indent=4, sort_keys=True)
+                logger.info('Finished converting mapping file')
+    except IOError:
+        pass
+    except Exception as err:
+        logger.exception('Unknown issue during migration. Exiting')
+        sys.exit(1)

--- a/utils/version.py
+++ b/utils/version.py
@@ -40,15 +40,6 @@ class MADVersion(object):
             self.start_update()
 
     def start_update(self):
-        # BACKUP ALL THE THINGS! if we need to update
-        if self._version != current_version:
-            target = '%s.%s.bk' % (self._application_args.mappings, self._version)
-            try:
-                shutil.copy(self._application_args.mappings, target)
-            except IOError:
-                logger.exception('Unable to clone configuration. Exiting')
-                sys.exit(1)
-
         if self._version < 1:
             logger.info('Execute Update for Version 1')
             # Adding quest_reward for PMSF ALT
@@ -270,114 +261,121 @@ class MADVersion(object):
             old_data = {}
             new_data = {}
             cache = {}
-            target = '%s.bk' % (self._application_args.mappings,)
             try:
+                target = '%s.bk' % (self._application_args.mappings,)
                 shutil.copy(self._application_args.mappings, target)
-            except IOError:
-                logger.exception('Unable to clone configuration. Exiting')
-                sys.exit(1)
-            with open(self._application_args.mappings, 'rb') as fh:
-                old_data = json.load(fh)
-            if ("migrated" in old_data and old_data["migrated"] is True):
-                with open(self._application_args.mappings, 'w') as outfile:
-                    json.dump(old_data, outfile, indent=4, sort_keys=True)
-            else:
-                walkerarea = 'walkerarea'
-                walkerarea_ind = 0
-                for key in update_order:
-                    try:
-                        entries = old_data[key]
-                    except Exception:
-                        entries = []
-                    cache[key] = {}
-                    index = 0
-                    new_data[key] = {
-                        'index': index,
-                        'entries': {}
-                    }
-                    if key == 'walker':
-                        new_data[walkerarea] = {
+                with open(self._application_args.mappings, 'rb') as fh:
+                    old_data = json.load(fh)
+                if ("migrated" in old_data and old_data["migrated"] is True):
+                    with open(self._application_args.mappings, 'w') as outfile:
+                        json.dump(old_data, outfile, indent=4, sort_keys=True)
+                else:
+                    walkerarea = 'walkerarea'
+                    walkerarea_ind = 0
+                    for key in update_order:
+                        try:
+                            entries = old_data[key]
+                        except Exception:
+                            entries = []
+                        cache[key] = {}
+                        index = 0
+                        new_data[key] = {
                             'index': index,
                             'entries': {}
                         }
-
-                    for entry in entries:
-                        if key == 'monivlist':
-                            cache[key][entry['monlist']] = index
-                        if key == 'devicesettings':
-                            cache[key][entry['devicepool']] = index
-                        elif key == 'areas':
-                            cache[key][entry['name']] = index
-                            try:
-                                mon_list = entry['settings']['mon_ids_iv']
-                                if type(mon_list) is list:
-                                    monlist_ind = new_data['monivlist']['index']
-                                    new_data['monivlist']['entries'][index] = {
-                                        'monlist': 'Update List',
-                                        'mon_ids_iv': mon_list
-                                    }
-                                    entry['settings']['mon_ids_iv'] = '/api/monivlist/%s' % (monlist_ind)
-                                    new_data['monivlist']['index'] += 1
-                                else:
-                                    try:
-                                        name = mon_list
-                                        uri = '/api/monivlist/%s' % (cache['monivlist'][name])
-                                        entry['settings']['mon_ids_iv'] = uri
-                                    except Exception:
-                                        # No name match.  Maybe an old record so lets toss it
-                                        del entry['settings']['mon_ids_iv']
-                            except KeyError:
-                                # Monlist is not defined for the area
-                                pass
-                            except Exception:
-                                # No monlist specified
-                                pass
-                        elif key == 'walker':
-                            cache[key][entry['walkername']] = index
-                            valid_areas = []
-                            if 'setup' in entry:
-                                for ind, area in enumerate(entry['setup']):
-                                    try:
-                                        area['walkerarea'] = '/api/area/%s' % (cache['areas'][area['walkerarea']],)
-                                    except KeyError:
-                                        # The area no longer exists.  Remove from the path
-                                        pass
-                                    else:
-                                        new_data[walkerarea]['entries'][walkerarea_ind] = area
-                                        valid_areas.append('/api/walkerarea/%s' % walkerarea_ind)
-                                        walkerarea_ind += 1
-                                entry['setup'] = valid_areas
-                                new_data[walkerarea]['index'] = walkerarea_ind
-                            else:
-                                entry['setup'] = []
-                        elif key == 'devices':
-                            if 'pool' in entry:
+                        if key == 'walker':
+                            new_data[walkerarea] = {
+                                'index': index,
+                                'entries': {}
+                            }
+                        for entry in entries:
+                            if key == 'monivlist':
+                                cache[key][entry['monlist']] = index
+                            if key == 'devicesettings':
+                                cache[key][entry['devicepool']] = index
+                            elif key == 'areas':
+                                cache[key][entry['name']] = index
                                 try:
-                                    entry['pool'] = '/api/devicesetting/%s' % (cache['devicesettings'][entry['pool']],)
+                                    mon_list = entry['settings']['mon_ids_iv']
+                                    if type(mon_list) is list:
+                                        monlist_ind = new_data['monivlist']['index']
+                                        new_data['monivlist']['entries'][index] = {
+                                            'monlist': 'Update List',
+                                            'mon_ids_iv': mon_list
+                                        }
+                                        entry['settings']['mon_ids_iv'] = '/api/monivlist/%s' % (monlist_ind)
+                                        new_data['monivlist']['index'] += 1
+                                    else:
+                                        try:
+                                            name = mon_list
+                                            uri = '/api/monivlist/%s' % (cache['monivlist'][name])
+                                            entry['settings']['mon_ids_iv'] = uri
+                                        except Exception:
+                                            # No name match.  Maybe an old record so lets toss it
+                                            del entry['settings']['mon_ids_iv']
+                                except KeyError:
+                                    # Monlist is not defined for the area
+                                    pass
                                 except Exception:
-                                    if entry['pool'] is not None:
-                                        logger.error('DeviceSettings {} is not valid', entry['pool'])
-                                    del entry['pool']
-                            try:
-                                entry['walker'] = '/api/walker/%s' % (cache['walker'][entry['walker']],)
-                            except Exception:
-                                # The walker no longer exists.  Skip the device
-                                continue
-                        new_data[key]['entries'][index] = entry
-                        index += 1
-                    new_data[key]['index'] = index
+                                    # No monlist specified
+                                    pass
+                            elif key == 'walker':
+                                cache[key][entry['walkername']] = index
+                                valid_areas = []
+                                if 'setup' in entry:
+                                    for ind, area in enumerate(entry['setup']):
+                                        try:
+                                            area['walkerarea'] = '/api/area/%s' % (cache['areas'][area['walkerarea']],)
+                                        except KeyError:
+                                            # The area no longer exists.  Remove from the path
+                                            pass
+                                        else:
+                                            new_data[walkerarea]['entries'][walkerarea_ind] = area
+                                            valid_areas.append('/api/walkerarea/%s' % walkerarea_ind)
+                                            walkerarea_ind += 1
+                                    entry['setup'] = valid_areas
+                                    new_data[walkerarea]['index'] = walkerarea_ind
+>>>>>>> New instance startup fixes
+                                else:
+                                    entry['setup'] = []
+                            elif key == 'devices':
+                                if 'pool' in entry:
+                                    try:
+                                        entry['pool'] = '/api/devicesetting/%s' % (cache['devicesettings'][entry['pool']],)
+                                    except Exception:
+                                        if entry['pool'] is not None:
+                                            logger.error('DeviceSettings {} is not valid', entry['pool'])
+                                        del entry['pool']
+                                try:
+                                    entry['walker'] = '/api/walker/%s' % (cache['walker'][entry['walker']],)
+                                except Exception:
+                                    # The walker no longer exists.  Skip the device
+                                    continue
+                            new_data[key]['entries'][index] = entry
+                            index += 1
+                        new_data[key]['index'] = index
 
-                new_data['migrated'] = True
+                    new_data['migrated'] = True
 
-                with open(self._application_args.mappings, 'w') as outfile:
-                    json.dump(new_data, outfile, indent=4, sort_keys=True)
+                    with open(self._application_args.mappings, 'w') as outfile:
+                        json.dump(new_data, outfile, indent=4, sort_keys=True)
+            except IOError:
+                pass
+            except Exception as err:
+                logger.exception('Unknown issue during migration. Exiting')
+                sys.exit(1)
         if self._version < 15:
-            with open(self._application_args.mappings, 'rb') as fh:
-                settings = json.load(fh)
-            self.__convert_to_id(settings)
-            with open(self._application_args.mappings, 'w') as outfile:
-                json.dump(settings, outfile, indent=4, sort_keys=True)
-
+            try:
+                with open(self._application_args.mappings, 'rb') as fh:
+                    settings = json.load(fh)
+                self.__convert_to_id(settings)
+                with open(self._application_args.mappings, 'w') as outfile:
+                    json.dump(settings, outfile, indent=4, sort_keys=True)
+            except IOError:
+                pass
+            except Exception as err:
+                logger.exception('Unknown issue during migration. Exiting')
+                sys.exit(1)
         if self._version < 16:
             query = (
                 "CREATE TABLE IF NOT EXISTS `trs_visited` ("
@@ -392,124 +390,130 @@ class MADVersion(object):
                 logger.exception("Unexpected error: {}", e)
 
         if self._version < 17:
-            # Goodbye mappings.json, it was nice knowing ya!
-            update_order = ['monivlist', 'auth', 'devicesettings', 'areas', 'walkerarea', 'walker', 'devices']
-            with open(self._application_args.mappings, 'rb') as fh:
-                config_file = json.load(fh)
-            geofences = {}
-            routecalcs = {}
-            conversion_issues = []
-            # A wonderful decision that I made was to start at ID 0 on the previous conversion which causes an issue
-            # with primary keys in MySQL / MariaDB.  Make the required changes to ID's and save the file in-case the
-            # conversion is re-run.  We do not want dupe data in the database
-            cache = {}
-            for section in update_order:
-                for elem_id, elem in config_file[section]['entries'].items():
-                    if section == 'areas':
-                        try:
-                            if int(elem['settings']['mon_ids_iv']) == 0:
-                                elem['settings']['mon_ids_iv'] = cache['monivlist']
-                        except KeyError:
-                            pass
-                    elif section == 'devices':
-                        if int(elem['walker']) == 0:
-                            elem['walker'] = cache['walker']
-                        if 'pool' in elem and elem['pool'] is not None and int(elem['pool']) == 0:
-                            elem['pool'] = cache['devicesettings']
-                    elif section == 'walkerarea':
-                        if int(elem['walkerarea']) == 0:
-                            elem['walkerarea'] = cache['areas']
-                    elif section == 'walker':
-                        setup = []
-                        for walkerarea_id in elem['setup']:
-                            if int(walkerarea_id) != 0:
-                                setup.append(walkerarea_id)
-                                continue
-                            setup.append(cache['walkerarea'])
-                        elem['setup'] = setup
-                entry = None
-                try:
-                    entry = config_file[section]['entries']["0"]
-                except KeyError:
-                    continue
-                cache[section] = str(config_file[section]['index'])
-                config_file[section]['entries'][cache[section]] = entry
-                del config_file[section]['entries']["0"]
-                config_file[section]['index'] += 1
-            if cache:
-                logger.info('One or more resources with ID 0 found.  Converting them off 0 and updating the '\
-                            'mappings.json file.  {}', cache)
-                with open(self._application_args.mappings, 'w') as outfile:
-                    json.dump(config_file, outfile, indent=4, sort_keys=True)
-            # Load the elements into their resources and save to DB
-            for section in update_order:
-                for key, elem in config_file[section]['entries'].items():
-                    logger.debug('Converting {} {}', section, key)
-                    if section == 'areas':
-                        mode = elem['mode']
-                        del elem['mode']
-                        resource = utils.data_manager.modules.MAPPINGS['area'](self.data_manager, mode=mode)
-                        geofence_sections = ['geofence_included', 'geofence_excluded']
-                        for geofence_section in geofence_sections:
+            try:
+                # Goodbye mappings.json, it was nice knowing ya!
+                update_order = ['monivlist', 'auth', 'devicesettings', 'areas', 'walkerarea', 'walker', 'devices']
+                with open(self._application_args.mappings, 'rb') as fh:
+                    config_file = json.load(fh)
+                geofences = {}
+                routecalcs = {}
+                conversion_issues = []
+                # A wonderful decision that I made was to start at ID 0 on the previous conversion which causes an issue
+                # with primary keys in MySQL / MariaDB.  Make the required changes to ID's and save the file in-case the
+                # conversion is re-run.  We do not want dupe data in the database
+                cache = {}
+                for section in update_order:
+                    for elem_id, elem in config_file[section]['entries'].items():
+                        if section == 'areas':
                             try:
-                                geofence = elem[geofence_section]
-                                if type(geofence) is int:
-                                    continue
-                                if geofence and geofence not in geofences:
-                                    try:
-                                        geo_id = self.__convert_geofence(geofence)
-                                        geofences[geofence] = geo_id
-                                        elem[geofence_section] = geofences[geofence]
-                                    except utils.data_manager.dm_exceptions.UpdateIssue as err:
-                                        conversion_issues.append((section, elem_id, err.issues))
-                                else:
-                                    elem[geofence_section] = geofences[geofence]
+                                if int(elem['settings']['mon_ids_iv']) == 0:
+                                    elem['settings']['mon_ids_iv'] = cache['monivlist']
                             except KeyError:
                                 pass
-                        route = '%s.calc' % (elem['routecalc'],)
-                        if type(elem['routecalc']) is str:
-                            if route not in routecalcs:
-                                route_path = os.path.join(self._application_args.file_path, route)
-                                route_resource = self.data_manager.get_resource('routecalc')
-                                stripped_data = []
-                                try:
-                                    with open(route_path, 'rb') as fh:
-                                        for line in fh:
-                                            stripped = line.strip()
-                                            if type(stripped) != str:
-                                                stripped = stripped.decode('utf-8')
-                                            stripped_data.append(stripped)
-                                except IOError as err:
-                                    conversion_issues.append((section, elem_id, err))
-                                    logger.warning('Unable to open %s.  Using empty route' % (route))
-                                route_resource['routefile'] = stripped_data
-                                route_resource.save(force_insert=True)
-                                routecalcs[route] = route_resource.identifier
-                            if route in routecalcs:
-                                elem['routecalc'] = routecalcs[route]
-                    else:
-                        # Lets remove plural from the section
-                        if section == 'devices':
-                            section = 'device'
-                        elif section == 'devicesettings':
-                            section = 'devicepool'
-                        resource = utils.data_manager.modules.MAPPINGS[section](self.data_manager)
-                    # Settings made it into some configs where it should not be.  lets clear those out now
-                    if 'settings' in elem and 'settings' not in resource.configuration:
-                        del elem['settings']
-                    resource.identifier = key
-                    resource.update(elem)
+                        elif section == 'devices':
+                            if int(elem['walker']) == 0:
+                                elem['walker'] = cache['walker']
+                            if 'pool' in elem and elem['pool'] is not None and int(elem['pool']) == 0:
+                                elem['pool'] = cache['devicesettings']
+                        elif section == 'walkerarea':
+                            if int(elem['walkerarea']) == 0:
+                                elem['walkerarea'] = cache['areas']
+                        elif section == 'walker':
+                            setup = []
+                            for walkerarea_id in elem['setup']:
+                                if int(walkerarea_id) != 0:
+                                    setup.append(walkerarea_id)
+                                    continue
+                                setup.append(cache['walkerarea'])
+                            elem['setup'] = setup
+                    entry = None
                     try:
-                        resource.save(force_insert=True, ignore_issues=['unknown'])
-                    except utils.data_manager.dm_exceptions.UpdateIssue as err:
-                        conversion_issues.append((section, key, err.issues))
-                    except Exception as err:
-                        conversion_issues.append((section, key, err))
-            if conversion_issues:
-                logger.error('The configuration was not partially moved to the database.  The following resources '\
-                             'were not converted.')
-                for (section, identifier, issue) in conversion_issues:
-                    logger.error('{} {}: {}', section, identifier, issue)
+                        entry = config_file[section]['entries']["0"]
+                    except KeyError:
+                        continue
+                    cache[section] = str(config_file[section]['index'])
+                    config_file[section]['entries'][cache[section]] = entry
+                    del config_file[section]['entries']["0"]
+                    config_file[section]['index'] += 1
+                if cache:
+                    logger.info('One or more resources with ID 0 found.  Converting them off 0 and updating the '\
+                                'mappings.json file.  {}', cache)
+                    with open(self._application_args.mappings, 'w') as outfile:
+                        json.dump(config_file, outfile, indent=4, sort_keys=True)
+                # Load the elements into their resources and save to DB
+                for section in update_order:
+                    for key, elem in config_file[section]['entries'].items():
+                        logger.debug('Converting {} {}', section, key)
+                        if section == 'areas':
+                            mode = elem['mode']
+                            del elem['mode']
+                            resource = utils.data_manager.modules.MAPPINGS['area'](self.data_manager, mode=mode)
+                            geofence_sections = ['geofence_included', 'geofence_excluded']
+                            for geofence_section in geofence_sections:
+                                try:
+                                    geofence = elem[geofence_section]
+                                    if type(geofence) is int:
+                                        continue
+                                    if geofence and geofence not in geofences:
+                                        try:
+                                            geo_id = self.__convert_geofence(geofence)
+                                            geofences[geofence] = geo_id
+                                            elem[geofence_section] = geofences[geofence]
+                                        except utils.data_manager.dm_exceptions.UpdateIssue as err:
+                                            conversion_issues.append((section, elem_id, err.issues))
+                                    else:
+                                        elem[geofence_section] = geofences[geofence]
+                                except KeyError:
+                                    pass
+                            route = '%s.calc' % (elem['routecalc'],)
+                            if type(elem['routecalc']) is str:
+                                if route not in routecalcs:
+                                    route_path = os.path.join(self._application_args.file_path, route)
+                                    route_resource = self.data_manager.get_resource('routecalc')
+                                    stripped_data = []
+                                    try:
+                                        with open(route_path, 'rb') as fh:
+                                            for line in fh:
+                                                stripped = line.strip()
+                                                if type(stripped) != str:
+                                                    stripped = stripped.decode('utf-8')
+                                                stripped_data.append(stripped)
+                                    except IOError as err:
+                                        conversion_issues.append((section, elem_id, err))
+                                        logger.warning('Unable to open %s.  Using empty route' % (route))
+                                    route_resource['routefile'] = stripped_data
+                                    route_resource.save(force_insert=True)
+                                    routecalcs[route] = route_resource.identifier
+                                if route in routecalcs:
+                                    elem['routecalc'] = routecalcs[route]
+                        else:
+                            # Lets remove plural from the section
+                            if section == 'devices':
+                                section = 'device'
+                            elif section == 'devicesettings':
+                                section = 'devicepool'
+                            resource = utils.data_manager.modules.MAPPINGS[section](self.data_manager)
+                        # Settings made it into some configs where it should not be.  lets clear those out now
+                        if 'settings' in elem and 'settings' not in resource.configuration:
+                            del elem['settings']
+                        resource.identifier = key
+                        resource.update(elem)
+                        try:
+                            resource.save(force_insert=True, ignore_issues=['unknown'])
+                        except utils.data_manager.dm_exceptions.UpdateIssue as err:
+                            conversion_issues.append((section, key, err.issues))
+                        except Exception as err:
+                            conversion_issues.append((section, key, err))
+                if conversion_issues:
+                    logger.error('The configuration was not partially moved to the database.  The following resources '\
+                                 'were not converted.')
+                    for (section, identifier, issue) in conversion_issues:
+                        logger.error('{} {}: {}', section, identifier, issue)
+            except IOError:
+                pass
+            except Exception as err:
+                logger.exception('Unknown issue during migration. Exiting')
+                sys.exit(1)
         if self._version < 18:
             query = (
                 "ALTER TABLE `trs_status` CHANGE `instance` `instance` VARCHAR(50) CHARACTER "

--- a/utils/version.py
+++ b/utils/version.py
@@ -440,12 +440,49 @@ class MADVersion(object):
                                 'mappings.json file.  {}', cache)
                     with open(self._application_args.mappings, 'w') as outfile:
                         json.dump(config_file, outfile, indent=4, sort_keys=True)
+                # For multi-instance we do not want to re-use IDs.  If and ID is reused we need to adjust it and all
+                # foreign keys
+                generate_new_ids = {}
+                for section in update_order:
+                    dm_section = section
+                    if section == 'areas':
+                        dm_section = 'area'
+                    elif section == 'devices':
+                        dm_section = 'device'
+                    elif section == 'devicesettings':
+                        dm_section = 'devicepool'
+                    for elem_id, elem in config_file[section]['entries'].items():
+                        try:
+                            mode = elem['mode']
+                        except:
+                            mode = None
+                        resource_def = self.data_manager.get_resource_def(dm_section, mode=mode)
+                        sql = "SELECT `%s` FROM `%s` WHERE `%s` = %%s AND `instance_id` != %%s"
+                        sql_args = (resource_def.primary_key, resource_def.table, resource_def.primary_key)
+                        sql_format_args = (elem_id, self.data_manager.instance_id)
+                        exists = self.dbwrapper.autofetch_value(sql % sql_args, args=sql_format_args)
+                        if not exists:
+                            continue
+                        logger.info('{} {} already exists and a new ID will be generated', dm_section, elem_id)
+                        if dm_section not in generate_new_ids:
+                            generate_new_ids[dm_section] = {}
+                        generate_new_ids[dm_section][elem_id] = None
                 # Load the elements into their resources and save to DB
                 for section in update_order:
-                    for key, elem in config_file[section]['entries'].items():
+                    dm_section = section
+                    if section == 'areas':
+                        dm_section = 'area'
+                    elif section == 'devices':
+                        dm_section = 'device'
+                    elif section == 'devicesettings':
+                        dm_section = 'devicepool'
+                    for key, elem in copy.deepcopy(config_file[section]['entries']).items():
+                        save_elem = copy.deepcopy(elem)
                         logger.debug('Converting {} {}', section, key)
+                        tmp_mode = None
                         if section == 'areas':
                             mode = elem['mode']
+                            tmp_mode = mode
                             del elem['mode']
                             resource = utils.data_manager.modules.MAPPINGS['area'](self.data_manager, mode=mode)
                             geofence_sections = ['geofence_included', 'geofence_excluded']
@@ -487,16 +524,60 @@ class MADVersion(object):
                                 if route in routecalcs:
                                     elem['routecalc'] = routecalcs[route]
                         else:
-                            # Lets remove plural from the section
-                            if section == 'devices':
-                                section = 'device'
-                            elif section == 'devicesettings':
-                                section = 'devicepool'
-                            resource = utils.data_manager.modules.MAPPINGS[section](self.data_manager)
+                            resource = utils.data_manager.modules.MAPPINGS[dm_section](self.data_manager)
                         # Settings made it into some configs where it should not be.  lets clear those out now
                         if 'settings' in elem and 'settings' not in resource.configuration:
                             del elem['settings']
-                        resource.identifier = key
+                        # Update any IDs that have been converted.  There are no required updates for monivlist, auth,
+                        # or devicesettings as they are not dependent on other resources
+                        # ['monivlist', 'auth', 'devicesettings', 'areas', 'walkerarea', 'walker', 'devices']
+                        if dm_section == 'area':
+                            try:
+                                monlist = elem['settings']['mon_ids_iv']
+                                elem['settings']['mon_ids_iv'] = generate_new_ids['monivlist'][monlist]
+                                save_elem['settings']['mon_ids_iv'] = str(generate_new_ids['monivlist'][monlist])
+                                logger.info('Updating monivlist to area {} to {}', key, elem['settings']['mon_ids_iv'])
+                            except KeyError:
+                                pass
+                        elif dm_section == 'device':
+                            try:
+                                pool_id = elem['pool']
+                                elem['pool'] = generate_new_ids['devicepool'][pool_id]
+                                save_elem['pool'] = str(generate_new_ids['devicepool'][pool_id])
+                                logger.info('Updating device pool from {} to {}', pool_id, elem['pool'])
+                            except KeyError:
+                                pass
+                            try:
+                                walker_id = elem['walker']
+                                elem['walker'] = generate_new_ids['walker'][walker_id]
+                                save_elem['walker'] = str(generate_new_ids['walker'][walker_id])
+                                logger.info('Updating device walker from {} to {}', pool_id, elem['walker'])
+                            except KeyError:
+                                pass
+                        elif dm_section == 'walker':
+                            new_list = []
+                            for walkerarea_id in elem['setup']:
+                                try:
+                                    new_list.append(str(generate_new_ids['walkerarea'][walkerarea_id]))
+                                    logger.info('Updating walker-walkerarea {} to {}', walkerarea_id, new_list[-1])
+                                except KeyError:
+                                    new_list.append(walkerarea_id)
+                            elem['setup'] = new_list
+                            save_elem['setup'] = new_list
+                        elif dm_section == 'walkerarea':
+                            try:
+                                area_id = elem['walkerarea']
+                                elem['walkerarea'] = generate_new_ids['area'][area_id]
+                                save_elem['walkerarea'] = str(generate_new_ids['area'][area_id])
+                                logger.info('Updating walkerarea from {} to {}', area_id, elem['walkerarea'])
+                            except KeyError:
+                                pass
+                        save_new_id = False
+                        try:
+                            generate_new_ids[dm_section][key]
+                            save_new_id = True
+                        except:
+                            resource.identifier = key
                         resource.update(elem)
                         try:
                             resource.save(force_insert=True, ignore_issues=['unknown'])
@@ -504,11 +585,21 @@ class MADVersion(object):
                             conversion_issues.append((section, key, err.issues))
                         except Exception as err:
                             conversion_issues.append((section, key, err))
+                        else:
+                            if save_new_id:
+                                generate_new_ids[dm_section][key] = resource.identifier
+                                config_file[section]['entries'][str(resource.identifier)] = save_elem
+                                del config_file[section]['entries'][key]
+                                if resource.identifier >= int(config_file[section]['index']):
+                                    config_file[section]['index'] = resource.identifier + 1
                 if conversion_issues:
                     logger.error('The configuration was not partially moved to the database.  The following resources '\
                                  'were not converted.')
                     for (section, identifier, issue) in conversion_issues:
                         logger.error('{} {}: {}', section, identifier, issue)
+                if generate_new_ids:
+                    with open(self._application_args.mappings, 'w') as outfile:
+                        json.dump(config_file, outfile, indent=4, sort_keys=True)
             except IOError:
                 pass
             except Exception as err:

--- a/utils/version.py
+++ b/utils/version.py
@@ -335,7 +335,6 @@ class MADVersion(object):
                                             walkerarea_ind += 1
                                     entry['setup'] = valid_areas
                                     new_data[walkerarea]['index'] = walkerarea_ind
->>>>>>> New instance startup fixes
                                 else:
                                     entry['setup'] = []
                             elif key == 'devices':


### PR DESCRIPTION
This PR allows for a new system to be setup from scratch and fixes several issues where multi-instance MAD instances were not converting correctly.

To test the multi-instance conversion:
1)  Convert to DB
2)  Edit config.ini and add status-name and set it to a value other than mad.  If this is already set, change the status name
3)  Roll back version.json to 16.
4)  Re-Run the upgrade.

To clear out from a multi-instance conversion you can run the following queries (where instance_id is from madmin_instance)
DELETE FROM settings_device WHERE instance_id = <instance_id>;
DELETE FROM settings_walker_to_walkerarea WHERE walker_id IN (SELECT walker_id FROM settings_walker WHERE instance_id = <instance_id>);
DELETE FROM settings_walker_to_walkerarea WHERE walkerarea_id IN (SELECT walkerarea_id FROM settings_walkerarea WHERE instance_id = <instance_id>);
DELETE FROM settings_walker WHERE instance_id = <instance_id>;
DELETE FROM settings_walkerarea WHERE instance_id = <instance_id>;
DELETE FROM settings_area WHERE instance_id = <instance_id>;
DELETE FROM settings_monivlist WHERE instance_id = <instance_id>;
DELETE FROM settings_routecalc WHERE instance_id = <instance_id>;
DELETE FROM settings_geofence WHERE instance_id = <instance_id>;
DELETE FROM settings_devicepool WHERE instance_id = <instance_id>;
DELETE FROM settings_auth WHERE instance_id = <instance_id>;