### PR TITLE
API now supports multi-instance deployments

### DIFF
--- a/utils/data_manager/__init__.py
+++ b/utils/data_manager/__init__.py
@@ -85,7 +85,7 @@ class DataManager(object):
                 resource_def = self.get_resource_def(section, mode=mode)
             except utils.data_manager.dm_exceptions.DataManagerException:
                 resource_def = copy.deepcopy(utils.data_manager.modules.MAPPINGS['area_nomode'])
-        resources = resource_def.search(self.dbc, resource_def, **params)
+        resources = resource_def.search(self.dbc, resource_def, self.instance_id, **params)
         results = collections.OrderedDict()
         for identifier in resources:
             resource = self.get_resource(section, identifier=identifier)

--- a/utils/data_manager/modules/area.py
+++ b/utils/data_manager/modules/area.py
@@ -76,15 +76,16 @@ class Area(resource.Resource):
             raise err
 
     @classmethod
-    def search(cls, dbc, res_obj, *args, **kwargs):
+    def search(cls, dbc, res_obj, instance_id, *args, **kwargs):
         where = ""
-        sql_args = ()
         mode = kwargs.get('mode', None)
+        where = "WHERE `instance_id` = %s"
+        sql_args = [instance_id]
         if mode:
-            where = "WHERE `mode` = %s\n"
-            sql_args = (mode,)
+            where += " AND `mode` = %s\n"
+            sql_args.append(mode)
         sql = "SELECT `%s`\n"\
               "FROM `%s`\n"\
-              "%s"\
+              "%s\n"\
               "ORDER BY `%s` ASC" % (res_obj.primary_key, res_obj.table, where, res_obj.search_field)
-        return dbc.autofetch_column(sql, args=sql_args)
+        return dbc.autofetch_column(sql, args=tuple(sql_args))

--- a/utils/data_manager/modules/resource.py
+++ b/utils/data_manager/modules/resource.py
@@ -397,14 +397,15 @@ class Resource(object):
         return self.identifier
 
     @classmethod
-    def search(cls, dbc, res_obj, *args, **kwargs):
+    def search(cls, dbc, res_obj, instance_id, *args, **kwargs):
 
         sql = "SELECT `%s`\n"\
-              "FROM `%s`"
+              "FROM `%s`\n"\
+              "WHERE `instance_id` = %%s"
         args = (res_obj.primary_key, res_obj.table,)
         if res_obj.search_field is not None:
             sql += "\nORDER BY `%s` ASC" % (res_obj.search_field)
-        return dbc.autofetch_column(sql % args)
+        return dbc.autofetch_column(sql % args, args=(instance_id))
 
     def translate_keys(self, data, operation, translations=None):
         if translations is None:


### PR DESCRIPTION
The old base resources did not support multi-instance systems and caused the API to have unhandled exceptions