### PR TITLE
Initial development of MADmin hosted APKs

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -1,18 +1,39 @@
 {
-	"Readout RGC Version":
-	[
-		{
-			"TYPE": "jobType.PASSTHROUGH",
-		    "SYNTAX": "dumpsys package de.grennith.rgc.remotegpscontroller | grep versionName",
-			"FIELDNAME": "RGC_Version"
-	    }
+    "Readout RGC Version":
+    [
+        {
+            "TYPE": "jobType.PASSTHROUGH",
+            "SYNTAX": "dumpsys package de.grennith.rgc.remotegpscontroller | grep versionName",
+            "FIELDNAME": "RGC_Version"
+        }
     ],
-	"Readout Pogodroid Version":
-	[
-		{
-			"TYPE": "jobType.PASSTHROUGH",
-		    "SYNTAX": "dumpsys package com.mad.pogodroid | grep versionName",
-			"FIELDNAME": "POGODROID_Version"
-	    }
+    "Readout Pogodroid Version":
+    [
+        {
+            "TYPE": "jobType.PASSTHROUGH",
+            "SYNTAX": "dumpsys package com.mad.pogodroid | grep versionName",
+            "FIELDNAME": "POGODROID_Version"
+        }
+    ],
+    "Smart Update - PoGo":
+    [
+        {
+            "TYPE": "jobType.SMART_UPDATE",
+            "SYNTAX": "com.nianticlabs.pokemongo"
+        }
+    ],
+    "Smart Update - PogoDroid":
+    [
+        {
+            "TYPE": "jobType.SMART_UPDATE",
+            "SYNTAX": "com.mad.pogodroid"
+        }
+    ],
+    "Smart Update - RGC":
+    [
+        {
+            "TYPE": "jobType.SMART_UPDATE",
+            "SYNTAX": "de.grennith.rgc.remotegpscontroller"
+        }
     ]
 }

--- a/configmode.py
+++ b/configmode.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
 
     jobstatus: dict = {}
 
-    device_Updater = deviceUpdater(ws_server, args, jobstatus)
+    device_Updater = deviceUpdater(ws_server, args, jobstatus, db_wrapper)
 
     logger.success(
         'Starting MADmin on port {} - Open a browser, visit MADmin and go to "Settings"', int(args.madmin_port))

--- a/db/DbSanityCheck.py
+++ b/db/DbSanityCheck.py
@@ -7,7 +7,14 @@ class DbSanityCheck:
 
     def __init__(self, db_exec: PooledQueryExecutor):
         self._db_exec: PooledQueryExecutor = db_exec
+        self.failing_issues = False
+        self.supports_apks = False
 
+    def check_all(self):
+        self.ensure_correct_sql_mode()
+        self.validate_max_allowed_packet()
+        if self.failing_issues:
+            sys.exit(1)
 
     def ensure_correct_sql_mode(self):
         """
@@ -25,4 +32,15 @@ class DbSanityCheck:
             logger.error("Please drop those settings: {}.", ", ".join(detected_wrong_modes))
             logger.error(
                 "More info: https://mad-docs.readthedocs.io/en/latest/common-issues/faq/#sql-mode-error-mysql-strict-mode-mysql-mode")
-            sys.exit(1)
+            self.failing_issues = True
+
+    def validate_max_allowed_packet(self):
+        query = "SELECT @@global.max_allowed_packet"
+        res = self._db_exec.autofetch_value(query)
+        # Not sure what a good number is.  Based on the current size 150MB seems reasonable for APK size
+        if res < 1024*1024*150:
+            logger.error("max_allowed_packet may need to be adjusted to use the MAD APK feature")
+            logger.error("MAD will function without this being set but you will be unable to upload and server MAD APK files")
+            logger.error("More info can be found @ https://dev.mysql.com/doc/refman/8.0/en/program-variables.html")
+        else:
+            self.supports_apks = True

--- a/db/DbSanityCheck.py
+++ b/db/DbSanityCheck.py
@@ -1,6 +1,7 @@
 import sys
 from utils.logging import logger
 from db.PooledQueryExecutor import PooledQueryExecutor
+from utils import global_variables
 
 class DbSanityCheck:
     blacklisted_modes = "NO_ZERO_DATE NO_ZERO_IN_DATE ONLY_FULL_GROUP_BY"
@@ -37,10 +38,9 @@ class DbSanityCheck:
     def validate_max_allowed_packet(self):
         query = "SELECT @@global.max_allowed_packet"
         res = self._db_exec.autofetch_value(query)
-        # Not sure what a good number is.  Based on the current size 150MB seems reasonable for APK size
-        if res < 1024*1024*150:
+        if res < global_variables.CHUNK_MAX_SIZE:
             logger.error("max_allowed_packet may need to be adjusted to use the MAD APK feature")
-            logger.error("MAD will function without this being set but you will be unable to upload and server MAD APK files")
+            logger.error("MAD will function without this being set but you will be unable to upload and serve MAD APK files")
             logger.error("More info can be found @ https://dev.mysql.com/doc/refman/8.0/en/program-variables.html")
         else:
             self.supports_apks = True

--- a/db/DbWrapper.py
+++ b/db/DbWrapper.py
@@ -26,7 +26,8 @@ class DbWrapper:
         self.application_args = args
 
         self.sanity_check: DbSanityCheck = DbSanityCheck(db_exec)
-        self.sanity_check.ensure_correct_sql_mode()
+        self.sanity_check.check_all()
+        self.supports_apks = self.sanity_check.supports_apks
 
         self.schema_updater: DbSchemaUpdater = DbSchemaUpdater(db_exec, args.dbname)
         self.schema_updater.ensure_unversioned_tables_exist()

--- a/db/PooledQueryExecutor.py
+++ b/db/PooledQueryExecutor.py
@@ -250,7 +250,7 @@ class PooledQueryExecutor:
         # TODO - Force LIMIT 1
         data = self.execute(sql, args=args, get_dict=True, raise_exc=True)
         if not data or len(data) == 0:
-            return data
+            return {}
         return data[0]
 
     def autofetch_column(self, sql, args=None):

--- a/madmin/api/__init__.py
+++ b/madmin/api/__init__.py
@@ -1,3 +1,4 @@
+from .apks import *
 from .resources import *
 from .import apiRequest, apiResponse
 import collections
@@ -13,7 +14,9 @@ valid_resources = {
     'monivlist': ftr_monlist.APIMonList,
     'routecalc': ftr_routecalc.APIRouteCalc,
     'walker': ftr_walker.APIWalker,
-    'walkerarea': ftr_walkerarea.APIWalkerArea
+    'walkerarea': ftr_walkerarea.APIWalkerArea,
+    # MAD APKs
+    'mad_apks': ftr_mad_apks.APIMadAPK,
 }
 
 class APIEntry(object):

--- a/madmin/api/apiHandler.py
+++ b/madmin/api/apiHandler.py
@@ -2,7 +2,6 @@ import flask
 from madmin.functions import auth_required
 from . import apiResponse, apiRequest, apiException, global_variables
 import utils.data_manager
-import traceback
 
 
 class APIHandler(object):
@@ -22,6 +21,7 @@ class APIHandler(object):
         self._app = app
         self._base = api_base
         self._data_manager = data_manager
+        self.dbc = self._data_manager.dbc
         self._mapping_manager = mapping_manager
         self._ws_server = ws_server
         self._instance = self._data_manager.instance_id
@@ -63,6 +63,8 @@ class APIHandler(object):
         try:
             self.api_req()
             processed_data = self.process_request(*args, **kwargs)
+            if type(processed_data) is flask.Response:
+                return processed_data
             response_data = processed_data[0]
             status_code = processed_data[1]
             try:

--- a/madmin/api/apiHandler.py
+++ b/madmin/api/apiHandler.py
@@ -36,6 +36,7 @@ class APIHandler(object):
         """
         pass
 
+    @auth_required
     def process_request(self, *args, **kwargs):
         """
         Define how to process the API request.  args and kwargs will be populated based off the route requirements
@@ -47,7 +48,6 @@ class APIHandler(object):
         """
         return (None, 501)
 
-    @auth_required
     def entrypoint(self, *args, **kwargs):
         """ Processes an API request
 

--- a/madmin/api/apiRequest.py
+++ b/madmin/api/apiRequest.py
@@ -48,6 +48,8 @@ class APIRequest(object):
                 self.data['call']
             except (ValueError, KeyError):
                 raise apiException.FormattingError('Invalid RPC definition')
+        elif self.content_type == 'application/octet-stream':
+            self.data = data
 
     def process_request(self):
         # Determine the content-type of the request and convert accordingly

--- a/madmin/api/apks/__init__.py
+++ b/madmin/api/apks/__init__.py
@@ -1,0 +1,3 @@
+__all__ = [
+    'ftr_mad_apks'
+] 

--- a/madmin/api/apks/apkHandler.py
+++ b/madmin/api/apks/apkHandler.py
@@ -1,6 +1,5 @@
 import flask
 from .. import apiHandler
-from madmin.functions import auth_required
 
 class APKHandler(apiHandler.APIHandler):
     component = None
@@ -30,7 +29,6 @@ class APKHandler(apiHandler.APIHandler):
     # =====================================
     # ========= API Functionality =========
     # =====================================
-    @auth_required
     def process_request(self, *args, **kwargs):
         """ Processes an API request
         Args:

--- a/madmin/api/apks/apkHandler.py
+++ b/madmin/api/apks/apkHandler.py
@@ -1,5 +1,6 @@
 import flask
 from .. import apiHandler
+from utils import global_variables
 
 class APKHandler(apiHandler.APIHandler):
     component = None
@@ -12,12 +13,11 @@ class APKHandler(apiHandler.APIHandler):
         self._app.route('/api/mad_apk',
                         methods=['GET'],
                         endpoint='api_madapk')(self.entrypoint)
-        apks = ['pogo', 'rgc', 'pogodroid']
         self._app.route('/api/mad_apk/<string:apk_type>',
                         methods=['GET'],
                         endpoint='api_madapk_apk_type')(self.entrypoint)
         self._app.route('/api/mad_apk/<string:apk_type>/<string:apk_arch>',
-                        methods=['GET', 'POST', 'DELETE', 'PUT'],
+                        methods=['GET', 'POST', 'DELETE'],
                         endpoint='api_madapk_apk_type_arch')(self.entrypoint)
         self._app.route('/api/mad_apk/<string:apk_type>/<string:apk_arch>/download',
                         methods=['GET'],
@@ -39,8 +39,35 @@ class APKHandler(apiHandler.APIHandler):
         """
         # Begin processing the request
         try:
-            apk_type = kwargs.get('apk_type', None)
-            apk_arch = kwargs.get('apk_arch', None)
+            try:
+                apk_type = kwargs.get('apk_type', None)
+                apk_type = int(apk_type)
+            except:
+                pass
+            try:
+                apk_arch = kwargs.get('apk_arch', None)
+                apk_arch = int(apk_arch)
+            except:
+                pass
+                #apk_arch = global_variables.MAD_APK_ARCH_NOARCH
+            if apk_type and isinstance(apk_type, str):
+                if apk_type == 'pogo':
+                    apk_type = global_variables.MAD_APK_USAGE_POGO
+                elif apk_type == 'rgc':
+                    apk_type = global_variables.MAD_APK_USAGE_RGC
+                elif apk_type == 'pogodroid':
+                    apk_type = global_variables.MAD_APK_USAGE_PD
+                else:
+                    return (None, 404)
+            if apk_arch and isinstance(apk_arch, str):
+                if apk_arch == 'armeabi-v7a':
+                    apk_arch = global_variables.MAD_APK_ARCH_ARMEABI_V7A
+                elif apk_arch == 'arm64-v8a':
+                    apk_arch = global_variables.MAD_APK_ARCH_ARM64_V8A
+                elif apk_arch == 'noarch':
+                    apk_arch = global_variables.MAD_APK_ARCH_NOARCH
+                else:
+                    global_variables.MAD_APK_ARCH_NOARCH
             if flask.request.method == 'GET':
                 return self.get(apk_type=apk_type, apk_arch=apk_arch)
             elif flask.request.method == 'DELETE':

--- a/madmin/api/apks/apkHandler.py
+++ b/madmin/api/apks/apkHandler.py
@@ -1,0 +1,56 @@
+import flask
+from .. import apiHandler
+from madmin.functions import auth_required
+
+class APKHandler(apiHandler.APIHandler):
+    component = None
+    iterable = True
+    default_sort = None
+    has_rpc_calls = False
+
+    def create_routes(self):
+        """ Creates all pertinent routes to for the API resource """
+        self._app.route('/api/mad_apk',
+                        methods=['GET'],
+                        endpoint='api_madapk')(self.entrypoint)
+        apks = ['pogo', 'rgc', 'pogodroid']
+        self._app.route('/api/mad_apk/<string:apk_type>',
+                        methods=['GET'],
+                        endpoint='api_madapk_apk_type')(self.entrypoint)
+        self._app.route('/api/mad_apk/<string:apk_type>/<string:apk_arch>',
+                        methods=['GET', 'POST', 'DELETE', 'PUT'],
+                        endpoint='api_madapk_apk_type_arch')(self.entrypoint)
+        self._app.route('/api/mad_apk/<string:apk_type>/<string:apk_arch>/download',
+                        methods=['GET'],
+                        endpoint='api_madapk_apk_download_arch')(self.entrypoint)
+        self._app.route('/api/mad_apk/<string:apk_type>/download',
+                        methods=['GET'],
+                        endpoint='api_madapk_apk_download_noarch')(self.entrypoint)
+
+    # =====================================
+    # ========= API Functionality =========
+    # =====================================
+    @auth_required
+    def process_request(self, *args, **kwargs):
+        """ Processes an API request
+        Args:
+            endpoint(str): Useless identifier to allow Flask to use a generic function signature
+            identifier(str): Identifier for the object to interact with
+        Returns:
+            Flask.Response
+        """
+        # Begin processing the request
+        try:
+            apk_type = kwargs.get('apk_type', None)
+            apk_arch = kwargs.get('apk_arch', None)
+            if flask.request.method == 'GET':
+                return self.get(apk_type=apk_type, apk_arch=apk_arch)
+            elif flask.request.method == 'DELETE':
+                return self.delete(apk_type=apk_type, apk_arch=apk_arch)
+            elif flask.request.method == 'POST':
+                data = self.post(apk_type=apk_type, apk_arch=apk_arch)
+                return data
+        except:
+            import traceback
+            traceback.print_exc()
+            return (None, 404) 

--- a/madmin/api/apks/apkHandler.py
+++ b/madmin/api/apks/apkHandler.py
@@ -11,7 +11,7 @@ class APKHandler(apiHandler.APIHandler):
     def create_routes(self):
         """ Creates all pertinent routes to for the API resource """
         self._app.route('/api/mad_apk',
-                        methods=['GET'],
+                        methods=['GET', 'POST'],
                         endpoint='api_madapk')(self.entrypoint)
         self._app.route('/api/mad_apk/<string:apk_type>',
                         methods=['GET'],

--- a/madmin/api/apks/ftr_mad_apks.py
+++ b/madmin/api/apks/ftr_mad_apks.py
@@ -1,0 +1,78 @@
+# TODO - Move POST / PUT from routes/apk to here
+from .apkHandler import APKHandler
+import utils.apk_util
+import flask
+import io
+from utils import global_variables
+import tempfile
+import apkutils
+from utils.logging import logger
+
+class APIMadAPK(APKHandler):
+    component = 'mad_apk'
+    default_sort = None
+    description = 'GET/Delete MAD APKs'
+    uri_base = 'mad_apk'
+
+    def allowed_file(self, filename):
+        return '.' in filename and filename.rsplit('.', 1)[1].lower() in global_variables.MAD_APK_ALLOWED_EXTENSIONS
+
+    def get_apk_list(self, apk_type, apk_arch):
+        apks = utils.apk_util.get_mad_apks(self.dbc)
+        try:
+            apks[apk_type]
+            try:
+                if apks[apk_type][apk_arch]['version'] != None:
+                    return (apks[apk_type][apk_arch], 200)
+                else:
+                    return ('MAD APK for %s has not been uploaded' % (apk_type,), 404)
+            except:
+                if apk_arch:
+                    return ('Invalid arch_type.  Valid arch_types: %s' % apks[apk_type].keys(), 404)
+                elif len(apks[apk_type]) == 1:
+                    key = list(apks[apk_type].keys())[0]
+                    if apks[apk_type][key]['version'] != None:
+                        return (apks[apk_type][key], 200)
+                    return ('MAD APK for %s has not been uploaded' % (apk_type,), 404)
+                else:
+                    return (apks[apk_type], 200)
+        except:
+            if apk_type:
+                return ('Invalid apk_type.  Valid apk_types: %s' % apks.keys(), 404)
+            else:
+                return (apks, 200)
+
+    def get(self, apk_type, apk_arch):
+        apks = self.get_apk_list(apk_type, apk_arch)
+        if flask.request.url.split('/')[-1] == 'download':
+            try:
+                if(apks[1]) == 200:
+                    file_id = apks[0]['file_id']
+                    sql = 'SELECT * FROM `filestore` WHERE `id` = %s'
+                    db_data = self.dbc.autofetch_row(sql, args=(file_id,))
+                    data = io.BytesIO(db_data['data'])
+                    data.seek(0,0)
+                    return flask.send_file(data, as_attachment=True, attachment_filename=db_data['filename'])
+                else:
+                    return apks
+            except (KeyError, TypeError):
+                return (None, 404)
+            return apks
+        else:
+            return apks
+
+    def post(self, apk_type, apk_arch):
+        return (None, 500)
+
+    def delete(self, apk_type, apk_arch):
+        if apk_type is None:
+            return (None, 404)
+        try:
+            file_data = self.get(apk_type, apk_arch)[0]
+            del_data = {
+                'id': file_data['file_id']
+            }
+            self.dbc.autoexec_delete('filestore', del_data)
+            return (None, 202)
+        except KeyError:
+            return (None, 404)

--- a/madmin/api/apks/ftr_mad_apks.py
+++ b/madmin/api/apks/ftr_mad_apks.py
@@ -93,6 +93,13 @@ class APIMadAPK(APKHandler):
                     return (None, 204)
                 except TypeError:
                     return (None, 404)
+            elif call == 'search_download':
+                downloader = utils.apk_util.AutoDownloader(self.dbc)
+                try:
+                    downloader.apk_all_actions()
+                    return (None, 204)
+                except TypeError:
+                    return (None, 404)
             else:
                 # RPC not implemented
                 return (call, 501)

--- a/madmin/api/global_variables.py
+++ b/madmin/api/global_variables.py
@@ -7,5 +7,6 @@ DEFAULT_HEADERS = {
 # These conversions need to be defined in .apiHandler.apiRequest.parse_data and .apiResponse.APIResponse.convert_to_format
 SUPPORTED_FORMATS = [
     'application/json',
-    'application/json-rpc'
+    'application/json-rpc',
+    'application/octet-stream'
 ]

--- a/madmin/functions.py
+++ b/madmin/functions.py
@@ -13,6 +13,21 @@ from pathlib import Path
 
 mapping_args = parseArgs()
 
+def auth_madmin():
+        username = getattr(mapping_args, 'madmin_user', '')
+        password = getattr(mapping_args, 'madmin_password', '')
+        quests_pub_enabled = getattr(mapping_args, 'quests_public', False)
+
+        if not username:
+            return True
+        if quests_pub_enabled and func.__name__ in ['get_quests', 'quest_pub', 'pushAssets']:
+            return True
+        if request.authorization:
+            if (request.authorization.username == username) and (
+                    request.authorization.password == password):
+                return True
+        return False
+
 def auth_required(func):
     @wraps(func)
     def decorated(*args, **kwargs):
@@ -20,15 +35,10 @@ def auth_required(func):
         password = getattr(mapping_args, 'madmin_password', '')
         quests_pub_enabled = getattr(mapping_args, 'quests_public', False)
 
-        if not username:
+        if auth_madmin():
             return func(*args, **kwargs)
-        if quests_pub_enabled and func.__name__ in ['get_quests', 'quest_pub', 'pushAssets']:
-            return func(*args, **kwargs)
-        if request.authorization:
-            if (request.authorization.username == username) and (
-                    request.authorization.password == password):
-                return func(*args, **kwargs)
-        return make_response('Could not verify!', 401, {'WWW-Authenticate': 'Basic realm="Login Required"'})
+        else:
+            return make_response('Could not verify!', 401, {'WWW-Authenticate': 'Basic realm="Login Required"'})
 
     return decorated
 

--- a/madmin/madmin.py
+++ b/madmin/madmin.py
@@ -15,6 +15,7 @@ from madmin.routes.control import control
 from madmin.routes.map import map
 from madmin.routes.config import config
 from madmin.routes.path import path
+from madmin.routes.apks import apk_manager
 from madmin.api import APIEntry
 from madmin.reverseproxy import ReverseProxied
 
@@ -45,6 +46,7 @@ def madmin_start(args, db_wrapper: DbWrapper, ws_server, mapping_manager: Mappin
     APIEntry(logger, app, data_manager, mapping_manager, ws_server, args.config_mode)
     config(db_wrapper, args, logger, app, mapping_manager, data_manager)
     path(db_wrapper, args, app, mapping_manager, jobstatus, data_manager)
+    apk_manager(db_wrapper, args, app, mapping_manager, jobstatus)
 
     app.logger.removeHandler(default_handler)
     logging.basicConfig(handlers=[InterceptHandler()], level=0)

--- a/madmin/routes/apks.py
+++ b/madmin/routes/apks.py
@@ -1,13 +1,11 @@
-from flask import (send_from_directory, render_template, request, jsonify, redirect, url_for, flash)
+from flask import (send_from_directory, render_template, request, jsonify, redirect, url_for, flash, Response)
 from madmin.functions import (auth_required, get_quest_areas)
 from utils.functions import (generate_path)
 from utils.MappingManager import MappingManager
 from utils.logging import logger
-import utils.apk_util
-from werkzeug.utils import secure_filename
+from utils import apk_util
 from utils import global_variables
-import apkutils
-import os
+import json
 
 class apk_manager(object):
     def __init__(self, db, args, app, mapping_manager: MappingManager, deviceUpdater):
@@ -22,6 +20,7 @@ class apk_manager(object):
         routes = [
             ("/apk", self.mad_apks),
             ("/apk_upload", self.upload_file, ['POST']),
+            ("/apk_update_status", self.apk_update_status),
         ]
         for route_def in routes:
             if len(route_def) == 2:
@@ -33,10 +32,35 @@ class apk_manager(object):
 
     def allowed_file(self, filename):
         return '.' in filename and filename.rsplit('.', 1)[1].lower() in global_variables.MAD_APK_ALLOWED_EXTENSIONS
+
+    def apk_update_status(self):
+        update_info = {}
+        sql = "SELECT `usage`, `arch`, `version`, `download_status`, `last_checked`\n"\
+              "FROM `mad_apk_autosearch`"
+        autosearch_data = self._db.autofetch_all(sql)
+        for row in autosearch_data:
+            composite_key = '%s_%s' % (row['usage'], row['arch'])
+            update_info[composite_key] = {}
+            sql = "SELECT ma.`version`, fm.`size`\n"\
+                  "FROM `mad_apks` ma\n"\
+                  "INNER JOIN `filestore_meta` fm ON fm.`filestore_id` = ma.`filestore_id`\n"\
+                  "WHERE ma.`usage` = %s AND ma.`arch` = %s"
+            curr_info = self._db.autofetch_row(sql, args=(row['usage'], row['arch']))
+            if row['download_status'] != 0:
+                update_info[composite_key]['download_status'] = row['download_status']
+            if row['usage'] == global_variables.MAD_APK_USAGE_POGO:
+                if not curr_info or apk_util.is_newer_version(row['version'], curr_info['version']):
+                    update_info[composite_key]['update'] = 1
+            else:
+                if not curr_info or int(curr_info['size']) != int(row['version']):
+                    update_info[composite_key]['update'] = 1
+            if not update_info[composite_key]:
+                del update_info[composite_key]
+        return Response(json.dumps(update_info), mimetype='application/json')
     
     @auth_required
     def mad_apks(self):
-        apks = utils.apk_util.get_mad_apks(self._db, front_end=True)
+        apks = apk_util.get_mad_apks(self._db)
         return render_template('madmin_apk_root.html', apks=apks)
 
     @auth_required
@@ -54,54 +78,10 @@ class apk_manager(object):
                     flash('File extension not allowed')
                     return redirect(url_for('mad_apks'))
                 if apk_upload and self.allowed_file(apk_upload.filename):
-                    filename = secure_filename(apk_upload.filename)
                     apk_type = global_variables.MAD_APK_USAGE[request.form['apk_type']]
                     apk_arch = global_variables.MAD_APK_ARCH[request.form['apk_arch']]
-                    # Temporarily save the file so we can do our version processing
-                    try:
-                        apk = apkutils.APK(apk_upload)
-                        version = apk.get_manifest()['@android:versionName']
-                        apk_upload.seek(0,0)
-                        logger.info('New APK uploaded for {} {} [{}]', request.form['apk_type'],
-                                                                       request.form['apk_arch'],
-                                                                       version)
-                        # Determine if we already have this file-type uploaded.  If so, remove it once the new one is
-                        # completed and update the id
-                        filestore_id_sql = "SELECT `filestore_id` FROM `mad_apks` WHERE `usage` = %s AND `arch` = %s"
-                        filestore_id = self._db.autofetch_value(filestore_id_sql, args=(apk_type, apk_arch,))
-                        if filestore_id:
-                            delete_data = {
-                                'filestore_id': filestore_id
-                            }
-                            self._db.autoexec_delete('filestore_meta', delete_data)
-                        apk_upload.seek(0, os.SEEK_END)
-                        file_length = apk_upload.tell()
-                        insert_data = {
-                            'filename': filename,
-                            'size': file_length,
-                            'mimetype': apk_upload.content_type,
-                        }
-                        new_id = self._db.autoexec_insert('filestore_meta', insert_data)
-                        insert_data = {
-                            'filestore_id': new_id,
-                            'usage': apk_type,
-                            'arch': apk_arch,
-                            'version': version,
-                        }
-                        self._db.autoexec_insert('mad_apks', insert_data)
-                        apk_upload.seek(0,0)
-                        while True:
-                            chunked_data = apk_upload.read(global_variables.CHUNK_MAX_SIZE)
-                            if not chunked_data:
-                                break
-                            insert_data = {
-                                'filestore_id': new_id,
-                                'size': len(chunked_data),
-                                'data': chunked_data
-                            }
-                            self._db.autoexec_insert('filestore_chunks', insert_data)
-                    except Exception as err:
-                        logger.exception('Unable to save the apk', exc_info=True)
+                    apk_util.MADAPKImporter(self._db, apk_upload.filename, apk_upload, apk_upload.content_type,
+                                            apk_type = apk_type, architecture = apk_arch, mad_apk = True)
                     return redirect(url_for('mad_apks'))
             except:
                 logger.exception('Unhandled exception occurred with the MAD APK', exc_info=True)

--- a/madmin/routes/apks.py
+++ b/madmin/routes/apks.py
@@ -36,7 +36,7 @@ class apk_manager(object):
     
     @auth_required
     def mad_apks(self):
-        apks = utils.apk_util.get_mad_apks(self._db)
+        apks = utils.apk_util.get_mad_apks(self._db, front_end=True)
         return render_template('madmin_apk_root.html', apks=apks)
 
     @auth_required

--- a/madmin/routes/apks.py
+++ b/madmin/routes/apks.py
@@ -1,0 +1,105 @@
+from flask import (send_from_directory, render_template, request, jsonify, redirect, url_for, flash)
+from madmin.functions import (auth_required, get_quest_areas)
+from utils.functions import (generate_path)
+from utils.MappingManager import MappingManager
+from utils.logging import logger
+import utils.apk_util
+from werkzeug.utils import secure_filename
+from utils import global_variables
+import apkutils
+import os
+import tempfile
+
+class apk_manager(object):
+    def __init__(self, db, args, app, mapping_manager: MappingManager, deviceUpdater):
+        self._db = db
+        self._args = args
+        self._app = app
+        self._mapping_manager = mapping_manager
+        self._deviceUpdater = deviceUpdater
+        self.add_route()
+
+    def add_route(self):
+        routes = [
+            ("/apk", self.mad_apks),
+            ("/apk_upload", self.upload_file, ['POST']),
+        ]
+        for route_def in routes:
+            if len(route_def) == 2:
+                route, view_func = route_def
+                self._app.route(route)(view_func)
+            elif len(route_def) == 3:
+                route, view_func, methods = route_def
+                self._app.route(route, methods=methods)(view_func)
+
+    def allowed_file(self, filename):
+        return '.' in filename and filename.rsplit('.', 1)[1].lower() in global_variables.MAD_APK_ALLOWED_EXTENSIONS
+    
+    @auth_required
+    def mad_apks(self):
+        apks = utils.apk_util.get_mad_apks(self._db)
+        return render_template('madmin_apk_root.html', apks=apks)
+
+    @auth_required
+    def upload_file(self):
+        if request.method == 'POST':
+            try:
+                if len(request.files) == 0:
+                    flash('No selected file')
+                    return redirect(url_for('mad_apks'))
+                apk_upload = request.files['apk']
+                if apk_upload.filename == '':
+                    flash('No selected file')
+                    return redirect(url_for('mad_apks'))
+                if not self.allowed_file(apk_upload.filename):
+                    flash('File extension not allowed')
+                    return redirect(url_for('mad_apks'))
+                if apk_upload and self.allowed_file(apk_upload.filename):
+                    filename = secure_filename(apk_upload.filename)
+                    filepath = os.path.join(tempfile.gettempdir(), filename)
+                    apk_type = global_variables.MAD_APK_USAGE[request.form['apk_type']]
+                    apk_arch = global_variables.MAD_APK_ARCH[request.form['apk_arch']]
+                    # Temporarily save the file so we can do our version processing
+                    try:
+                        apk_upload.save(filepath)
+                        apk = apkutils.APK(filepath)
+                        version = apk.get_manifest()['@android:versionName']
+                        apk_upload.seek(0,0)
+                        data = apk_upload.read()
+                        logger.info('New APK uploaded for {} {} [{}]', request.form['apk_type'],
+                                                                       request.form['apk_arch'],
+                                                                       version)
+                        apk_upload.seek(0,0)
+                        # Determine if we already have this file-type uploaded.  If so, remove it once the new one is
+                        # completed and update the id
+                        filestore_id_sql = "SELECT `id` FROM `mad_apks` WHERE `usage` = %s AND `arch` = %s"
+                        filestore_id = self._db.autofetch_value(filestore_id_sql, args=(apk_type, apk_arch,))
+                        if filestore_id:
+                            delete_data = {
+                                'id': filestore_id
+                            }
+                            self._db.autoexec_delete('filestore', delete_data)
+                        insert_data = {
+                            'filename': filename,
+                            'data': apk_upload.read()
+                        }
+                        new_id = self._db.autoexec_insert('filestore', insert_data)
+                        insert_data = {
+                            'id': new_id,
+                            'usage': apk_type,
+                            'arch': apk_arch,
+                            'version': version,
+                        }
+                        self._db.autoexec_insert('mad_apks', insert_data)
+                    except Exception as err:
+                        logger.exception('Unable to save the apk', exc_info=True)
+                    finally:
+                        try:
+                            os.unlink(filepath)
+                        except:
+                            pass
+                    return redirect(url_for('mad_apks'))
+            except:
+                import traceback
+                traceback.print_exc()
+        return redirect(url_for('mad_apks'))

--- a/madmin/routes/apks.py
+++ b/madmin/routes/apks.py
@@ -5,6 +5,7 @@ from utils.MappingManager import MappingManager
 from utils.logging import logger
 from utils import apk_util
 from utils import global_variables
+import werkzeug.exceptions
 import json
 
 class apk_manager(object):
@@ -83,6 +84,9 @@ class apk_manager(object):
                     apk_util.MADAPKImporter(self._db, apk_upload.filename, apk_upload, apk_upload.content_type,
                                             apk_type = apk_type, architecture = apk_arch, mad_apk = True)
                     return redirect(url_for('mad_apks'))
+            except werkzeug.exceptions.RequestEntityTooLarge:
+                flash('File too large.  Please use a a smaller file')
+                return redirect(url_for('mad_apks'))
             except:
                 logger.exception('Unhandled exception occurred with the MAD APK', exc_info=True)
         return redirect(url_for('mad_apks'))

--- a/madmin/templates/base.html
+++ b/madmin/templates/base.html
@@ -78,6 +78,14 @@
                       <a href="{{ url_for('reload_jobs') }}" class="dropdown-item">Reload existing Jobs</a>
                     </div>
                   </li>
+                  <li class="nav-item dropdown">
+                      <a class="nav-link dropdown-toggle" href="system" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        System
+                    </a>
+                      <div class="dropdown-menu"i aria-labelledby="navbarDropdown">
+                      <a href="{{ url_for('mad_apks') }}" class="dropdown-item">MADmin APKs</a>
+                    </div>
+                  </li>
               </ul>
               <button type="button" class="btn btn-success btn-sm nav-link text-uppercase font-weight-bold" id="reload">Apply settings</a>
           </div>

--- a/madmin/templates/madmin_apk_root.html
+++ b/madmin/templates/madmin_apk_root.html
@@ -193,7 +193,10 @@
     <div class="col">
         <div class="card border-secondary">
             <div class="card-body py-2">
-                <p class="card-text">This section allows you to easily manage the required APKs for running MAD.</p>
+                <p class="card-text"><center><b>BETA FEATURE</b></center>
+                    <br>The current implementation is using the DB to store the files it will evict some DB cache as it pushes updates to devices.  Performance has not been benchmarked around this feature.
+                    <br>This section allows you to easily manage the required APKs for running MAD.
+                </p>
             </div>
         </div>
     </div>

--- a/madmin/templates/madmin_apk_root.html
+++ b/madmin/templates/madmin_apk_root.html
@@ -5,11 +5,13 @@
 
 {% block scripts %}
 <script>
+  $(document).ready(function () {
     $('.upload').on('click', function() {
         $("#apk_type").val($(this).data('apk_type'));
         $("#apk_arch").val($(this).data('apk_arch'));
-        if($(this).data('apk_type') != undefined && $(this).data('apk_arch') != undefined)
+        if($(this).data('apk_type') != undefined && $(this).data('apk_arch') != undefined) {
             $('#file-input').trigger('click');
+        }
     });
     $('#file-input').on('change', function () {
         $("#upload_form").submit();
@@ -77,7 +79,6 @@
         success: function(data, status, xhr) {
             if(xhr.status == 200) {
               var apk_status = xhr.responseJSON;
-              console.log(apk_status);
               $.each($(".update_status"), function () {
                 var apk_type = $(this).data('apk_type');
                 var apk_arch = $(this).data('apk_arch');
@@ -153,7 +154,6 @@
             });
         }
     }
-$(document).ready(function () {
     check_apk_status();
     setInterval(check_apk_status, 5000);
   });

--- a/madmin/templates/madmin_apk_root.html
+++ b/madmin/templates/madmin_apk_root.html
@@ -8,10 +8,12 @@
     $('.upload').on('click', function() {
         $("#apk_type").val($(this).data('apk_type'));
         $("#apk_arch").val($(this).data('apk_arch'));
-        $('#file-input').trigger('click');
+        if($(this).data('apk_type') != undefined && $(this).data('apk_arch') != undefined)
+            $('#file-input').trigger('click');
     });
     $('#file-input').on('change', function () {
-        $("#upload_form").submit()
+        $("#upload_form").submit();
+        $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Uploading APK...</h2>' });
     }).click();
 
     $(".delete").click(function() {

--- a/madmin/templates/madmin_apk_root.html
+++ b/madmin/templates/madmin_apk_root.html
@@ -46,6 +46,32 @@
         }
     });
 
+    $(".bulk_update").click(function() {
+        if(confirm('Are you sure you want to Update and Download this APK?')) {
+            $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Bulk Updating...</h2>' });
+            rpc_call = {
+              'call': 'search_download'
+            }
+            $.ajax({
+                contentType : 'application/json-rpc',
+                url : '{{ url_for('api_madapk') }}',
+                data: JSON.stringify(rpc_call),
+                type : 'POST',
+                success: function(data, status, xhr) {
+                    if(xhr.status == 204) {
+                        location.reload();
+                    }
+                    $.unblockUI();
+                },
+                error: function(data, status, xhr) {
+                    alert('Unable to delete the APK.  An unknown error occurred');
+                    $.unblockUI();
+                    location.reload();
+                },
+            });
+        }
+    });
+
     $(".delete").click(function() {
         if(confirm('Are you sure you want to delete this APK?')) {
             var elem =  $(this);
@@ -154,6 +180,7 @@
             });
         }
     }
+
     check_apk_status();
     setInterval(check_apk_status, 5000);
   });
@@ -171,6 +198,16 @@
         </div>
     </div>
 </div>
+{% with messages = get_flashed_messages() %}
+  {% if messages %}
+    <ul class=flashes>
+    {% for message in messages %}
+      <li>{{ message }}</li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endwith %}
+{% block body %}{% endblock %}
 <div class="row mt-3">
     <div class="col">
         <table class="table table-striped table-hover table-sm">
@@ -202,6 +239,9 @@
                 {% endfor %}
             </tbody>
         </table>
+        <div align="right">
+            Update Everything -><button class="bulk_update btn btn-info btn-sm"><i class="fas fa-3x fa-hat-wizard"></i></button>
+        </div>
     </div>
 </div>
 <div style='display: none;'>

--- a/madmin/templates/madmin_apk_root.html
+++ b/madmin/templates/madmin_apk_root.html
@@ -1,0 +1,92 @@
+{% extends "base.html" %}
+
+{% block header %}
+{% endblock %}
+
+{% block scripts %}
+<script>
+    $('.upload').on('click', function() {
+        $("#apk_type").val($(this).data('apk_type'));
+        $("#apk_arch").val($(this).data('apk_arch'));
+        $('#file-input').trigger('click');
+    });
+    $('#file-input').on('change', function () {
+        $("#upload_form").submit()
+    }).click();
+
+    $(".delete").click(function() {
+        if(confirm('Are you sure you want to delete this APK?')) {
+            var elem =  $(this);
+            $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Deleting an APK...</h2>' });
+            var apk_type = $(this).data('apk_type');
+            var apk_arch = $(this).data('apk_arch');
+            var url = '{{ url_for('api_madapk') }}/'+ apk_type +'/'+ apk_arch;
+            $.ajax({
+                url : '{{ url_for('api_madapk') }}/'+ apk_type +'/'+ apk_arch,
+                type : 'DELETE',
+                success: function(data, status, xhr) {
+                    if(xhr.status == 202) {
+                        location.reload();
+                    }
+                    $.unblockUI();
+                },
+                error: function(data, status, xhr) {
+                    alert('Unable to delete the APK.  An unknown error occurred');
+                    $.unblockUI();
+                },
+            });
+        }
+    });
+</script>
+{% endblock %}
+
+{% block content %}
+{{ super() }}
+<div class="row">
+    <div class="col">
+        <div class="card border-secondary">
+            <div class="card-body py-2">
+                <p class="card-text">This section allows you to easily manage the required APKs for running MAD.</p>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="row mt-3">
+    <div class="col">
+        <table class="table table-striped table-hover table-sm">
+            <thead class="thead-dark">
+                <tr>
+                    <th style="width: 20%" class="align-middle">APK Type</th>
+                    <th style="width: 40%" class="align-middle">Version</th>
+                    <th style="width: 20%" class="align-middle d-none d-lg-table-cell">Architecture</th>
+                    <th style="width: 20%" class="text-right align-middle"></th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for apk_type, architectures in apks.items()|sort %}
+                    {% for architecture, data in architectures.items() %}
+                        <tr>
+                            <td class="align-middle">{{ apk_type }}</td>
+                            <td class="align-middle">{{ data.version }}</td>
+                            <td class="align-middle">{{ architecture }}</td>
+                            <td align="right">
+                                <button type="button" data-apk_type="{{ apk_type }}" data-apk_arch="{{ architecture }}" class="upload btn btn-success btn-sm"><i class="fas fa-upload"></i></button>
+                                {% if data.file_id != None %}
+                                <button type="button" data-apk_type="{{ apk_type }}" data-apk_arch="{{ architecture }}" class="delete btn btn-danger btn-sm"><i class="fas fa-trash-alt"></i></button>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+<div style='display: none;'>
+    <form id='upload_form' action="{{ url_for('upload_file') }}" method="post" enctype="multipart/form-data">
+        <input id="file-input" type="file" name="apk" style="display: none;" />
+        <input type='text' id="apk_type" name="apk_type"/>
+        <input type='text' id="apk_arch" name="apk_arch"/>
+    </form>
+</div>
+{% endblock %}

--- a/madmin/templates/madmin_apk_root.html
+++ b/madmin/templates/madmin_apk_root.html
@@ -16,6 +16,34 @@
         $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Uploading APK...</h2>' });
     }).click();
 
+    $(".search").click(function() {
+        if(confirm('Are you sure you want to search for an updated APK?  Currently no locks so dont spam it :)')) {
+            $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Starting search...</h2>' });
+            rpc_call = {
+              'call': 'search'
+            }
+            url = '{{ url_for('api_madapk') }}/'+ $(this).data('apk_type') + '/'+ $(this).data('apk_arch');
+            $.ajax({
+                url : url,
+                contentType : 'application/json-rpc',
+                data: JSON.stringify(rpc_call),
+                type : 'POST',
+                success: function(data, status, xhr) {
+                    if(xhr.status == 204) {
+                      alert('Searching for new APK successfully started');
+                    }
+                    $.unblockUI();
+                    location.reload();
+                },
+                error: function(data, status, xhr) {
+                    alert('Unable to start the search.  Please look at server logs');
+                    $.unblockUI();
+                    location.reload();
+                }
+            });
+        }
+    });
+
     $(".delete").click(function() {
         if(confirm('Are you sure you want to delete this APK?')) {
             var elem =  $(this);
@@ -31,14 +59,104 @@
                         location.reload();
                     }
                     $.unblockUI();
+                    location.reload();
                 },
                 error: function(data, status, xhr) {
                     alert('Unable to delete the APK.  An unknown error occurred');
                     $.unblockUI();
+                    location.reload();
                 },
             });
         }
     });
+
+  function check_apk_status() {
+    $.ajax({
+        url : '{{ url_for('apk_update_status') }}',
+        type : 'GET',
+        success: function(data, status, xhr) {
+            if(xhr.status == 200) {
+              var apk_status = xhr.responseJSON;
+              console.log(apk_status);
+              $.each($(".update_status"), function () {
+                var apk_type = $(this).data('apk_type');
+                var apk_arch = $(this).data('apk_arch');
+                var status = $(this).data('status');
+                var composite_key = apk_type +'_'+ apk_arch;
+                var elem;
+                if(apk_status.hasOwnProperty(composite_key)) {
+                  // Currently downloading
+                  if(apk_status[composite_key].hasOwnProperty('download_status')) {
+                    elem = $(document.createElement("img")).attr({
+                      'src': "{{ url_for('static', filename='loading.gif') }}",
+                      'class': 'apk_disp',
+                      'data-apk_type': apk_type,
+                      'data-apk_arch': apk_arch,
+                      'data-status': 2,
+                      'width': '32px',
+                      'heigth': '30px'
+                    });
+                  } else {
+                    // Update available
+                    var fa_img = $(document.createElement("i")).attr({
+                      'class': "fa fa-cloud-upload-alt"
+                    });
+                    elem = $(document.createElement("button")).attr({
+                      'class': 'apk_disp btn btn-info btn-sm',
+                      'data-apk_type': apk_type,
+                      'data-apk_arch': apk_arch,
+                      'data-status': 1,
+                      'width': '32px',
+                      'heigth': '30px'
+                    }).bind('click', download_apk).append(fa_img);
+                  }
+                } else {
+                    $(this).empty()
+                }
+                if(elem) {
+                  $(this).empty().append(elem);
+                }
+              });
+            }
+        },
+        error: function(data, status, xhr) {
+            alert('Unable to get apk update status.  Can you reach the server?');
+        }
+    });
+  }
+
+    function download_apk(){
+        if(confirm('Are you sure you want to download the APK?')) {
+            $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif') }}" width="100px" /><br /><h2>Starting download...</h2>' });
+            rpc_call = {
+              'call': 'import'
+            }
+            url = '{{ url_for('api_madapk') }}/'+ $(this).data('apk_type') + '/'+ $(this).data('apk_arch');
+            $.ajax({
+                url : url,
+                contentType : 'application/json-rpc',
+                data: JSON.stringify(rpc_call),
+                type : 'POST',
+                success: function(data, status, xhr) {
+                    if(xhr.status == 204) {
+                      alert('Downloading APK successfully started');
+                    }
+                    $.unblockUI();
+                    check_apk_status();
+                    location.reload();
+                },
+                error: function(data, status, xhr) {
+                    alert('Unable to start the download.  Please look at server logs');
+                    $.unblockUI();
+                    location.reload();
+                }
+            });
+        }
+    }
+$(document).ready(function () {
+    check_apk_status();
+    setInterval(check_apk_status, 5000);
+  });
 </script>
 {% endblock %}
 
@@ -68,13 +186,15 @@
                 {% for apk_type, architectures in apks.items()|sort %}
                     {% for architecture, data in architectures.items() %}
                         <tr>
-                            <td class="align-middle">{{ apk_type }}</td>
+                            <td class="align-middle">{{ data.usage_disp }}</td>
                             <td class="align-middle">{{ data.version }}</td>
-                            <td class="align-middle">{{ architecture }}</td>
+                            <td class="align-middle">{{ data.arch_disp }}</td>
                             <td align="right">
-                                <button type="button" data-apk_type="{{ apk_type }}" data-apk_arch="{{ architecture }}" class="upload btn btn-success btn-sm"><i class="fas fa-upload"></i></button>
+                                <div class='update_status' data-apk_type="{{ apk_type }}" data-apk_arch="{{ architecture }}" style='display:inline;'></div>
+                                <button type="button" data-apk_type="{{ data.usage_disp }}" data-apk_arch="{{ data.arch_disp }}" class="search btn btn-success btn-sm"><i class="fas fa-sync"></i></button>
+                                <button type="button" data-apk_type="{{ data.usage_disp }}" data-apk_arch="{{ data.arch_disp }}" class="upload btn btn-success btn-sm"><i class="fas fa-upload"></i></button>
                                 {% if data.file_id != None %}
-                                <button type="button" data-apk_type="{{ apk_type }}" data-apk_arch="{{ architecture }}" class="delete btn btn-danger btn-sm"><i class="fas fa-trash-alt"></i></button>
+                                <button type="button" data-apk_type="{{ data.usage_disp }}" data-apk_arch="{{ data.arch_disp }}" class="delete btn btn-danger btn-sm"><i class="fas fa-trash-alt"></i></button>
                                 {% endif %}
                             </td>
                         </tr>

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ s2sphere~=0.2
 watchdog~=0.9
 websockets>=7
 numpy~=1.18.0
+apkutils~=0.6.6

--- a/start.py
+++ b/start.py
@@ -222,7 +222,7 @@ if __name__ == "__main__":
         t_ws.start()
 
         # init jobprocessor
-        device_Updater = deviceUpdater(ws_server, args, jobstatus)
+        device_Updater = deviceUpdater(ws_server, args, jobstatus, db_wrapper)
 
         webhook_worker = None
         if args.webhook:

--- a/utils/apk_util.py
+++ b/utils/apk_util.py
@@ -1,8 +1,27 @@
 from utils import global_variables
+from utils.logging import logger
 
-def get_mad_apks(db):
+def chunk_generator(dbc, filestore_id):
+    sql = "SELECT `chunk_id` FROM `filestore_chunks` WHERE `filestore_id` = %s"
+    data_sql = "SELECT `data` FROM `filestore_chunks` WHERE `chunk_id` = %s"
+    chunk_ids = dbc.autofetch_column(sql, args=(filestore_id,))
+    for chunk_id in chunk_ids:
+        yield dbc.autofetch_value(data_sql, args=(chunk_id))
+
+def get_mad_apks(db, front_end=False) -> dict:
+    keys = {
+       'pogo': global_variables.MAD_APK_USAGE_POGO,
+       'rgc':  global_variables.MAD_APK_USAGE_RGC,
+       'pogodroid': global_variables.MAD_APK_USAGE_PD
+    }
+    if front_end:
+        keys = {
+           'pogo': 'pogo',
+           'rgc':  'rgc',
+           'pogodroid': 'pogodroid'
+        }
     apks = {
-        'pogo': {
+        keys['pogo']: {
             'armeabi-v7a': {
                 'version': None,
                 'file_id': None,
@@ -14,14 +33,14 @@ def get_mad_apks(db):
                 'filename': None,
             },
         },
-        'rgc': {
+        keys['rgc']: {
             'noarch': {
                 'version': None,
                 'file_id': None,
                 'filename': None,
             },
         },
-        'pogodroid': {
+        keys['pogodroid']: {
             'noarch': {
                 'version': None,
                 'file_id': None,
@@ -37,18 +56,55 @@ def get_mad_apks(db):
         apk_arch = None
         file_data = db.autofetch_row(file_sql, args=(apk['filestore_id']))
         if apk['usage'] == global_variables.MAD_APK_USAGE_POGO:
-            apk_type = 'pogo'
+            apk_name = 'pogo'
             if apk['arch'] == global_variables.MAD_APK_ARCH_ARMEABI_V7A:
                 apk_arch = 'armeabi-v7a'
             else:
                 apk_arch = 'arm64-v8a'
         elif apk['usage'] == global_variables.MAD_APK_USAGE_RGC:
-            apk_type = 'rgc'
+            apk_name = 'rgc'
             apk_arch = 'noarch'
         elif apk['usage'] == global_variables.MAD_APK_USAGE_PD:
-            apk_type = 'pogodroid'
+            apk_name = 'pogodroid'
             apk_arch = 'noarch'
+        if not front_end:
+            apk_name = apk['usage']
         file_data['version'] = apk['version']
         file_data['file_id'] = apk['filestore_id']
-        apks[apk_type][apk_arch] = file_data
+        apks[apk_name][apk_arch] = file_data
     return apks
+
+def get_mad_apk(db, apk_type: str, architecture: str ='noarch') -> dict:
+    apks = get_mad_apks(db)
+    try:
+        return apks[global_variables.MAD_APK_USAGE[apk_type]][architecture]
+    except KeyError:
+        if architecture != 'noarch':
+            return get_mad_apk(db, apk_type)
+        else:
+            return False
+
+def get_mad_apk_ver(db, apk_type: str, apk_arch: str ='noarch') -> str:
+    apks = get_mad_apks(db)
+    try:
+        return get_mad_apk(db, apk_type, apk_arch=apk_arch)['version']
+    except KeyError:
+        return False
+
+def has_newer_ver(installed: str, mad_ver: str) -> bool:
+    mad_can_update = False
+    if mad_ver == installed:
+        return None
+    split_mad = mad_ver.split('.')
+    split_installed = installed.split('.')
+    solution = False
+    try:
+        for ind, val in enumerate(split_mad):
+            if int(val) < int(split_installed[ind]):
+                solution = True
+                break
+    except KeyError:
+        pass
+    if not solution:
+        mad_can_update = True
+    return mad_can_update

--- a/utils/apk_util.py
+++ b/utils/apk_util.py
@@ -353,8 +353,12 @@ def get_mad_apks(db) -> dict:
         apks[apk['usage']][apk['arch']] = file_data
     return apks
 
-def get_mad_apk(db, apk_type: str, architecture: str ='noarch') -> dict:
+def get_mad_apk(db, apk_type, architecture='noarch') -> dict:
     apks = get_mad_apks(db)
+    if type(apk_type) is str:
+        apk_type = global_variables.MAD_APK_USAGE[apk_type]
+    if type(architecture) is str:
+        architecture = global_variables.MAD_APK_ARCH[architecture]
     try:
         return apks[global_variables.MAD_APK_USAGE[apk_type]][architecture]
     except KeyError:

--- a/utils/apk_util.py
+++ b/utils/apk_util.py
@@ -6,30 +6,36 @@ def get_mad_apks(db):
             'armeabi-v7a': {
                 'version': None,
                 'file_id': None,
+                'filename': None,
             },
             'arm64-v8a': {
                 'version': None,
                 'file_id': None,
+                'filename': None,
             },
         },
         'rgc': {
             'noarch': {
                 'version': None,
                 'file_id': None,
+                'filename': None,
             },
         },
         'pogodroid': {
             'noarch': {
                 'version': None,
                 'file_id': None,
+                'filename': None,
             },
         }
     }
     sql = "SELECT * FROM `mad_apks`"
+    file_sql = "SELECT `filename`, `size`, `mimetype` FROM `filestore_meta` WHERE `filestore_id` = %s"
     mad_apks = db.autofetch_all(sql)
     for apk in mad_apks:
         apk_type = None
         apk_arch = None
+        file_data = db.autofetch_row(file_sql, args=(apk['filestore_id']))
         if apk['usage'] == global_variables.MAD_APK_USAGE_POGO:
             apk_type = 'pogo'
             if apk['arch'] == global_variables.MAD_APK_ARCH_ARMEABI_V7A:
@@ -42,8 +48,7 @@ def get_mad_apks(db):
         elif apk['usage'] == global_variables.MAD_APK_USAGE_PD:
             apk_type = 'pogodroid'
             apk_arch = 'noarch'
-        apks[apk_type][apk_arch] = {
-            'version': apk['version'],
-            'file_id': apk['id']
-        }
+        file_data['version'] = apk['version']
+        file_data['file_id'] = apk['filestore_id']
+        apks[apk_type][apk_arch] = file_data
     return apks

--- a/utils/apk_util.py
+++ b/utils/apk_util.py
@@ -1,0 +1,49 @@
+from utils import global_variables
+
+def get_mad_apks(db):
+    apks = {
+        'pogo': {
+            'armeabi-v7a': {
+                'version': None,
+                'file_id': None,
+            },
+            'arm64-v8a': {
+                'version': None,
+                'file_id': None,
+            },
+        },
+        'rgc': {
+            'noarch': {
+                'version': None,
+                'file_id': None,
+            },
+        },
+        'pogodroid': {
+            'noarch': {
+                'version': None,
+                'file_id': None,
+            },
+        }
+    }
+    sql = "SELECT * FROM `mad_apks`"
+    mad_apks = db.autofetch_all(sql)
+    for apk in mad_apks:
+        apk_type = None
+        apk_arch = None
+        if apk['usage'] == global_variables.MAD_APK_USAGE_POGO:
+            apk_type = 'pogo'
+            if apk['arch'] == global_variables.MAD_APK_ARCH_ARMEABI_V7A:
+                apk_arch = 'armeabi-v7a'
+            else:
+                apk_arch = 'arm64-v8a'
+        elif apk['usage'] == global_variables.MAD_APK_USAGE_RGC:
+            apk_type = 'rgc'
+            apk_arch = 'noarch'
+        elif apk['usage'] == global_variables.MAD_APK_USAGE_PD:
+            apk_type = 'pogodroid'
+            apk_arch = 'noarch'
+        apks[apk_type][apk_arch] = {
+            'version': apk['version'],
+            'file_id': apk['id']
+        }
+    return apks

--- a/utils/apk_util.py
+++ b/utils/apk_util.py
@@ -1,5 +1,260 @@
 from utils import global_variables
 from utils.logging import logger
+from werkzeug.utils import secure_filename
+import re
+import apkutils
+import requests
+import os
+import time
+import io
+
+APK_HEADERS = {
+    'User-Agent': 'Mozilla/5.0 (Windows; U; Windows NT 5.1; de; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3',
+}
+
+class AutoDownloader(object):
+    def __init__(self, dbc):
+        self.dbc = dbc
+
+    def apk_search(self, apk_type, architecture):
+        if apk_type == global_variables.MAD_APK_USAGE_POGO:
+            self.find_latest_pogo(architecture)
+        elif apk_type == global_variables.MAD_APK_USAGE_RGC:
+            self.find_latest_rgc(architecture)
+        elif apk_type == global_variables.MAD_APK_USAGE_PD:
+            self.find_latest_pd(architecture)
+
+    def apk_download(self, apk_type, architecture):
+        if apk_type == global_variables.MAD_APK_USAGE_POGO:
+            self.download_pogo(architecture)
+        elif apk_type == global_variables.MAD_APK_USAGE_RGC:
+            self.download_rgc(architecture)
+        elif apk_type == global_variables.MAD_APK_USAGE_PD:
+            self.download_pd(architecture)
+
+    def download_pogo(self, architecture):
+        # Determine the version and fileid
+        sql = "SELECT `version` FROM `mad_apks` WHERE `usage` = %s AND `arch` = %s"
+        current_ver = self.dbc.autofetch_value(sql, args=(global_variables.MAD_APK_USAGE_POGO, architecture))
+        latest_data = self.get_lastest(global_variables.MAD_APK_USAGE_POGO, architecture)
+        if not latest_data or latest_data['url'] is None:
+            self.find_latest_pogo(architecture)
+            latest_data = self.get_lastest(global_variables.MAD_APK_USAGE_POGO, architecture)
+        if not latest_data:
+            logger.warning('Unable to find latest data for PoGo')
+        else:
+            if current_ver is None or is_newer_version(latest_data['version'], current_ver):
+                filename = 'pogo_%s_%s.apk' % (architecture, latest_data['version'],)
+                download_url = latest_data['url']
+                apk = APKDownloader(self.dbc, download_url, architecture, global_variables.MAD_APK_USAGE_POGO,
+                                   filename=filename)
+                apk.upload_file()
+
+    def download_pd(self, architecture):
+        logger.info("Downloading latest PogoDroid")
+        self.__download_simple(global_variables.MAD_APK_USAGE_PD, architecture)
+
+    def __download_simple(self, apk_type, architecture):
+        latest_data = self.get_lastest(apk_type, architecture)
+        if not latest_data or latest_data['url'] is None:
+            self.apk_search(apk_type, architecture)
+            latest_data = self.get_lastest(apk_type, architecture)
+        if not latest_data:
+            logger.warning('Unable to find latest data')
+        else:
+            filename = latest_data['url'].split('/')[-1]
+            apk = APKDownloader(self.dbc, latest_data['url'], architecture, apk_type, filename=filename)
+            apk.upload_file()
+
+    def download_rgc(self, architecture):
+        logger.info("Downloading latest RGC")
+        self.__download_simple(global_variables.MAD_APK_USAGE_RGC, architecture)
+
+    def __find_latest_head(self, apk_type, arch, url):
+        sql = "SELECT maa.`version` AS 'maa_ver', ma.`version` AS 'ma_ver', fm.`size`\n"\
+              "FROM `mad_apk_autosearch` maa\n"\
+              "LEFT JOIN `mad_apks` ma ON ma.`usage` = maa.`usage` AND ma.`arch` = maa.`arch`\n"\
+              "LEFT JOIN `filestore_meta` fm ON fm.`filestore_id` = ma.`filestore_id`\n"\
+              "WHERE maa.`usage` = %s AND maa.`arch` = %s"
+        curr_info = self.dbc.autofetch_row(sql, args=(apk_type, arch))
+        head = requests.head(url, verify=False, headers=APK_HEADERS, allow_redirects=True)
+        installed_size = curr_info.get('size', None)
+        mirror_size = head.headers['Content-Length']
+        if not curr_info or (installed_size and installed_size != mirror_size):
+            logger.info('Newer version found on the mirror of size {}', mirror_size)
+        else:
+            logger.info('No newer version found')
+        self.set_last_searched(apk_type, arch, version=mirror_size, url=url)
+
+    def find_latest_pd(self, architecture):
+        logger.info('Searching for a new version of PD [{}]', architecture)
+        self.__find_latest_head(global_variables.MAD_APK_USAGE_PD, architecture, global_variables.URL_PD_APK)
+
+    def find_latest_pogo(self, architecture):
+        # Determine the version and fileid
+        logger.info('Searching for a new version of PoGo [{}]', architecture)
+        download_url = None
+        url = global_variables.URL_POGO_APK_ARMEABI_V7A
+        if architecture == global_variables.URL_POGO_APK_ARM64_V8A:
+            url = global_variables.URL_POGO_APK_ARM64_V8A
+        response = requests.get(url, verify=False, headers=APK_HEADERS)
+        parsed = str(response.content)
+        mirror_version = str(re.search(r'"infoslide-value">([0-9\.]+)', parsed).group(1))
+        mirror_id = str(re.search(r'data-postid="(\d+)"', parsed).group(1))
+        sql = "SELECT `version` FROM `mad_apks` WHERE `usage` = %s AND `arch` = %s"
+        current_ver = self.dbc.autofetch_value(sql, args=(global_variables.MAD_APK_USAGE_POGO, architecture))
+        if current_ver is None or is_newer_version(mirror_version, current_ver):
+            logger.info('Newer version found on the mirror: {}', mirror_version)
+            download_url = global_variables.URL_POGO_APK % (mirror_id,)
+        else:
+            logger.info('No newer version found')
+        self.set_last_searched(global_variables.MAD_APK_USAGE_POGO, architecture, version=mirror_version, url=download_url)
+
+    def find_latest_rgc(self, architecture):
+        logger.info('Searching for a new version of RGC [{}]', architecture)
+        self.__find_latest_head(global_variables.MAD_APK_USAGE_RGC, architecture, global_variables.URL_RGC_APK)
+
+    def get_lastest(self, usage, arch):
+        sql = "SELECT `version`, `url` FROM `mad_apk_autosearch` WHERE `usage` = %s AND `arch` = %s"
+        return self.dbc.autofetch_row(sql, args=(usage, arch))
+
+    def set_last_searched(self, usage, arch, version: str = None, url: str = None):
+        data = {
+            'usage': usage,
+            'arch': arch,
+            'last_checked': 'NOW()'
+        }
+        if version:
+            data['version'] = version
+        if url:
+            data['url'] = url
+        self.dbc.autoexec_insert('mad_apk_autosearch', data, literals=['last_checked'], optype='ON DUPLICATE')
+
+class APKDownloader(object):
+    def __init__(self, dbc, url: str, architecture: int, apk_type: int, filename: str = None, file = None):
+        self.dbc = dbc
+        self.url = url
+        self.apk_type = apk_type
+        self.architecture = architecture
+        self.file = None
+        self.content_type = None
+        self.filename = filename
+        if not file:
+            self.__download_file()
+        else:
+            self.content_type = 'application/vnd.android.package-archive'
+
+    def __download_file(self):
+        update_data = {
+            'download_status': 1
+        }
+        where = {
+            'usage': self.apk_type,
+            'arch': self.architecture
+        }
+        self.dbc.autoexec_update('mad_apk_autosearch', update_data, where_keyvals=where)
+        try:
+            r = requests.get(self.url, verify=False, headers=APK_HEADERS)
+            self.file = io.BytesIO(r.content)
+            try:
+                if not self.filename:
+                    self.filename = re.findall("filename=(.+)", r.headers['content-disposition'])[0]
+            except:
+                self.filename = self.filename if self.filename else self.url
+            self.content_type = 'application/vnd.android.package-archive'
+        except:
+            logger.warning('Unable to download the file @ {}', self.url)
+        finally:
+            update_data['download_status'] = 0
+            self.dbc.autoexec_update('mad_apk_autosearch', update_data, where_keyvals=where)
+
+    def upload_file(self):
+        if self.content_type:
+            MADAPKImporter(self.dbc, self.filename, self.file, self.content_type, apk_type = self.apk_type,
+                           architecture = self.architecture, mad_apk = True)
+
+class MADAPKImporter(object):
+    def __init__(self, dbc, filename: str, apk_file, content_type, apk_type: int=None, architecture: int=None,
+                 mad_apk: bool=False):
+        self.dbc = dbc
+        self.filename = secure_filename(filename)
+        self.apk_type = apk_type
+        self.architecture = architecture
+        self.content_type = content_type
+        self.mad_apk = mad_apk
+        self.package = None
+        self.version = None
+        self.__valid = True
+        self.__validate_file(apk_file)
+        self.__import_file(apk_file)
+
+    def __import_file(self, apk_file):
+        if self.__valid:
+            try:
+                filestore_id = None
+                # Determine if we already have this file-type uploaded.  If so, remove it once the new one is
+                # completed and update the id
+                if self.mad_apk and self.apk_type and self.architecture:
+                    filestore_id_sql = "SELECT `filestore_id` FROM `mad_apks` WHERE `usage` = %s AND `arch` = %s"
+                    filestore_id = self.dbc.autofetch_value(filestore_id_sql, args=(self.apk_type, self.architecture,))
+                    if filestore_id:
+                        delete_data = {
+                            'filestore_id': filestore_id
+                        }
+                        self.dbc.autoexec_delete('filestore_meta', delete_data)
+                apk_file.seek(0, os.SEEK_END)
+                file_length = apk_file.tell()
+                # Check to see if the filename exists.  If it does, rename it
+                sql = 'SELECT `filestore_id` FROM `filestore_meta` WHERE `filename` = %s'
+                exists = self.dbc.autofetch_value(sql, args=(self.filename,))
+                if exists:
+                    self.filename = '%s_%s' % (int(time.time()), self.filename)
+                insert_data = {
+                    'filename': self.filename,
+                    'size': file_length,
+                    'mimetype': self.content_type,
+                }
+                new_id = self.dbc.autoexec_insert('filestore_meta', insert_data)
+                insert_data = {
+                    'filestore_id': new_id,
+                    'usage': self.apk_type,
+                    'arch': self.architecture,
+                    'version': self.version,
+                }
+                self.dbc.autoexec_insert('mad_apks', insert_data, optype='ON DUPLICATE')
+                apk_file.seek(0,0)
+                logger.info('Starting upload of APK')
+                while True:
+                    chunked_data = apk_file.read(global_variables.CHUNK_MAX_SIZE)
+                    if not chunked_data:
+                        break
+                    insert_data = {
+                        'filestore_id': new_id,
+                        'size': len(chunked_data),
+                        'data': chunked_data
+                    }
+                    self.dbc.autoexec_insert('filestore_chunks', insert_data)
+                logger.info('Finished upload of APK')
+            except Exception as err:
+                logger.exception('Unable to save the apk', exc_info=True)
+
+    def __validate_file(self, apk_file):
+        try:
+            apk = apkutils.APK(apk_file)
+        except:
+            logger.warning('Unable to parse APK file')
+            self.valid = False
+        else:
+            self.version = apk.get_manifest()['@android:versionName']
+            self.package = apk.get_manifest()['@package']
+            log_msg = 'New APK uploaded for {}'
+            args = [self.filename]
+            if self.architecture:
+                log_msg += ' {}'
+                args.append(self.architecture)
+            log_msg += ' [{}]'
+            args.append(self.version)
+            logger.info(log_msg, *args)
 
 def chunk_generator(dbc, filestore_id):
     sql = "SELECT `chunk_id` FROM `filestore_chunks` WHERE `filestore_id` = %s"
@@ -8,43 +263,40 @@ def chunk_generator(dbc, filestore_id):
     for chunk_id in chunk_ids:
         yield dbc.autofetch_value(data_sql, args=(chunk_id))
 
-def get_mad_apks(db, front_end=False) -> dict:
-    keys = {
-       'pogo': global_variables.MAD_APK_USAGE_POGO,
-       'rgc':  global_variables.MAD_APK_USAGE_RGC,
-       'pogodroid': global_variables.MAD_APK_USAGE_PD
-    }
-    if front_end:
-        keys = {
-           'pogo': 'pogo',
-           'rgc':  'rgc',
-           'pogodroid': 'pogodroid'
-        }
+def get_mad_apks(db) -> dict:
     apks = {
-        keys['pogo']: {
-            'armeabi-v7a': {
+        global_variables.MAD_APK_USAGE_POGO: {
+            global_variables.MAD_APK_ARCH_ARMEABI_V7A: {
                 'version': None,
                 'file_id': None,
                 'filename': None,
+                'arch_disp': 'armeabi-v7a',
+                'usage_disp': 'pogo'
             },
-            'arm64-v8a': {
+            global_variables.MAD_APK_ARCH_ARM64_V8A: {
                 'version': None,
                 'file_id': None,
                 'filename': None,
-            },
-        },
-        keys['rgc']: {
-            'noarch': {
-                'version': None,
-                'file_id': None,
-                'filename': None,
+                'arch_disp': 'arm64-v8a',
+                'usage_disp': 'pogo'
             },
         },
-        keys['pogodroid']: {
-            'noarch': {
+        global_variables.MAD_APK_USAGE_RGC: {
+            global_variables.MAD_APK_ARCH_NOARCH: {
                 'version': None,
                 'file_id': None,
                 'filename': None,
+                'arch_disp': 'noarch',
+                'usage_disp': 'rgc'
+            },
+        },
+        global_variables.MAD_APK_USAGE_PD: {
+            global_variables.MAD_APK_ARCH_NOARCH: {
+                'version': None,
+                'file_id': None,
+                'filename': None,
+                'arch_disp': 'noarch',
+                'usage_disp': 'pogodroid'
             },
         }
     }
@@ -67,11 +319,11 @@ def get_mad_apks(db, front_end=False) -> dict:
         elif apk['usage'] == global_variables.MAD_APK_USAGE_PD:
             apk_name = 'pogodroid'
             apk_arch = 'noarch'
-        if not front_end:
-            apk_name = apk['usage']
         file_data['version'] = apk['version']
         file_data['file_id'] = apk['filestore_id']
-        apks[apk_name][apk_arch] = file_data
+        file_data['arch_disp'] = apk_arch
+        file_data['usage_disp'] = apk_name
+        apks[apk['usage']][apk['arch']] = file_data
     return apks
 
 def get_mad_apk(db, apk_type: str, architecture: str ='noarch') -> dict:
@@ -91,20 +343,21 @@ def get_mad_apk_ver(db, apk_type: str, apk_arch: str ='noarch') -> str:
     except KeyError:
         return False
 
-def has_newer_ver(installed: str, mad_ver: str) -> bool:
-    mad_can_update = False
-    if mad_ver == installed:
+def is_newer_version(first_ver: str, second_ver: str) -> bool:
+    """ Determines if the first version is newer than the second """
+    first_is_newer = False
+    if first_ver == second_ver:
         return None
-    split_mad = mad_ver.split('.')
-    split_installed = installed.split('.')
+    split_first_ver = first_ver.split('.')
     solution = False
     try:
-        for ind, val in enumerate(split_mad):
-            if int(val) < int(split_installed[ind]):
+        split_second_ver = second_ver.split('.')
+        for ind, val in enumerate(split_first_ver):
+            if int(val) < int(split_first_ver[ind]):
                 solution = True
                 break
-    except KeyError:
+    except (AttributeError, KeyError):
         pass
     if not solution:
-        mad_can_update = True
-    return mad_can_update
+        first_is_newer = True
+    return first_is_newer

--- a/utils/global_variables.py
+++ b/utils/global_variables.py
@@ -1,0 +1,18 @@
+# This file is to specify any globals / magic-numbers used throughout MAD
+MAD_APK_USAGE_POGO = 0
+MAD_APK_USAGE_RGC = 1
+MAD_APK_USAGE_PD = 2
+MAD_APK_USAGE = {
+    'pogo': MAD_APK_USAGE_POGO,
+    'rgc': MAD_APK_USAGE_RGC,
+    'pogodroid': MAD_APK_USAGE_PD,
+}
+MAD_APK_ARCH_NOARCH = 0
+MAD_APK_ARCH_ARMEABI_V7A = 1
+MAD_APK_ARCH_ARM64_V8A = 2
+MAD_APK_ARCH = {
+    'noarch': MAD_APK_ARCH_NOARCH,
+    'armeabi-v7a': MAD_APK_ARCH_ARMEABI_V7A,
+    'arm64-v8a': MAD_APK_ARCH_ARM64_V8A,
+}
+MAD_APK_ALLOWED_EXTENSIONS = set(['apk'])

--- a/utils/global_variables.py
+++ b/utils/global_variables.py
@@ -7,6 +7,9 @@ MAD_APK_USAGE = {
     'pogo': MAD_APK_USAGE_POGO,
     'rgc': MAD_APK_USAGE_RGC,
     'pogodroid': MAD_APK_USAGE_PD,
+    'com.nianticlabs.pokemongo': MAD_APK_USAGE_POGO,
+    'de.grennith.rgc.remotegpscontroller': MAD_APK_USAGE_RGC,
+    'com.mad.pogodroid': MAD_APK_USAGE_PD,
 }
 MAD_APK_ARCH_NOARCH = 0
 MAD_APK_ARCH_ARMEABI_V7A = 1

--- a/utils/global_variables.py
+++ b/utils/global_variables.py
@@ -27,3 +27,5 @@ URL_POGO_APK_ARMEABI_V7A = 'https://www.apkmirror.com/apk/niantic-inc/pokemon-go
 URL_POGO_APK_ARM64_V8A = 'https://www.apkmirror.com/apk/niantic-inc/pokemon-go/variant-%7B%22arches_slug%22%3A%5B%22arm64-v8a%22%5D%7D/'
 URL_RGC_APK = 'https://raw.githubusercontent.com/Map-A-Droid/MAD/master/APK/RemoteGpsController.apk'
 URL_PD_APK = 'https://www.maddev.de/apk/PogoDroid.apk'
+
+ADDRESSES_GITHUB = 'https://raw.githubusercontent.com/Map-A-Droid/MAD/master/configs/addresses.json'

--- a/utils/global_variables.py
+++ b/utils/global_variables.py
@@ -1,4 +1,5 @@
 # This file is to specify any globals / magic-numbers used throughout MAD
+CHUNK_MAX_SIZE = 1024 * 1024 * 8 # 8MiB
 MAD_APK_USAGE_POGO = 0
 MAD_APK_USAGE_RGC = 1
 MAD_APK_USAGE_PD = 2

--- a/utils/global_variables.py
+++ b/utils/global_variables.py
@@ -1,4 +1,6 @@
 # This file is to specify any globals / magic-numbers used throughout MAD
+
+# MAD APK related elements
 CHUNK_MAX_SIZE = 1024 * 1024 * 8 # 8MiB
 MAD_APK_USAGE_POGO = 0
 MAD_APK_USAGE_RGC = 1
@@ -20,3 +22,8 @@ MAD_APK_ARCH = {
     'arm64-v8a': MAD_APK_ARCH_ARM64_V8A,
 }
 MAD_APK_ALLOWED_EXTENSIONS = set(['apk'])
+URL_POGO_APK = 'https://www.apkmirror.com/wp-content/themes/APKMirror/download.php?id=%s'
+URL_POGO_APK_ARMEABI_V7A = 'https://www.apkmirror.com/apk/niantic-inc/pokemon-go/variant-%7B%22arches_slug%22%3A%5B%22armeabi-v7a%22%5D%7D/'
+URL_POGO_APK_ARM64_V8A = 'https://www.apkmirror.com/apk/niantic-inc/pokemon-go/variant-%7B%22arches_slug%22%3A%5B%22arm64-v8a%22%5D%7D/'
+URL_RGC_APK = 'https://raw.githubusercontent.com/Map-A-Droid/MAD/master/APK/RemoteGpsController.apk'
+URL_PD_APK = 'https://www.maddev.de/apk/PogoDroid.apk'

--- a/utils/version.py
+++ b/utils/version.py
@@ -685,9 +685,9 @@ class MADVersion(object):
             query = (
                 "CREATE TABLE IF NOT EXISTS `filestore_meta` ( "
                 "`filestore_id` INT NOT NULL AUTO_INCREMENT, "
-                "`filename` VARCHAR(256) NOT NULL, "
+                "`filename` VARCHAR(255) NOT NULL, "
                 "`size` INT NOT NULL, "
-                "`mimetype` VARCHAR(256) NOT NULL, "
+                "`mimetype` VARCHAR(255) NOT NULL, "
                 "PRIMARY KEY (`filestore_id`), "
                 "UNIQUE (`filename`))"
             )

--- a/utils/version.py
+++ b/utils/version.py
@@ -675,6 +675,37 @@ class MADVersion(object):
                     self.dbwrapper.execute(alter_query, commit=True)
                 except Exception as e:
                     logger.exception("Unexpected error: {}", e)
+        if self._version < 20:
+            query = (
+                "CREATE TABLE IF NOT EXISTS `filestore` ( "
+                "`id` INT NOT NULL AUTO_INCREMENT, "
+                "`filename` VARCHAR(256) NOT NULL, "
+                "`data` LONGBLOB NOT NULL, "
+                "PRIMARY KEY (`id`), "
+                "UNIQUE (`filename`))"
+            )
+            try:
+                self.dbwrapper.execute(query, commit=True)
+            except Exception as e:
+                logger.exception("Unexpected error: {}", e)
+                sys.exit(1)
+            sql = """CREATE TABLE IF NOT EXISTS `mad_apks` (
+                `id` INT NOT NULL AUTO_INCREMENT,
+                `usage` INT NOT NULL,
+                `arch` INT NOT NULL,
+                `version` VARCHAR(32) NOT NULL,
+                PRIMARY KEY (`id`),
+                UNIQUE (`usage`, `arch`),
+                CONSTRAINT `fk_fs_apks`
+                    FOREIGN KEY (`id`)
+                    REFERENCES `filestore` (`id`)
+                    ON DELETE CASCADE
+                )"""
+            try:
+                self.dbwrapper.execute(sql, commit=True)
+            except Exception as e:
+                logger.exception("Unexpected error: {}", e)
+                sys.exit(1)
 
         if self._version < 20:
             sql = "ALTER TABLE versions ADD PRIMARY KEY(`key`)"

--- a/utils/version.py
+++ b/utils/version.py
@@ -688,8 +688,7 @@ class MADVersion(object):
                 "`filename` VARCHAR(255) NOT NULL, "
                 "`size` INT NOT NULL, "
                 "`mimetype` VARCHAR(255) NOT NULL, "
-                "PRIMARY KEY (`filestore_id`), "
-                "UNIQUE (`filename`))"
+                "PRIMARY KEY (`filestore_id`))"
             )
             try:
                 self.dbwrapper.execute(query, commit=True)

--- a/websocket/communicator.py
+++ b/websocket/communicator.py
@@ -40,10 +40,10 @@ class Communicator:
         finally:
             self.__sendMutex.release()
 
-    def install_apk(self, filepath: str, timeout: float) -> bool:
-        # TODO: check if file exists...
-        with open(filepath, "rb") as file:  # opening for [r]eading as [b]inary
-            data = file.read()  # if you only wanted to read 512 bytes, do .read(512)
+    def install_apk(self, timeout: float, filepath: str = None, data = None) -> bool:
+        if not data:
+            with open(filepath, "rb") as file:  # opening for [r]eading as [b]inary
+                data = file.read()  # if you only wanted to read 512 bytes, do .read(512)
         return self.__run_and_ok_bytes(message=data, timeout=timeout, byte_command=1)
 
     def startApp(self, package_name):


### PR DESCRIPTION
This allows MAD to host any uploaded APKs.  This allows for local file-transfers when installing APKs for ATVs.

Testing:
Upload a file (there are no version checks or validation you are using the correct type [pogo, pd, rgc])
wait for the screen to refresh.  Once refreshed you should see your file.  You can download the file @
`/api/mad_apk/<apk_type>/<arch>/download` (ie `/api/mad_apk/pogo/armeabi-v7a/download`).  Authorization for this page are the same requirements as RGC / PD.
To-Do list (future releases)
Move the upload to the API
Update Jobs to use these local files
Have MAD auto-find newer versions and import (probably a config flag)

![image](https://user-images.githubusercontent.com/13160095/71776749-75559700-2f64-11ea-9d03-65698febc51d.png)
