### PR TITLE
Fixed an issue where the API was incorrectly reporting issues

### DIFF
--- a/utils/data_manager/modules/geofence.py
+++ b/utils/data_manager/modules/geofence.py
@@ -78,7 +78,7 @@ class GeoFence(resource.Resource):
         core_data['fence_data'] = json.dumps(self._data['fields']['fence_data'])
         super().save(core_data=core_data, force_insert=force_insert, ignore_issues=ignore_issues)
 
-    def presave_validation(self, ignore_issues=[]):
+    def validate_custom(self):
         issues = {}
         try:
             geofence_helper = GeofenceHelper(self, None)
@@ -86,4 +86,4 @@ class GeoFence(resource.Resource):
             issues = {
                 'invalid': [('fence_data', 'Must be one coord set per line (float,float)')]
             }
-        super().presave_validation(ignore_issues=ignore_issues, issues=issues)
+        return issues

--- a/utils/data_manager/modules/resource.py
+++ b/utils/data_manager/modules/resource.py
@@ -330,9 +330,10 @@ class Resource(object):
             except TypeError:
                 continue
 
-    def presave_validation(self, ignore_issues=[], issues={}):
+    def presave_validation(self, ignore_issues=[]):
         # Validate required data has been set
         top_levels = ['fields', 'settings']
+        issues = {}
         for top_level in top_levels:
             try:
                 for key, val in self._data[top_level].issues.items():
@@ -345,6 +346,15 @@ class Resource(object):
                     issues[key] += val
             except KeyError:
                 continue
+        custom_issues = self.validate_custom()
+        if custom_issues:
+            for key, set_issues in custom_issues.items():
+                if key not in issues:
+                    issues[key] = set_issues
+                elif type(set_issues) is list:
+                    issues[key] += set_issues
+                elif type(set_issues) is dict:
+                    issues[key].update(set_issues)
         if issues:
             raise dm_exceptions.UpdateIssue(**issues)
 
@@ -411,5 +421,5 @@ class Resource(object):
             translated[translations[key]] = val
         return translated
 
-    def validate_data(self):
+    def validate_custom(self):
         pass


### PR DESCRIPTION
The implementation of validate the Geofence was causing the API to incorrectly report issues between calls.  This caused error codes to be returned that were not valid and prevented the data from being processed.  All 90 unit-tests pass with this change.
