### PR TITLE
Bulk clear level-up data

### DIFF
--- a/madmin/api/resources/ftr_device.py
+++ b/madmin/api/resources/ftr_device.py
@@ -21,6 +21,9 @@ class APIDevice(ResourceHandler):
                         self._mapping_manager.device_set_disabled(origin)
                         self._ws_server.force_disconnect(origin)
                     return (None, 200)
+                elif call == 'flush_level':
+                    resource.flush_level()
+                    return (None, 204)
                 else:
                     return (call, 501)
             except KeyError:

--- a/madmin/routes/control.py
+++ b/madmin/routes/control.py
@@ -71,8 +71,7 @@ class control(object):
             ("/get_all_workers", self.get_all_workers),
             ("/job_for_worker", self.job_for_worker),
             ("/reload_jobs", self.reload_jobs),
-            ("/trigger_research_menu", self.trigger_research_menu),
-            ("/flushlevel", self.flush)
+            ("/trigger_research_menu", self.trigger_research_menu)
         ]
         for route, view_func in routes:
             self._app.route(route, methods=['GET', 'POST'])(view_func)
@@ -557,14 +556,6 @@ class control(object):
 
         flash('Job successfully queued')
         return redirect(url_for('install_status'), code=302)
-
-    @logger.catch
-    @auth_required
-    def flush(self):
-        origin = request.args.get("origin")
-        logger.info('Removing visitation status for {}...', origin)
-        self._db.flush_levelinfo(origin)
-        return redirect(url_for('settings_devices'), code=302)
 
     @auth_required
     @logger.catch()

--- a/madmin/templates/settings_devices.html
+++ b/madmin/templates/settings_devices.html
@@ -7,12 +7,23 @@
 {% block scripts %}
 {{ super() }}
 <script>
-function bulk_update(uri, patch_data) {
+function bulk_patch(uri, patch_data) {
   $.ajax({
       url : uri,
       data : JSON.stringify(patch_data),
       type : 'PATCH',
       contentType : 'application/json'
+  });
+}
+function flush_level(uri, data) {
+  rpc_call = {
+    'call': 'flush_level'
+  }
+  $.ajax({
+      url : uri,
+      contentType : 'application/json-rpc',
+      data: JSON.stringify(rpc_call),
+      type : 'POST'
   });
 }
 $(document).ready(function () {
@@ -21,23 +32,26 @@ $(document).ready(function () {
         var walker_uri = $(this).children("option:selected").attr('name');
         var patch_data = {"walker": walker_uri};
         $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Load...</h2>' });
-        bulk_update(uri, patch_data);
+        bulk_patch(uri, patch_data);
         $.unblockUI();
     });
     $(".bulk_update").change(function() {
       var selected_uri = $(this).children("option:selected").val();
       var devices = $('.bulk_sel:checkbox:checked');
-      if(devices.length > 0 && confirm('Are you sure you want to bulk update walkers?')) {
-        $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Bulk setting walkers</h2>' });
-        var patch_data;
+      if(devices.length > 0 && confirm('Are you sure you want to bulk update?')) {
+        $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Bulk Updating</h2>' });
+        var data = {};
+        var operation = bulk_patch;
         if(selected_uri.indexOf('walker') > 0) {
-          patch_data = {"walker": selected_uri};
+          data = {"walker": selected_uri};
+        } else if(selected_uri.indexOf('pool') > 0) {
+          data = {"pool": selected_uri};
         } else {
-          patch_data = {"pool": selected_uri};
+          operation = flush_level;
         }
         $.each($('.bulk_sel:checkbox:checked'), function() {
           uri = '{{ url_for('api_device') }}/' + $(this).data('identifier');
-          bulk_update(uri, patch_data);
+          operation(uri, data);
         });
         $.unblockUI();
         location.reload();
@@ -186,6 +200,7 @@ $(document).ready(function () {
             {% for pool_id, pool in pools.items() %}
              <option value="{{ url_for('api_devicepool') + '/'+ pool_id|string }}">Set devicepool to {{ pool.devicepool }}</option>
             {% endfor %}
+            <option value='flush_level'>Clear levelup data</option>
           </select>
         </td>
       </tr>

--- a/madmin/templates/settings_singledevice.html
+++ b/madmin/templates/settings_singledevice.html
@@ -14,10 +14,14 @@ $(document).ready(function () {
           return;
         }
         $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Clearing ...</h2>' });
+        rpc_call = {
+          'call': 'flush_level'
+        }
         $.ajax({
-            url : "/flushlevel?origin={{ element.origin }}",
-            type : 'GET',
-            contentType : 'application/json',
+            url : "{{ uri }}",
+            contentType : 'application/json-rpc',
+            data: JSON.stringify(rpc_call),
+            type : 'POST',
             success: function(data, status, xhr) {
               $.unblockUI();
               if(xhr.status < 400)

--- a/tests/api/test_device.py
+++ b/tests/api/test_device.py
@@ -55,3 +55,15 @@ class APIDevice(api_base.APITestBase):
         response = self.api.patch(device_obj['uri'], json=payload)
         self.assertEqual(response.status_code, 204)
         self.remove_resources()
+
+    def test_clear_level(self):
+        payload = {
+            "call": "flush_level"
+        }
+        headers = {
+            'Content-Type': 'application/json-rpc'
+        }
+        device_obj = super().create_valid_resource('device')
+        response = self.api.post(device_obj['uri'], json=payload, headers=headers)
+        self.assertEqual(response.status_code, 204)
+        self.remove_resources()

--- a/utils/data_manager/modules/device.py
+++ b/utils/data_manager/modules/device.py
@@ -1,5 +1,6 @@
 from .. import dm_exceptions
 from . import resource
+from utils.logging import logger
 
 class Device(resource.Resource):
     table = 'settings_device'
@@ -306,6 +307,10 @@ class Device(resource.Resource):
             }
         }
     }
+
+    def flush_level(self):
+        logger.info('Removing visitation status for {}...', self['origin'])
+        self._dbc.flush_levelinfo(self['origin'])
 
     def _load(self):
         super()._load()


### PR DESCRIPTION
Implementation for #628 
Enables bulk-update functionality on the devices page for clearing level-up data.  This functionality has been moved to the API as RPC