### PR TITLE
RPC Translation issue

### DIFF
--- a/madmin/api/resources/resourceHandler.py
+++ b/madmin/api/resources/resourceHandler.py
@@ -225,7 +225,11 @@ class ResourceHandler(apiHandler.APIHandler):
                     return self.get_resource_data_root(resource_def, resource_info)
                 else:
                     return self.get(identifier, resource_def, resource_info)
-            translated_data = self.translate_data_for_datamanager(self.api_req.data, resource_def)
+            # Only translate the data if this is not a RPC call
+            if flask.request.method == 'POST' and self.api_req.content_type == 'application/json-rpc':
+                translated_data = self.api_req.data
+            else:
+                translated_data = self.translate_data_for_datamanager(self.api_req.data, resource_def)
             if flask.request.method == 'PATCH':
                 return self.patch(identifier, translated_data, resource_def, resource_info)
             elif flask.request.method == 'POST':

--- a/tests/api/test_area.py
+++ b/tests/api/test_area.py
@@ -128,3 +128,16 @@ class APIArea(api_base.APITestBase):
         response = self.api.get(uri)
         self.remove_resources()
         self.assertDictEqual(payload, response.json())
+
+    def test_recalc(self):
+        area_obj = super().create_valid_resource('area')
+        self.api.get('/reload')
+        recalc_payload = {
+            'call': 'recalculate'
+        }
+        headers = {
+            'Content-Type': 'application/json-rpc'
+        }
+        response = self.api.post(area_obj['uri'], json=recalc_payload, headers=headers)
+        self.assertEqual(response.status_code, 204)
+        self.remove_resources()


### PR DESCRIPTION
The API restructuring (#631 ) caused an issue where incoming RPC was being translated into backend objects.  This is not possible and was causing a traceback.

A unit-test has been added to validate RPC functionality moving forward.

-m unittest
...........................................................................................
----------------------------------------------------------------------
Ran 91 tests in 4.527s
