### PR TITLE
Route calculation on startup is non-blocking

### DIFF
--- a/route/RouteManagerBase.py
+++ b/route/RouteManagerBase.py
@@ -308,6 +308,8 @@ class RouteManagerBase(ABC):
                 }
                 t = Thread(target=self.recalc_route_adhoc, args=args, kwargs=kwargs)
                 t.start()
+        else:
+            self.recalc_route(max_radius, max_coords_within_radius, num_procs=0, delete_old_route=False)
 
     def recalc_route(self, max_radius: float, max_coords_within_radius: int, num_procs: int = 1,
                      delete_old_route: bool = False, in_memory: bool = False, calctype: bool = None):

--- a/route/RouteManagerBase.py
+++ b/route/RouteManagerBase.py
@@ -295,18 +295,19 @@ class RouteManagerBase(ABC):
         return len(self._current_route_round_coords) > 0
 
     def initial_calculation(self, max_radius: float, max_coords_within_radius: int, num_procs: int = 1,
-                     delete_old_route: bool = False, in_memory: bool = False):
-        self.recalc_route(max_radius, max_coords_within_radius, num_procs,
-                          delete_old_route=delete_old_route,
-                          in_memory=in_memory,
-                          calctype='quick')
-        if self._calctype != 'quick':
-            args=(self._max_radius, self._max_coords_within_radius)
-            kwargs = {
-                'num_procs':0
-            }
-            t = Thread(target=self.recalc_route_adhoc, args=args, kwargs=kwargs)
-            t.start()
+                     delete_old_route: bool = False):
+        if not self._route_resource['routefile']:
+            self.recalc_route(max_radius, max_coords_within_radius, num_procs,
+                              delete_old_route=delete_old_route,
+                              in_memory=True,
+                              calctype='quick')
+            if self._calctype != 'quick':
+                args=(self._max_radius, self._max_coords_within_radius)
+                kwargs = {
+                    'num_procs':0
+                }
+                t = Thread(target=self.recalc_route_adhoc, args=args, kwargs=kwargs)
+                t.start()
 
     def recalc_route(self, max_radius: float, max_coords_within_radius: int, num_procs: int = 1,
                      delete_old_route: bool = False, in_memory: bool = False, calctype: bool = None):

--- a/utils/MappingManager.py
+++ b/utils/MappingManager.py
@@ -420,7 +420,7 @@ class MappingManager:
                 max_count_in_radius = mode_mapping[area_true.area_type]["max_count"]
                 if not area.get("init", False):
                     logger.info("Initializing area {}", area["name"])
-                    proc = thread_pool.apply_async(route_manager.recalc_route, args=(max_radius, max_count_in_radius,
+                    proc = thread_pool.apply_async(route_manager.initial_calculation, args=(max_radius, max_count_in_radius,
                                                                                      0, False))
                     areas_procs[area_id] = proc
                 else:


### PR DESCRIPTION
Route calculation is almost non-blocking on boot.  If a route is not calculated it will perform a quick calculation.  Once the quick recalculation is finished a new thread is started to perform ad-hoc recalculation which is non-blocking.

Implementation for #566 