### PR TITLE
move internal version from version.json to DB

### DIFF
--- a/db/DbWrapper.py
+++ b/db/DbWrapper.py
@@ -1028,3 +1028,21 @@ class DbWrapper:
             }
             res = self._db_exec.autoexec_insert('madmin_instance', instance_data)
             return res
+
+    def set_mad_version(self, version):
+        query = "INSERT INTO versions (versions.key, val) VALUES('mad_version', {})".format(int(version))
+        res = self.execute(query, commit=True)
+        return res
+
+    def get_mad_version(self):
+        query = "SELECT val FROM versions where versions.key = 'mad_version'"
+        res = self.execute(query)
+        if res:
+            return int(res[0][0])
+        else:
+            return None
+
+    def update_mad_version(self, version):
+        query = "UPDATE versions SET val = '{}' WHERE versions.key = 'mad_version'".format(int(version))
+        res = self.execute(query, commit=True)
+        return res

--- a/db/DbWrapper.py
+++ b/db/DbWrapper.py
@@ -1029,20 +1029,12 @@ class DbWrapper:
             res = self._db_exec.autoexec_insert('madmin_instance', instance_data)
             return res
 
-    def set_mad_version(self, version):
-        query = "INSERT INTO versions (versions.key, val) VALUES('mad_version', {})".format(int(version))
-        res = self.execute(query, commit=True)
-        return res
-
     def get_mad_version(self):
-        query = "SELECT val FROM versions where versions.key = 'mad_version'"
-        res = self.execute(query)
-        if res:
-            return int(res[0][0])
-        else:
-            return None
+        return self.autofetch_value('SELECT val FROM versions where versions.key = %s', args=('mad_version'))
 
     def update_mad_version(self, version):
-        query = "UPDATE versions SET val = '{}' WHERE versions.key = 'mad_version'".format(int(version))
-        res = self.execute(query, commit=True)
-        return res
+        update_data = {
+            'key': 'mad_version',
+            'val': version
+        }
+        return self.autoexec_insert('versions', update_data, optype="ON DUPLICATE")

--- a/utils/version.py
+++ b/utils/version.py
@@ -12,7 +12,7 @@ import copy
 from db.DbWrapper import DbWrapper
 from db.DbSchemaUpdater import DbSchemaUpdater
 
-current_version = 19
+current_version = 20
 
 class MADVersion(object):
 
@@ -34,11 +34,11 @@ class MADVersion(object):
                 with open('version.json') as f:
                     version = json.load(f)
                 self._version = int(version['version'])
-                self.dbwrapper.set_mad_version(self._version)
+                self.dbwrapper.update_mad_version(self._version)
             except FileNotFoundError:
                 logger.warning("Could not find version.json during move to DB"
                         ", will use version 0")
-                self.dbwrapper.set_mad_version(0)
+                self.dbwrapper.update_mad_version(0)
                 self.start_update()
             dbVersion = self.dbwrapper.get_mad_version()
             if dbVersion:
@@ -675,6 +675,13 @@ class MADVersion(object):
                     self.dbwrapper.execute(alter_query, commit=True)
                 except Exception as e:
                     logger.exception("Unexpected error: {}", e)
+
+        if self._version < 20:
+            sql = "ALTER TABLE versions ADD PRIMARY KEY(`key`)"
+            try:
+                self.dbwrapper.execute(sql, commit=True)
+            except Exception as e:
+                logger.exception("Unexpected error: {}", e)
 
         self.set_version(current_version)
 

--- a/utils/version.py
+++ b/utils/version.py
@@ -25,19 +25,36 @@ class MADVersion(object):
         self.instance_id = data_manager.instance_id
 
     def get_version(self):
-        try:
-            # checking mappings.json
-            convert_mappings()
-            with open('version.json') as f:
-                version = json.load(f)
-            self._version = int(version['version'])
-            if int(self._version) < int(current_version):
-                logger.success('Performing update now')
+        # checking mappings.json
+        convert_mappings()
+        dbVersion = self.dbwrapper.get_mad_version()
+        if not dbVersion:
+            logger.warning("Moving internal MAD version to database")
+            try:
+                with open('version.json') as f:
+                    version = json.load(f)
+                self._version = int(version['version'])
+                self.dbwrapper.set_mad_version(self._version)
+            except FileNotFoundError:
+                logger.warning("Could not find version.json during move to DB"
+                        ", will use version 0")
+                self.dbwrapper.set_mad_version(0)
                 self.start_update()
-                logger.success('Updates finished')
-        except FileNotFoundError:
-            self.set_version(0)
+            dbVersion = self.dbwrapper.get_mad_version()
+            if dbVersion:
+                logger.success("Moved internal MAD version to database "
+                        "as version {}", dbVersion)
+            else:
+                logger.error("Moving internal MAD version to DB failed!")
+        else:
+            logger.info("Internal MAD version in DB is {}", dbVersion)
+            self._version = int(dbVersion)
+
+        if int(self._version) < int(current_version):
+            logger.warning('Performing updates from version {} to {} now',
+                    self._version, current_version)
             self.start_update()
+            logger.success('Updates to version {} finished', self._version)
 
     def start_update(self):
         if self._version < 1:
@@ -662,9 +679,8 @@ class MADVersion(object):
         self.set_version(current_version)
 
     def set_version(self, version):
-        output = {'version': version}
-        with open('version.json', 'w') as outfile:
-            json.dump(output, outfile)
+        self.dbwrapper.update_mad_version(version)
+        self._version = version
 
     def __convert_geofence(self, path):
         stripped_data = []


### PR DESCRIPTION
resolves #625 (also resolves #443 😃 ) and should enable multi-instance, multi-DB from a single MAD directory.

As we've pretty much moved everything possible into the database now, it's just logical to make this change.

Tested locally by playing around with the `current_version` value in `utils/version.py` and looking at the log outputs and database and subsequently moved to my production instances without any apparent issues.

Please notify or edit especially if there's any issue with the changes to `db/DbWrapper.py` - it seems to work but I'm not sure if it's correctly implemented within the system of `db/` files and classes/methods.