### PR TITLE
QoL updates

### DIFF
--- a/madmin/api/__init__.py
+++ b/madmin/api/__init__.py
@@ -28,13 +28,13 @@ class APIHandler(object):
         _logger: logger (loguru.logger): MADmin debug logger
         _modules (dict): Dictionary of APIHandlers for referring to the other API sections
     """
-    def __init__(self, logger, app, data_manager, mapping_manager, ws_server):
+    def __init__(self, logger, app, data_manager, mapping_manager, ws_server, config_mode):
         self._logger = logger
         self._app = app
         self._modules = {}
         self._app.route(BASE_URI, methods=['GET'])(self.process_request)
         for mod_name, module in valid_modules.items():
-            tmp = module(logger, app, BASE_URI, data_manager, mapping_manager, ws_server)
+            tmp = module(logger, app, BASE_URI, data_manager, mapping_manager, ws_server, config_mode)
             self._modules[tmp.uri_base] = tmp.description
 
     def create_routes(self):

--- a/madmin/api/apiHandler.py
+++ b/madmin/api/apiHandler.py
@@ -25,7 +25,7 @@ class ResourceHandler(object):
     mode = None
     has_rpc_calls = False
 
-    def __init__(self, logger, app, base, data_manager, mapping_manager, ws_server):
+    def __init__(self, logger, app, base, data_manager, mapping_manager, ws_server, config_mode):
         self._logger = logger
         self._app = app
         self._data_manager = data_manager
@@ -33,6 +33,7 @@ class ResourceHandler(object):
         self._ws_server = ws_server
         self._base = base
         self._instance = self._data_manager.instance_id
+        self._config_mode = config_mode
         self.api_req = None
         if self.component:
             self.uri_base = '%s/%s' % (self._base, self.component)

--- a/madmin/api/apiHandler.py
+++ b/madmin/api/apiHandler.py
@@ -275,8 +275,6 @@ class ResourceHandler(object):
             return apiResponse.APIResponse(self._logger, self.api_req)(err.issues, 422)
         except utils.data_manager.UnknownIdentifier:
             return apiResponse.APIResponse(self._logger, self.api_req)(None, 404)
-        except Exception:
-            return apiResponse.APIResponse(self._logger, self.api_req)('', 500)
 
     def delete(self, identifier, *args, **kwargs):
         """ API Call to remove data """

--- a/madmin/api/modules/ftr_area.py
+++ b/madmin/api/modules/ftr_area.py
@@ -19,10 +19,13 @@ class APIArea(apiHandler.ResourceHandler):
                 call = self.api_req.data['call']
                 args = self.api_req.data.get('args', {})
                 if call == 'recalculate':
-                    resource = self._data_manager.get_resource('area', identifier=identifier)
-                    t = threading.Thread(target=self._mapping_manager.routemanager_recalcualte,args=(resource.identifier,))
-                    t.start()
-                    return apiResponse.APIResponse(self._logger, self.api_req)(None, 204)
+                    if not self._config_mode:
+                        resource = self._data_manager.get_resource('area', identifier=identifier)
+                        t = threading.Thread(target=self._mapping_manager.routemanager_recalcualte,args=(resource.identifier,))
+                        t.start()
+                        return apiResponse.APIResponse(self._logger, self.api_req)(None, 204)
+                    else:
+                        return apiResponse.APIResponse(self._logger, self.api_req)(None, 409)
                 else:
                     return apiResponse.APIResponse(self._logger, self.api_req)(call, 501)
             except KeyError:

--- a/madmin/api/modules/ftr_area.py
+++ b/madmin/api/modules/ftr_area.py
@@ -1,5 +1,4 @@
 from .. import apiHandler, apiResponse, apiException
-import threading
 
 class APIArea(apiHandler.ResourceHandler):
     component = 'area'
@@ -19,10 +18,9 @@ class APIArea(apiHandler.ResourceHandler):
                 call = self.api_req.data['call']
                 args = self.api_req.data.get('args', {})
                 if call == 'recalculate':
-                    if not self._config_mode:
-                        resource = self._data_manager.get_resource('area', identifier=identifier)
-                        t = threading.Thread(target=self._mapping_manager.routemanager_recalcualte,args=(resource.identifier,))
-                        t.start()
+                    resource = self._data_manager.get_resource('area', identifier=identifier)
+                    status = self._mapping_manager.routemanager_recalcualte(resource.identifier)
+                    if status:
                         return apiResponse.APIResponse(self._logger, self.api_req)(None, 204)
                     else:
                         return apiResponse.APIResponse(self._logger, self.api_req)(None, 409)

--- a/madmin/api/modules/ftr_area.py
+++ b/madmin/api/modules/ftr_area.py
@@ -20,7 +20,6 @@ class APIArea(apiHandler.ResourceHandler):
                 args = self.api_req.data.get('args', {})
                 if call == 'recalculate':
                     resource = self._data_manager.get_resource('area', identifier=identifier)
-                    print(resource)
                     t = threading.Thread(target=self._mapping_manager.routemanager_recalcualte,args=(resource.identifier,))
                     t.start()
                     return apiResponse.APIResponse(self._logger, self.api_req)(None, 204)

--- a/madmin/madmin.py
+++ b/madmin/madmin.py
@@ -37,7 +37,7 @@ def madmin_start(args, db_wrapper: DbWrapper, ws_server, mapping_manager: Mappin
     statistics(db_wrapper, args, app, mapping_manager, data_manager)
     control(db_wrapper, args, mapping_manager, ws_server, logger, app, deviceUpdater)
     map(db_wrapper, args, mapping_manager, app, data_manager)
-    APIHandler(logger, app, data_manager, mapping_manager, ws_server)
+    APIHandler(logger, app, data_manager, mapping_manager, ws_server, args.config_mode)
     config(db_wrapper, args, logger, app, mapping_manager, data_manager)
     path(db_wrapper, args, app, mapping_manager, jobstatus, data_manager)
 

--- a/madmin/routes/config.py
+++ b/madmin/routes/config.py
@@ -187,6 +187,7 @@ class config(object):
                 'fences': 'geofence'
             },
             'passthrough': {
+                'config_mode': self._args.config_mode,
                 'fences': fences
             },
             'mode_required': True

--- a/madmin/routes/control.py
+++ b/madmin/routes/control.py
@@ -316,6 +316,7 @@ class control(object):
         else:
             temp_comm = self._ws_server.get_origin_communicator(origin)
             temp_comm.reboot()
+        self._ws_server.force_disconnect(origin)
         return redirect(url_for('get_phonescreens'), code=302)
 
     @auth_required

--- a/madmin/routes/control.py
+++ b/madmin/routes/control.py
@@ -129,7 +129,7 @@ class control(object):
                 self._ws_connected_phones.append(adb)
 
             filename = generate_device_screenshot_path(phonename, devicemappings, self._args)
-            if os.path.isfile(filename):
+            try:
                 screenshot_ending: str = ".jpg"
                 image_resize(filename, os.path.join(
                     self._args.temp_path, "madmin"), width=250)
@@ -138,10 +138,15 @@ class control(object):
                     generate_phones(phonename, add_text, adb_option,
                                     screen, filename, self._datetimeformat, dummy=False)
                 )
-            else:
+            except IOError:
                 screen = "static/dummy.png"
                 screens_phone.append(generate_phones(
                     phonename, add_text, adb_option, screen, filename, self._datetimeformat, dummy=True))
+                try:
+                    os.remove(filename)
+                    self._logger.info("Screenshot {} was corrupted and has been deleted", filename)
+                except:
+                    pass
 
         for phonename in self._adb_connect.return_adb_devices():
             if phonename.serial not in self._ws_connected_phones:

--- a/madmin/routes/map.py
+++ b/madmin/routes/map.py
@@ -284,7 +284,7 @@ class map(object):
                 data[i]["encounter_id"] = str(data[i]["encounter_id"])
                 data[i]["name"] = i8ln(mon_raw["name"])
             except Exception:
-                traceback.print_exc()
+                pass
 
         return jsonify(data)
 

--- a/madmin/routes/statistics.py
+++ b/madmin/routes/statistics.py
@@ -507,11 +507,13 @@ class statistics(object):
             try:
                 device['routemanager'] = areas[int(device['routemanager_id'])]['name']
                 device['routemanager_mode'] = areas[int(device['routemanager_id'])]['mode']
-            except (TypeError,ValueError):
-                continue
-            except KeyError:
-                device['routemanager'] = 'Unknown Area %s' % (device['routemanager_id'],)
-                device['routemanager_mode'] = 'Unknown Area %s' % (device['routemanager_id'],)
+            except (TypeError, ValueError, KeyError):
+                if device['routemanager_id'] == 'idle':
+                    device['routemanager'] = 'Idle'
+                    device['routemanager_mode'] = 'idle'
+                else:
+                    device['routemanager'] = 'Unknown Area %s' % (device['routemanager_id'],)
+                    device['routemanager_mode'] = 'Unknown Area %s' % (device['routemanager_id'],)
                 device['routemanager_id'] = -1
             data.append(device)
 

--- a/madmin/static/js/madmin.js
+++ b/madmin/static/js/madmin.js
@@ -1580,7 +1580,7 @@ new Vue({
         var fencename = prompt("Please enter name of fence", "");
         coords = loopCoords(layer.getLatLngs())
         newfences[layer] = fencename
-        layer.bindPopup('<b>' + fencename + '</b><br><a href=savefence?name=' + fencename + '&coords=' + coords + '>Save to MAD</a>');
+        layer.bindPopup('<b>' + fencename + '</b><br><a href=savefence?name=' + encodeURI(fencename) + '&coords=' + coords + '>Save to MAD</a>');
         editableLayers.addLayer(layer);
         layer.openPopup();
     });
@@ -1589,7 +1589,7 @@ new Vue({
         var layers = e.layers;
         layers.eachLayer(function (layer) {
             coords = loopCoords(layer.getLatLngs())
-            layer._popup.setContent('<b>' + newfences[layer] + '</b><br><a href=savefence?name=' + newfences[layer] + '&coords=' + coords + '>Save to MAD</a>')
+            layer._popup.setContent('<b>' + newfences[layer] + '</b><br><a href=savefence?name=' + encodeURI(newfences[layer]) + '&coords=' + coords + '>Save to MAD</a>')
             layer.openPopup();
         });
     });

--- a/madmin/templates/settings_areas.html
+++ b/madmin/templates/settings_areas.html
@@ -139,7 +139,9 @@ $(document).ready(function () {
             </p>
           </td>
           <td class="text-right align-middle">
-            <button data-area='{{ area_id }}' type="button" class="recalculate btn btn-info btn-sm"><i class="fa fa-sync"></i></button>
+            {% if config_mode == False %}
+              <button data-area='{{ area_id }}' type="button" class="recalculate btn btn-info btn-sm"><i class="fa fa-sync"></i></button>
+            {% endif %}
             <a href="{{ redirect }}?id={{ area_id }}&mode={{ area.area_type }}"><button type="button" class="btn btn-success btn-sm edit" data-identifier="{{ loop.index }}"><i class="far fa-edit"></i></button></a>
             <button data-identifier='{{ area_id }}' type="button" class="delete btn btn-danger btn-sm"><i class="fas fa-trash-alt"></i>
           </td>

--- a/mitm_receiver/PlayerStats.py
+++ b/mitm_receiver/PlayerStats.py
@@ -62,15 +62,19 @@ class PlayerStats(object):
     def open_player_stats(self):
         statsfile = Path(os.path.join(
             self.__application_args.file_path, str(self._id) + '.stats'))
-        if not statsfile.is_file():
+        try:
+            with open(os.path.join(self.__application_args.file_path, str(self._id) + '.stats')) as f:
+                data = json.load(f)
+                self.set_level(data[self._id][0]['level'])
+        except IOError:
             logger.error('[{}] - no Statsfile found', str(self._id))
             self.set_level(0)
             return False
-
-        with open(os.path.join(self.__application_args.file_path, str(self._id) + '.stats')) as f:
-            data = json.load(f)
-
-        self.set_level(data[self._id][0]['level'])
+        except json.decoder.JSONDecodeError:
+            logger.error('[{}] - Corrupted JSON file found.  Clearing out the file', str(self._id))
+            os.remove(statsfile)
+            self.set_level(0)
+            return False
 
     def compare_hour(selfs, timestamp):
         if datetime.datetime.fromtimestamp(int(time.time())).strftime('%H') != \

--- a/route/RouteManagerBase.py
+++ b/route/RouteManagerBase.py
@@ -301,9 +301,12 @@ class RouteManagerBase(ABC):
                 self._route.append(Location(coord["lat"], coord["lng"]))
             self._current_route_round_coords = self._route.copy()
             self._current_index_of_route = 0
+        return new_route
 
     def recalc_route_adhoc(self, max_radius: float, max_coords_within_radius: int, num_procs: int = 1):
-        self.recalc_route(max_radius, max_coords_within_radius, num_procs, True)
+        new_route = self.recalc_route(max_radius, max_coords_within_radius, num_procs, in_memory=True)
+        self._route_resource['routefile'] = new_route
+        self._route_resource.save()
         for worker in self._workers_registered:
             self.unregister_worker(worker)
 

--- a/route/RouteManagerBase.py
+++ b/route/RouteManagerBase.py
@@ -312,8 +312,12 @@ class RouteManagerBase(ABC):
             calc_coords.append('%s,%s' % (coord['lat'], coord['lng']))
         self._route_resource['routefile'] = calc_coords
         self._route_resource.save()
-        for worker in self._workers_registered:
-            self.unregister_worker(worker)
+        connected_worker_count = len(self._workers_registered)
+        if connected_worker_count > 0:
+            for worker in self._workers_registered:
+                self.unregister_worker(worker)
+        else:
+            self.stop_routemanager()
 
     def _update_priority_queue_loop(self):
         if self._priority_queue_update_interval() is None or self._priority_queue_update_interval() == 0:

--- a/route/RouteManagerBase.py
+++ b/route/RouteManagerBase.py
@@ -276,22 +276,23 @@ class RouteManagerBase(ABC):
         self.add_coords_numpy(to_be_appended)
 
     def calculate_new_route(self, coords, max_radius, max_coords_within_radius, delete_old_route, num_procs=0, in_memory=False):
-        new_route = self._route_resource.calculate_new_route(coords, max_radius, max_coords_within_radius,
-                                                            delete_old_route, self._calctype, self.useS2, self.S2level,
-                                                            num_procs=0,
-                                                            overwrite_calculation=self._overwrite_calculation,
-                                                            in_memory=in_memory,
-                                                            route_name=self.name)
-        if self._overwrite_calculation:
-            self._overwrite_calculation = False
-        return new_route
+        if coords:
+            new_route = self._route_resource.calculate_new_route(coords, max_radius, max_coords_within_radius,
+                                                                delete_old_route, self._calctype, self.useS2, self.S2level,
+                                                                num_procs=0,
+                                                                overwrite_calculation=self._overwrite_calculation,
+                                                                in_memory=in_memory,
+                                                                route_name=self.name)
+            if self._overwrite_calculation:
+                self._overwrite_calculation = False
+            return new_route
+        return []
 
     def empty_routequeue(self):
         return len(self._current_route_round_coords) > 0
 
     def recalc_route(self, max_radius: float, max_coords_within_radius: int, num_procs: int = 1,
                      delete_old_route: bool = False, in_memory: bool = False):
-
         current_coords = self._coords_unstructured
         new_route = self.calculate_new_route(current_coords, max_radius, max_coords_within_radius,
                                              delete_old_route, num_procs, in_memory=in_memory)
@@ -303,7 +304,8 @@ class RouteManagerBase(ABC):
             self._current_index_of_route = 0
         return new_route
 
-    def recalc_route_adhoc(self, max_radius: float, max_coords_within_radius: int, num_procs: int = 1):
+    def recalc_route_adhoc(self, max_radius: float, max_coords_within_radius: int, num_procs: int = 1,
+        active: bool = False):
         new_route = self.recalc_route(max_radius, max_coords_within_radius, num_procs, in_memory=True)
         calc_coords = []
         for coord in new_route:

--- a/route/RouteManagerBase.py
+++ b/route/RouteManagerBase.py
@@ -100,7 +100,7 @@ class RouteManagerBase(ABC):
                 fenced_coords = self.geofence_helper.get_geofenced_coordinates(
                     coords)
             new_coords = self._route_resource.getJsonRoute(fenced_coords, max_radius, max_coords_within_radius,
-                                                           algorithm=calctype)
+                                                           algorithm=calctype, route_name=self.name)
             for coord in new_coords:
                 self._route.append(Location(coord["lat"], coord["lng"]))
         self._current_index_of_route = 0
@@ -280,7 +280,8 @@ class RouteManagerBase(ABC):
                                                             delete_old_route, self._calctype, self.useS2, self.S2level,
                                                             num_procs=0,
                                                             overwrite_calculation=self._overwrite_calculation,
-                                                            in_memory=in_memory)
+                                                            in_memory=in_memory,
+                                                            route_name=self.name)
         if self._overwrite_calculation:
             self._overwrite_calculation = False
         return new_route

--- a/route/RouteManagerBase.py
+++ b/route/RouteManagerBase.py
@@ -305,7 +305,10 @@ class RouteManagerBase(ABC):
 
     def recalc_route_adhoc(self, max_radius: float, max_coords_within_radius: int, num_procs: int = 1):
         new_route = self.recalc_route(max_radius, max_coords_within_radius, num_procs, in_memory=True)
-        self._route_resource['routefile'] = new_route
+        calc_coords = []
+        for coord in new_route:
+            calc_coords.append('%s,%s' % (coord['lat'], coord['lng']))
+        self._route_resource['routefile'] = calc_coords
         self._route_resource.save()
         for worker in self._workers_registered:
             self.unregister_worker(worker)

--- a/route/routecalc/calculate_route_quick.py
+++ b/route/routecalc/calculate_route_quick.py
@@ -4,7 +4,7 @@ from utils.logging import logger
 from .util import *
 
 
-def route_calc_impl(coords, num_processes=1):
+def route_calc_impl(coords, route_name, num_processes=1):
     less_coords_array = []
     for i in range(len(coords)):
         less_coords_array.append([coords[i][0].item(), coords[i][1].item()])

--- a/tests/api/test_geofences.py
+++ b/tests/api/test_geofences.py
@@ -61,3 +61,20 @@ class APIGeoFence(api_base.APITestBase):
         result.update(payload)
         self.valid_patch(payload, result)
         self.remove_resources()
+
+    def test_invalid_post_fencedata(self):
+        payload = {
+            'fence_type': 'polygon',
+            'fence_data': ['1.00,1.00', '1.00,a']
+        }
+        errors = {"missing": ["name"], "invalid": [['fence_data', 'Must be one coord set per line (float,float)']]}
+        super().invalid_post(payload, errors)
+
+    def test_invalid_patch_fencedata(self):
+        payload = {
+            'fence_type': 'polygon',
+            'fence_data': ['1.00,1.00', '1.00,a']
+        }
+        errors = {"invalid": [['fence_data', 'Must be one coord set per line (float,float)']]}
+        super().invalid_patch(payload, errors)
+        self.remove_resources()

--- a/utils/MappingManager.py
+++ b/utils/MappingManager.py
@@ -310,6 +310,7 @@ class MappingManager:
             else:
                 routemanager._start_routemanager()
                 active = False
+                successful = True
             args=(routemanager._max_radius, routemanager._max_coords_within_radius)
             kwargs = {
                 'num_procs':0,
@@ -317,8 +318,6 @@ class MappingManager:
             }
             t = Thread(target=routemanager.recalc_route_adhoc, args=args, kwargs=kwargs)
             t.start()
-            if len(routemanager._workers_registered) == 0:
-                routemanager.stop_routemanager()
         except Exception as e:
             import traceback
             traceback.print_exc()

--- a/utils/data_manager/modules/device.py
+++ b/utils/data_manager/modules/device.py
@@ -312,3 +312,11 @@ class Device(resource.Resource):
         self.state = 0
         if self._data_manager.is_device_active(self['origin']):
             self.state = 1
+
+    def delete(self):
+        super().delete()
+        del_data = {
+            'instance_id': self.instance_id,
+            'origin': self['origin']
+        }
+        self._dbc.autoexec_delete('trs_status', del_data)

--- a/utils/data_manager/modules/geofence.py
+++ b/utils/data_manager/modules/geofence.py
@@ -1,6 +1,7 @@
 from . import resource
 from .. import dm_exceptions
 import json
+from geofence.geofenceHelper import GeofenceHelper
 
 class GeoFence(resource.Resource):
     table = 'settings_geofence'
@@ -76,3 +77,13 @@ class GeoFence(resource.Resource):
         core_data = self.get_resource()
         core_data['fence_data'] = json.dumps(self._data['fields']['fence_data'])
         super().save(core_data=core_data, force_insert=force_insert, ignore_issues=ignore_issues)
+
+    def presave_validation(self, ignore_issues=[]):
+        issues = {}
+        try:
+            geofence_helper = GeofenceHelper(self, None)
+        except Exception as err:
+            issues = {
+                'invalid': [('fence_data', 'Must be one coord set per line (float,float)')]
+            }
+        super().presave_validation(ignore_issues=ignore_issues, issues=issues)

--- a/utils/data_manager/modules/resource.py
+++ b/utils/data_manager/modules/resource.py
@@ -330,9 +330,8 @@ class Resource(object):
             except TypeError:
                 continue
 
-    def presave_validation(self, ignore_issues=[]):
+    def presave_validation(self, ignore_issues=[], issues={}):
         # Validate required data has been set
-        issues = {}
         top_levels = ['fields', 'settings']
         for top_level in top_levels:
             try:
@@ -411,3 +410,6 @@ class Resource(object):
                 continue
             translated[translations[key]] = val
         return translated
+
+    def validate_data(self):
+        pass

--- a/utils/version.py
+++ b/utils/version.py
@@ -303,7 +303,6 @@ class MADVersion(object):
 
                     for entry in entries:
                         if key == 'monivlist':
-                            print(entry)
                             cache[key][entry['monlist']] = index
                         if key == 'devicesettings':
                             cache[key][entry['devicepool']] = index

--- a/utils/walkerArgs.py
+++ b/utils/walkerArgs.py
@@ -343,7 +343,7 @@ def parseArgs():
     args.log_filename = args.log_filename.replace('<SN>', args.status_name)
 
     args.config_mode = True
-    if sys.argv[0] == 'start.py':
+    if sys.argv[0].split('/')[-1] == 'start.py':
         args.config_mode = False
 
     return args

--- a/utils/walkerArgs.py
+++ b/utils/walkerArgs.py
@@ -342,4 +342,8 @@ def parseArgs():
     args.log_filename = args.log_filename.replace('<sn>', '<SN>')
     args.log_filename = args.log_filename.replace('<SN>', args.status_name)
 
+    args.config_mode = True
+    if sys.argv[0] == 'start.py':
+        args.config_mode = False
+
     return args


### PR DESCRIPTION
- adding a new devices no longer requires a restart of MAD
- Fix for #599 (idle devices not showing on status page)
- Routecalcs
  - Ad-Hoc recalculation does not remove the old calculation until finished
  - Ad-Hoc recalculation is only available when running in start.py  (short-term goal is to deprecate configmode.py once the mapping.json requirement is removed #617 and use a flag to disable workers from connecting)
  - Route recalculation now shows the progress when performing optimized recalcs. The update percentages is tiered based off the number of elements.
  - Recalculation can now occur if the data-manager is in an idle state
- GeoFences
  - Geofences drawn on MADmin map can now include spaces
  - Geofences are validated prior to saving.  This will prevent an invalid GeoFence from crashing MAD 
- Corrupted images no longer prevent DeviceControl from loading.  The corrupted image is removed and DeviceControl displays no screenshot
- Corrupted stats files no longer prevent Unhandled Exceptions with MAD.  The corrupted file is removed and a new one will be generated
- Devices rebooted through MADmin now gracefully disconnect
![image](https://user-images.githubusercontent.com/13160095/71013479-c0dff800-20be-11ea-9da0-0515c28fdc4a.png)
