### PR TITLE
Check mainscreen before clearing box

### DIFF
--- a/worker/WorkerQuests.py
+++ b/worker/WorkerQuests.py
@@ -435,6 +435,11 @@ class WorkerQuests(MITMBase):
         logger.info('Cleanup Box')
         not_allow = ('Gift', 'Geschenk', 'Glücksei', 'Glucks-Ei', 'Glücks-Ei', 'Lucky Egg', 'CEuf Chance',
                      'Cadeau', 'Appareil photo', 'Wunderbox', 'Mystery Box', 'Boîte Mystère')
+        reached_main_menu = self._check_pogo_main_screen(10, True)
+                if not reached_main_menu:
+                    if not self._restart_pogo(mitm_mapper=self._mitm_mapper):
+                        # TODO: put in loop, count up for a reboot ;)
+                        raise InternalStopWorkerException
         x, y = self._resocalc.get_close_main_button_coords(self)[0], self._resocalc.get_close_main_button_coords(self)[
             1]
         self._communicator.click(int(x), int(y))

--- a/worker/WorkerQuests.py
+++ b/worker/WorkerQuests.py
@@ -436,10 +436,10 @@ class WorkerQuests(MITMBase):
         not_allow = ('Gift', 'Geschenk', 'Glücksei', 'Glucks-Ei', 'Glücks-Ei', 'Lucky Egg', 'CEuf Chance',
                      'Cadeau', 'Appareil photo', 'Wunderbox', 'Mystery Box', 'Boîte Mystère')
         reached_main_menu = self._check_pogo_main_screen(10, True)
-                if not reached_main_menu:
-                    if not self._restart_pogo(mitm_mapper=self._mitm_mapper):
-                        # TODO: put in loop, count up for a reboot ;)
-                        raise InternalStopWorkerException
+        if not reached_main_menu:
+            if not self._restart_pogo(mitm_mapper=self._mitm_mapper):
+                # TODO: put in loop, count up for a reboot ;)
+                raise InternalStopWorkerException
         x, y = self._resocalc.get_close_main_button_coords(self)[0], self._resocalc.get_close_main_button_coords(self)[
             1]
         self._communicator.click(int(x), int(y))


### PR DESCRIPTION
Sometimes the worker thinks it's clearing items while really, it is just turning the map because it closed the team rocket dialog instead of opening the communicator menu.

clear_box assumes that it's on the mainscreen when it starts and this PR adds a check for that.

Haven't had it get stuck since making this change.