### PR TITLE
Added raid costume support to db and webhook

### DIFF
--- a/db/DbPogoProtoSubmit.py
+++ b/db/DbPogoProtoSubmit.py
@@ -506,12 +506,12 @@ class DbPogoProtoSubmit:
         now = datetime.utcfromtimestamp(time.time()).strftime("%Y-%m-%d %H:%M:%S")
 
         query_raid = (
-            "INSERT INTO raid (gym_id, level, spawn, start, end, pokemon_id, cp, move_1, move_2, last_scanned, form, is_exclusive, gender) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
+            "INSERT INTO raid (gym_id, level, spawn, start, end, pokemon_id, cp, move_1, move_2, last_scanned, form, is_exclusive, gender, costume) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
             "ON DUPLICATE KEY UPDATE level=VALUES(level), spawn=VALUES(spawn), start=VALUES(start), "
             "end=VALUES(end), pokemon_id=VALUES(pokemon_id), cp=VALUES(cp), move_1=VALUES(move_1), "
             "move_2=VALUES(move_2), last_scanned=VALUES(last_scanned), is_exclusive=VALUES(is_exclusive), "
-            "form=VALUES(form), gender=VALUES(gender)"
+            "form=VALUES(form), gender=VALUES(gender), costume=VALUES(costume)"
         )
 
         for cell in cells:
@@ -525,6 +525,7 @@ class DbPogoProtoSubmit:
                         move_2 = gym["gym_details"]["raid_info"]["raid_pokemon"]["move_2"]
                         form = gym["gym_details"]["raid_info"]["raid_pokemon"]["display"]["form_value"]
                         gender = gym["gym_details"]["raid_info"]["raid_pokemon"]["display"]["gender_value"]
+                        costume = gym["gym_details"]["raid_info"]["raid_pokemon"]["display"]["costume_value"]
                     else:
                         pokemon_id = None
                         cp = 0
@@ -532,6 +533,7 @@ class DbPogoProtoSubmit:
                         move_2 = 2
                         form = None
                         gender = None
+                        costume = None
 
                     raidendSec = int(gym["gym_details"]["raid_info"]["raid_end"] / 1000)
                     raidspawnSec = int(gym["gym_details"]["raid_info"]["raid_spawn"] / 1000)
@@ -563,7 +565,8 @@ class DbPogoProtoSubmit:
                             pokemon_id, cp, move_1, move_2, now,
                             form,
                             is_exclusive,
-                            gender
+                            gender,
+                            costume
                         )
                     )
         self._db_exec.executemany(query_raid, raid_args, commit=True)

--- a/db/DbSchemaUpdater.py
+++ b/db/DbSchemaUpdater.py
@@ -165,6 +165,11 @@ class DbSchemaUpdater:
             "ctype": "tinyint(1) NULL"
         },
         {
+            "table": "raid",
+            "column": "costume",
+            "ctype": "tinyint(1) NULL"
+        },
+        {
             "table": "gym",
             "column": "is_ex_raid_eligible",
             "ctype": "tinyint(1) NOT NULL DEFAULT 0"

--- a/db/DbWebhookReader.py
+++ b/db/DbWebhookReader.py
@@ -17,7 +17,7 @@ class DbWebhookReader:
         query = (
             "SELECT raid.gym_id, raid.level, raid.spawn, raid.start, raid.end, raid.pokemon_id, "
             "raid.cp, raid.move_1, raid.move_2, raid.last_scanned, raid.form, raid.is_exclusive, raid.gender, "
-            "gymdetails.name, gymdetails.url, gym.latitude, gym.longitude, "
+            "raid.costume, gymdetails.name, gymdetails.url, gym.latitude, gym.longitude, "
             "gym.team_id, weather_boosted_condition, gym.is_ex_raid_eligible "
             "FROM raid "
             "LEFT JOIN gymdetails ON gymdetails.gym_id = raid.gym_id "
@@ -30,7 +30,7 @@ class DbWebhookReader:
         ret = []
         for (gym_id, level, spawn, start, end, pokemon_id,
                 cp, move_1, move_2, last_scanned, form, is_exclusive, gender,
-                name, url, latitude, longitude, team_id,
+                costume, name, url, latitude, longitude, team_id,
                 weather_boosted_condition, is_ex_raid_eligible) in res:
             ret.append({
                 "gym_id": gym_id,
@@ -52,7 +52,8 @@ class DbWebhookReader:
                 "weather_boosted_condition": weather_boosted_condition,
                 "is_exclusive": is_exclusive,
                 "gender": gender,
-                "is_ex_raid_eligible": is_ex_raid_eligible
+                "is_ex_raid_eligible": is_ex_raid_eligible,
+                "costume": costume
             })
         return ret
 

--- a/webhook/webhookworker.py
+++ b/webhook/webhookworker.py
@@ -356,6 +356,9 @@ class WebhookWorker:
             if raid["gender"] is not None:
                 raid_payload["gender"] = raid["gender"]
 
+            if raid["costume"] is not None:
+                raid_payload["costume"] = raid["costume"]
+
             # create final message
             entire_payload = {"type": "raid", "message": raid_payload}
 


### PR DESCRIPTION
Added costume support for webhook type "raid" which is supported by other receivers.
Also modified files to create db column and pick up information to fill the needed data.

This additional costume information for raids is useful for the currently costumed raids.