### PR TITLE
Refactor screen handling

### DIFF
--- a/ocr/pogoWindows.py
+++ b/ocr/pogoWindows.py
@@ -874,9 +874,15 @@ class PogoWindows:
             return None
 
         for text in texts:
-            globaldict = self.__internal_get_screen_text(text, identifier)
+            try:
+                globaldict = pytesseract.image_to_data(text, output_type=Output.DICT, timeout=40,
+                                                       config='--dpi 70')
+            except Exception as e:
+                logger.error("Tesseract Error for device {}: {}. Exception: {}".format(str(identifier),
+                                                                                       str(globaldict), e))
+                globaldict = None
             logger.debug("Screentext: {}".format(str(globaldict)))
-            if 'text' not in globaldict:
+            if  globaldict is None or'text' not in globaldict:
                 continue
             n_boxes = len(globaldict['level'])
             for i in range(n_boxes):

--- a/ocr/pogoWindows.py
+++ b/ocr/pogoWindows.py
@@ -842,14 +842,15 @@ class PogoWindows:
         return most_frequent_pixel[1]
 
     def screendetection_get_type_by_screen_analysis(self, image,
-                                                    identifier) -> Optional[Tuple[ScreenType, dict, int, int, int]]:
+                                                    identifier) -> Optional[Tuple[ScreenType,
+                                                                                  Optional[dict], int, int, int]]:
         return self.__thread_pool.apply_async(self.__screendetection_get_type_internal,
                                               (image, identifier)).get()
 
     def __screendetection_get_type_internal(self, image,
-                                            identifier) -> Optional[Tuple[ScreenType, dict, int, int, int]]:
+                                            identifier) -> Optional[Tuple[ScreenType, Optional[dict], int, int, int]]:
         returntype: ScreenType = ScreenType.UNDEFINED
-        globaldict: dict = {}
+        globaldict: Optional[dict] = {}
         diff: int = 1
         logger.debug(
             "__screendetection_get_type_internal: Detecting screen type - identifier {}", identifier)

--- a/ocr/pogoWindows.py
+++ b/ocr/pogoWindows.py
@@ -36,20 +36,20 @@ class PogoWindows:
         self._ScreenType[3]: list = ['KIDS', 'Google', 'Facebook']
         self._ScreenType[4]: list = ['Benutzername', 'Passwort', 'Username', 'Password', 'DRESSEURS']
         self._ScreenType[5]: list = ['TRY', 'DIFFERENT', 'ACCOUNT', 'Anmeldung', 'Konto', 'anderes',
-                                           'connexion.', 'connexion']
+                                     'connexion.', 'connexion']
         self._ScreenType[6]: list = ['Authentifizierung', 'fehlgeschlagen', 'Unable', 'authenticate',
-                                           'Authentification', 'Essaye']
+                                     'Authentification', 'Essaye']
         self._ScreenType[7]: list = ['incorrect.', 'attempts', 'falsch.', 'gesperrt']
         self._ScreenType[8]: list = ['Spieldaten', 'abgerufen', 'lecture', 'depuis', 'server', 'data']
         self._ScreenType[12]: list = ['Events,', 'Benachrichtigungen', 'Einstellungen', 'events,', 'offers,',
-                                  'notifications', 'évenements,', 'evenements,', 'offres']
+                                      'notifications', 'évenements,', 'evenements,', 'offres']
         self._ScreenType[14]: list = ['kompatibel', 'compatible', 'OS', 'software', 'device', 'Gerät', 'Betriebssystem',
-                           'logiciel']
+                                      'logiciel']
         self._ScreenType[15]: list = ['continuer...', 'aktualisieren?', 'now?', 'Aktualisieren', 'Aktualisieren,',
-                                    'aktualisieren', 'update', 'continue...', 'Veux-tu', 'Fais', 'continuer']
+                                      'aktualisieren', 'update', 'continue...', 'Veux-tu', 'Fais', 'continuer']
         self._ScreenType[16]: list = ['modified', 'client', 'Strike', 'suspension', 'third-party',
-                                    'modifizierte', 'Verstoß', 'Sperrung', 'Drittpartei']
-        self._ScreenType[17]: list = ['Suspension', 'suspended', 'violating', 'days',]
+                                      'modifizierte', 'Verstoß', 'Sperrung', 'Drittpartei']
+        self._ScreenType[17]: list = ['Suspension', 'suspended', 'violating', 'days', ]
         self._ScreenType[18]: list = ['Termination', 'terminated', 'permanently']
         self._ScreenType[21]: list = ['GPS', 'signal', 'GPS-Signal', '(11)', 'introuvable.',
                                       'found.', 'gefunden.', 'Signal']
@@ -125,8 +125,8 @@ class PogoWindows:
 
         if crop:
             screenshot_read = screenshot_read[int(height) - int(int(height / 4)):int(height),
-                                            int(int(width) / 2) - int(int(width) / 8):int(int(width) / 2) + int(
-                                            int(width) / 8)]
+                              int(int(width) / 2) - int(int(width) / 8):int(int(width) / 2) + int(
+                                  int(width) / 8)]
 
         logger.debug("__read_circle_count: Determined screenshot scale: " +
                      str(height) + " x " + str(width))
@@ -198,7 +198,7 @@ class PogoWindows:
 
         if crop:
             screenshot_read = screenshot_read[int(height) - int(height / 5):int(height),
-                                            int(width) / 2 - int(width) / 8:int(width) / 2 + int(width) / 8]
+                              int(width) / 2 - int(width) / 8:int(width) / 2 + int(width) / 8]
 
         logger.debug("__readCircleCords: Determined screenshot scale: " +
                      str(height) + " x " + str(width))
@@ -414,14 +414,15 @@ class PogoWindows:
             logger.error("Screenshot corrupted :(")
             return False
 
-        if self.__read_circle_count(os.path.join('', filename), identifier, float(11), communicator, xcord=False, crop=True,
+        if self.__read_circle_count(os.path.join('', filename), identifier, float(11), communicator, xcord=False,
+                                    crop=True,
                                     click=False, canny=True) == -1:
             logger.debug("__check_raid_line: Not active")
             return False
 
         height, width, _ = screenshot_read.shape
         screenshot_read = screenshot_read[int(height / 2) - int(height / 3):int(height / 2) + int(height / 3),
-                                        int(0):int(width)]
+                          int(0):int(width)]
         gray = cv2.cvtColor(screenshot_read, cv2.COLOR_BGR2GRAY)
         gray = cv2.GaussianBlur(gray, (5, 5), 0)
         logger.debug("__check_raid_line: Determined screenshot scale: " +
@@ -449,7 +450,9 @@ class PogoWindows:
                     # Coords - X: " + str(x1) + " " + str(x2) + " Y: " + str(y1) + " " + str(y2)) return False
                 else:
                     if y1 == y2 and (x2 - x1 <= maxLineLength) and (
-                            x2 - x1 >= minLineLength) and ((x1 < width / 2 and x2 < width / 2) or (x1 < width / 2 and x2 > width / 2)) and y1 < (height / 2):
+                            x2 - x1 >= minLineLength) and (
+                            (x1 < width / 2 and x2 < width / 2) or (x1 < width / 2 and x2 > width / 2)) and y1 < (
+                            height / 2):
                         logger.debug(
                             "__check_raid_line: Nearby is active - but not Raid-Tab")
                         if clickinvers:
@@ -482,11 +485,12 @@ class PogoWindows:
             return False
 
         height, width, _ = image.shape
-        image = image[int(height / 2 - (height / 3))                      :int(height / 2 + (height / 3)), 0:int(width)]
+        image = image[int(height / 2 - (height / 3)):int(height / 2 + (height / 3)), 0:int(width)]
         cv2.imwrite(os.path.join(self.temp_dir_path, str(
             identifier) + '_AmountOfRaids.jpg'), image)
 
-        if self.__read_circle_count(os.path.join(self.temp_dir_path, str(identifier) + '_AmountOfRaids.jpg'), identifier, 18,
+        if self.__read_circle_count(os.path.join(self.temp_dir_path, str(identifier) + '_AmountOfRaids.jpg'),
+                                    identifier, 18,
                                     communicator) > 0:
             logger.info(
                 "__check_orange_raid_circle_present: Raidcircle found, assuming raids nearby")
@@ -558,7 +562,7 @@ class PogoWindows:
         time.sleep(4)
         return False
 
-    def __check_close_present(self, filename, identifier, communicator,  radiusratio=12, Xcord=True):
+    def __check_close_present(self, filename, identifier, communicator, radiusratio=12, Xcord=True):
         if not os.path.isfile(filename):
             logger.warning(
                 "__check_close_present: {} does not exist", str(filename))
@@ -575,7 +579,8 @@ class PogoWindows:
                                  str(identifier) + '_exitcircle.jpg'), image)
 
         if self.__read_circle_count(os.path.join(self.temp_dir_path, str(identifier) + '_exitcircle.jpg'), identifier,
-                                  float(radiusratio), communicator, xcord=False, crop=True, click=True, canny=True) > 0:
+                                    float(radiusratio), communicator, xcord=False, crop=True, click=True,
+                                    canny=True) > 0:
             return True
 
     def check_close_except_nearby_button(self, filename, identifier, communicator, close_raid=False):
@@ -590,7 +595,7 @@ class PogoWindows:
     def __internal_check_close_except_nearby_button(self, filename, identifier, communicator, close_raid=False):
         logger.debug(
             "__internal_check_close_except_nearby_button: Checking close except nearby with: file {}, identifier {}",
-                filename, identifier)
+            filename, identifier)
         try:
             screenshot_read = cv2.imread(filename)
         except:
@@ -641,7 +646,7 @@ class PogoWindows:
         else:
             logger.debug("Could not find close button (X).")
             return False
-        
+
     def get_inventory_text(self, filename, identifier, x1, x2, y1, y2):
         if not os.path.isfile(filename):
             logger.error("get_inventory_text: {} does not exist", str(filename))
@@ -666,7 +671,11 @@ class PogoWindows:
         gray = cv2.resize(gray, dim, interpolation=cv2.INTER_AREA)
         cv2.imwrite(temp_path_item, gray)
         with Image.open(temp_path_item) as im:
-            text = pytesseract.image_to_string(im)
+            try:
+                text = pytesseract.image_to_string(im)
+            except Exception as e:
+                logger.error("Error running tesseract on inventory text: {}", e)
+                text = ""
         return text
 
     def check_pogo_mainscreen(self, filename, identifier):
@@ -695,7 +704,7 @@ class PogoWindows:
 
         height, width, _ = screenshot_read.shape
         gray = screenshot_read[int(height) - int(round(height / 5)):int(height),
-                               0: int(int(width) / 4)]
+               0: int(int(width) / 4)]
         height_, width_, _ = gray.shape
         radMin = int((width / float(6.8) - 3) / 2)
         radMax = int((width / float(6) + 3) / 2)
@@ -706,7 +715,7 @@ class PogoWindows:
         if circles is not None:
             circles = np.round(circles[0, :]).astype("int")
             for (x, y, r) in circles:
-                if x < width_ - width_/3:
+                if x < width_ - width_ / 3:
                     mainscreen += 1
 
         if mainscreen > 0:
@@ -729,7 +738,7 @@ class PogoWindows:
             return False
 
         if self.__read_circle_count(filename, identifier,
-                                  float(7.7), communicator, xcord=False, crop=True, click=True, canny=True) > 0:
+                                    float(7.7), communicator, xcord=False, crop=True, click=True, canny=True) > 0:
             logger.debug(
                 "Found close button (X). Closing the window - Ratio: 10")
             return True
@@ -772,10 +781,11 @@ class PogoWindows:
             "get_screen_text: Reading screen text - identifier {}", identifier)
 
         try:
-                returning_dict = pytesseract.image_to_data(screenshot, output_type=Output.DICT, timeout=40,
-                                                           config='--dpi 70')
-        except:
-            logger.error("Tesseract Error for device {}: {}".format(str(identifier), str(returning_dict)))
+            returning_dict = pytesseract.image_to_data(screenshot, output_type=Output.DICT, timeout=40,
+                                                       config='--dpi 70')
+        except Exception as e:
+            logger.error("Tesseract Error for device {}: {}. Exception: {}".format(str(identifier),
+                                                                                 str(returning_dict), e))
             returning_dict = []
 
         if isinstance(returning_dict, dict):

--- a/ocr/screenPath.py
+++ b/ocr/screenPath.py
@@ -128,24 +128,24 @@ class WordToScreenMatching(object):
         returntype: ScreenType = ScreenType.UNDEFINED
         global_dict: dict = {}
         if "AccountPickerActivity" in topmost_app or 'SignInActivity' in topmost_app:
-            return ScreenType.GGL
+            return ScreenType.GGL, global_dict
         elif "GrantPermissionsActivity" in topmost_app:
-            return ScreenType.PERMISSION
+            return ScreenType.PERMISSION, global_dict
         elif "ConsentActivity" in topmost_app:
-            return ScreenType.CONSENT
+            return ScreenType.CONSENT, global_dict
         elif "com.nianticlabs.pokemongo" not in topmost_app:
-            return ScreenType.CLOSE
+            return ScreenType.CLOSE, global_dict
         elif self._nextscreen != ScreenType.UNDEFINED:
             # TODO: how can the nextscreen be known in the current? o.O
-            return self._nextscreen
+            return self._nextscreen, global_dict
         elif not self.get_devicesettings_value('screendetection', False):
             logger.info('No more screen detection - disabled ...')
-            return ScreenType.DISABLED
+            return ScreenType.DISABLED, global_dict
         else:
             if not self._takeScreenshot(delayBefore=self.get_devicesettings_value("post_screenshot_delay", 1),
                                         delayAfter=2):
                 logger.error("_check_windows: Failed getting screenshot")
-                return ScreenType.ERROR
+                return ScreenType.ERROR, global_dict
 
             screenpath = self.get_screenshot_path()
 
@@ -155,7 +155,7 @@ class WordToScreenMatching(object):
             if not global_dict:
                 self._nextscreen = ScreenType.UNDEFINED
                 logger.warning('Could not understand any text on screen - starting next round...')
-                return ScreenType.ERROR
+                return ScreenType.ERROR, global_dict
 
             self._ratio = self._height / self._width
 
@@ -163,7 +163,7 @@ class WordToScreenMatching(object):
 
             if 'text' not in global_dict:
                 logger.error('Error while text detection')
-                return ScreenType.ERROR
+                return ScreenType.ERROR, global_dict
             elif returntype == ScreenType.UNDEFINED and "com.nianticlabs.pokemongo" in topmost_app:
                 return ScreenType.POGO, global_dict
 

--- a/ocr/screenPath.py
+++ b/ocr/screenPath.py
@@ -185,7 +185,6 @@ class WordToScreenMatching(object):
                 temp_dict['CLUB'] = global_dict['top'][i] / diff
 
             if self.get_devicesettings_value('logintype', 'google') == 'ptc':
-                logger.debug("PTC login for account, trying to handle that")
                 self._nextscreen = ScreenType.PTC
                 if 'CLUB' in (global_dict['text'][i]):
                     self._click_center_button(diff, global_dict, i)

--- a/ocr/screenPath.py
+++ b/ocr/screenPath.py
@@ -433,20 +433,13 @@ class WordToScreenMatching(object):
         if screenpath is None or len(screenpath) == 0:
             logger.error("Invalid screen path: {}", screenpath)
             return ScreenType.ERROR
-        globaldict = {}
+        globaldict = self._pogoWindowManager.get_screen_text(screenpath, self._id)
         frame = None
-        try:
-            with Image.open(screenpath) as frame:
-                frame = frame.convert('LA')
-                globaldict = self._pogoWindowManager.get_screen_text(frame, self._id)
-        except (FileNotFoundError, ValueError) as e:
-            logger.error("Failed opening image {} with exception {}", screenpath, e)
-            return ScreenType.ERROR
 
         click_text = 'FIELD,SPECIAL,FELD,SPEZIAL,SPECIALES,TERRAIN'
         if not globaldict:
             # dict is empty
-            return ScreenType.UNDEFINED
+            return ScreenType.ERROR
         n_boxes = len(globaldict['level'])
         for i in range(n_boxes):
             if any(elem in (globaldict['text'][i]) for elem in click_text.split(",")):

--- a/ocr/screenPath.py
+++ b/ocr/screenPath.py
@@ -416,11 +416,10 @@ class WordToScreenMatching(object):
         if not topmostapp:
             return ScreenType.ERROR
 
-        globaldict: dict = {}
         diff: int = -1
-        returntype: ScreenType = self.__evaluate_topmost_app(topmost_app=topmostapp)
-        logger.info("Processing Screen: {}", str(ScreenType(returntype)))
-        return self.__handle_screentype(screentype=returntype, global_dict=globaldict, diff=diff)
+        screentype, global_dict = self.__evaluate_topmost_app(topmost_app=topmostapp)
+        logger.info("Processing Screen: {}", str(ScreenType(screentype)))
+        return self.__handle_screentype(screentype=screentype, global_dict=global_dict, diff=diff)
 
     def checkQuest(self, screenpath):
 

--- a/ocr/screenPath.py
+++ b/ocr/screenPath.py
@@ -14,6 +14,7 @@ import numpy as np
 from utils.madGlobals import ScreenshotType
 from PIL import Image
 
+
 class LoginType(Enum):
     UNKNOWN = -1
     google = 1
@@ -172,6 +173,7 @@ class WordToScreenMatching(object):
     def __handle_login_screen(self, global_dict: dict, diff: int):
         temp_dict: dict = {}
         n_boxes = len(global_dict['level'])
+        logger.debug("Selecting login with: {}", global_dict)
         for i in range(n_boxes):
             if 'Facebook' in (global_dict['text'][i]):
                 temp_dict['Facebook'] = global_dict['top'][i] / diff
@@ -182,11 +184,13 @@ class WordToScreenMatching(object):
                 temp_dict['CLUB'] = global_dict['top'][i] / diff
 
             if self.get_devicesettings_value('logintype', 'google') == 'ptc':
+                logger.debug("PTC login for account, trying to handle that")
                 self._nextscreen = ScreenType.PTC
                 if 'CLUB' in (global_dict['text'][i]):
                     self._click_center_button(diff, global_dict, i)
                     time.sleep(5)
-
+                else:
+                    logger.error("Unhandled login!")
             else:
                 self._nextscreen = ScreenType.UNDEFINED
                 if 'Google' in (global_dict['text'][i]):

--- a/ocr/screenPath.py
+++ b/ocr/screenPath.py
@@ -164,6 +164,8 @@ class WordToScreenMatching(object):
             if 'text' not in global_dict:
                 logger.error('Error while text detection')
                 return ScreenType.ERROR
+            elif returntype == ScreenType.UNDEFINED and "com.nianticlabs.pokemongo" in topmost_app:
+                return ScreenType.POGO, global_dict
 
         return returntype, global_dict
 

--- a/ocr/screenPath.py
+++ b/ocr/screenPath.py
@@ -269,7 +269,7 @@ class WordToScreenMatching(object):
             screentype = ScreenType.ERROR
         elif screentype == ScreenType.POGO:
             screentype = self.__check_pogo_screen_ban_or_loading(screentype)
-        elif screentype in ScreenType.QUEST:
+        elif screentype == ScreenType.QUEST:
             logger.warning("Already on quest screen")
             # TODO: consider closing quest window?
             self._nextscreen = ScreenType.UNDEFINED

--- a/ocr/screenPath.py
+++ b/ocr/screenPath.py
@@ -429,7 +429,7 @@ class WordToScreenMatching(object):
         logger.info("Processing Screen: {}", str(ScreenType(screentype)))
         return self.__handle_screentype(screentype=screentype, global_dict=global_dict, diff=diff)
 
-    def checkQuest(self, screenpath) -> ScreenType:
+    def checkQuest(self, screenpath: str) -> ScreenType:
         if screenpath is None or len(screenpath) == 0:
             logger.error("Invalid screen path: {}", screenpath)
             return ScreenType.ERROR

--- a/ocr/screen_type.py
+++ b/ocr/screen_type.py
@@ -1,0 +1,29 @@
+from enum import Enum
+
+
+class ScreenType(Enum):
+    UNDEFINED = -1
+    BIRTHDATE = 1  # birthday selection screen, set by PogoWindows.__screendetection_get_type_internal
+    RETURNING = 2  # returning player screen
+    LOGINSELECT = 3  # login selection regarding OAUTH
+    PTC = 4  # PTC login
+    FAILURE = 5  # login failure
+    RETRY = 6  # auth failed, retry screen
+    WRONG = 7  # incorrect credentials?
+    GAMEDATA = 8  # game data could not be fetched from server
+    GGL = 10  # Google account picker
+    PERMISSION = 11  # permission grant overlay (Android)
+    MARKETING = 12  # marketing notification request (pogo)
+    CONSENT = 13  # consent activity
+    SN = 14  # OS not compatible message (pogo)
+    UPDATE = 15  # Force update modal (pogo)
+    STRIKE = 16  # Strike / red warning modal (pogo)
+    SUSPENDED = 17  # account suspended modal / temporarily banned (pogo)
+    TERMINATED = 18  # account terminated modal (pogo)
+    QUEST = 20  # research menu / quest listing (pogo)
+    GPS = 21  # GPS signal not found error message (pogo)
+    POGO = 99  # uhm, whatever... At least pogo is topmost, no idea where we are yet tho (in the process of switching)
+    ERROR = 100  # some issue occurred while handling screentypes or not able to determine screen
+    BLACK = 110  # screen is black, likely loading up game
+    CLOSE = 500  # pogo is not topmost app (whatever app is topmost, it's not pogo)
+    DISABLED = 999  # screendetection disabled

--- a/websocket/WebsocketServer.py
+++ b/websocket/WebsocketServer.py
@@ -290,7 +290,6 @@ class WebsocketServer(object):
                         walker_index = 0
                         self.__mapping_manager.set_devicesetting_value_of(origin, 'walker_area_index', walker_index)
                         walker_settings = walker_area_array[walker_index]
-                        await websocket_client_connection.close()
                         return False
                     walker_index += 1
                     self.__mapping_manager.set_devicesetting_value_of(origin, 'walker_area_index', walker_index)
@@ -308,7 +307,6 @@ class WebsocketServer(object):
                 walker_area_name = walker_area_array[walker_index]['walkerarea']
 
                 if walker_area_name not in self.__mapping_manager.get_all_routemanager_names():
-                    await websocket_client_connection.close()
                     raise WrongAreaInWalker()
 
                 logger.debug('Devicesettings {}: {}', str(origin), devicesettings)
@@ -356,7 +354,7 @@ class WebsocketServer(object):
 
             if worker is None:
                 logger.error("Invalid walker mode for {}. Closing connection".format(str(origin)))
-                await websocket_client_connection.close()
+                return False
             else:
                 logger.debug("Starting worker for {}", str(origin))
                 new_worker_thread = Thread(
@@ -368,10 +366,10 @@ class WebsocketServer(object):
                 new_worker_thread.start()
         except WrongAreaInWalker:
             logger.error('Unknown Area in Walker settings - check config')
-            await websocket_client_connection.close()
+            return False
         except Exception as e:
             logger.opt(exception=True).error("Other unhandled exception during registration of {}: {}", origin, e)
-            await websocket_client_connection.close()
+            return False
         finally:
             async with self.__users_mutex:
                 self.__users_connecting.remove(origin)

--- a/websocket/WebsocketServer.py
+++ b/websocket/WebsocketServer.py
@@ -153,14 +153,8 @@ class WebsocketServer(object):
         # wait for a connection...
         try:
             continue_work = await self.__register(websocket_client_connection)
-            reason = None
-            if type(continue_work) is tuple:
-                (continue_work, reason) = continue_work
             if not continue_work:
-                if not reason:
-                    logger.error("Failed registering client, closing connection")
-                else:
-                    logger.info(reason)
+                logger.error("Failed registering client, closing connection")
                 await websocket_client_connection.close()
                 return
         except data_manager.dm_exceptions.DataManagerException:
@@ -372,7 +366,7 @@ class WebsocketServer(object):
             logger.error('Unknown Area in Walker settings - check config')
             await websocket_client_connection.close()
         except Exception as e:
-            logger.opt(exception=True).error("Other unhandled exception during registration of {}: .", origin, e)
+            logger.opt(exception=True).error("Other unhandled exception during registration of {}: {}", origin, e)
             await websocket_client_connection.close()
         finally:
             async with self.__users_mutex:

--- a/websocket/WebsocketServer.py
+++ b/websocket/WebsocketServer.py
@@ -207,6 +207,7 @@ class WebsocketServer(object):
             return False
 
         auths = self.__mapping_manager.get_auths()
+        authBase64 = None
         if auths:
             try:
                 authBase64 = str(

--- a/websocket/WebsocketServer.py
+++ b/websocket/WebsocketServer.py
@@ -152,12 +152,14 @@ class WebsocketServer(object):
         logger.info("Waiting for connection...")
         # wait for a connection...
         try:
-            continue_work = await self.__register(websocket_client_connection)
+            continue_work: bool = await self.__register(websocket_client_connection)
             if not continue_work:
                 logger.error("Failed registering client, closing connection")
                 await websocket_client_connection.close()
                 return
         except data_manager.dm_exceptions.DataManagerException:
+            if websocket_client_connection.open:
+                await websocket_client_connection.close()
             return
 
         consumer_task = asyncio.ensure_future(

--- a/worker/MITMBase.py
+++ b/worker/MITMBase.py
@@ -134,6 +134,9 @@ class MITMBase(WorkerBase):
         return data_requested
 
     def _start_pogo(self) -> bool:
+        pogo_topmost = self._communicator.isPogoTopmost()
+        if pogo_topmost:
+            return True
         self._mitm_mapper.set_injection_status(self._id, False)
         started_pogo: bool = WorkerBase._start_pogo(self)
         if not self._wait_for_injection() or self._stop_worker_event.is_set():

--- a/worker/WorkerBase.py
+++ b/worker/WorkerBase.py
@@ -590,13 +590,11 @@ class WorkerBase(ABC):
                 logger.info("Found Black Loading Screen - waiting ...")
                 time.sleep(20)
 
-            if screen_type in [ScreenType.GAMEDATA, ScreenType.CONSENT]:
+            if screen_type in [ScreenType.GAMEDATA, ScreenType.CONSENT, ScreenType.CLOSE]:
                 logger.warning('Error getting Gamedata or strange ggl message appears')
                 self._loginerrorcounter += 1
-                self._restart_pogo(True)
-            elif screen_type == ScreenType.CLOSE:
-                logger.warning('Pogo not in foreground...')
-                self._restart_pogo(True)
+                if self._loginerrorcounter < 3:
+                    self._restart_pogo(True)
             elif screen_type == ScreenType.DISABLED:
                 # Screendetection is disabled
                 break

--- a/worker/WorkerBase.py
+++ b/worker/WorkerBase.py
@@ -657,7 +657,7 @@ class WorkerBase(ABC):
             time.sleep(2)
         return
 
-    def _check_quest(self):
+    def _check_quest(self) -> ScreenType:
         logger.info('Precheck Quest Menu')
         questcounter: int = 0
         questloop: int = 0
@@ -670,7 +670,7 @@ class WorkerBase(ABC):
         if not self._takeScreenshot(delayBefore=self.get_devicesettings_value("post_screenshot_delay", 1),
                                     delayAfter=2):
             logger.error("_check_windows: Failed getting screenshot")
-            return False
+            return ScreenType.ERROR
 
         while not returncode == ScreenType.POGO and not self._stop_worker_event.isSet():
             returncode = self._WordToScreenMatching.checkQuest(self.get_screenshot_path())
@@ -708,7 +708,7 @@ class WorkerBase(ABC):
             questloop += 1
             firstround = False
 
-        return
+        return ScreenType.POGO
 
     def _start_pogo(self) -> bool:
         """

--- a/worker/WorkerQuests.py
+++ b/worker/WorkerQuests.py
@@ -486,9 +486,13 @@ class WorkerQuests(MITMBase):
 
                 try:
                     item_text = self._pogoWindowManager.get_inventory_text(self.get_screenshot_path(),
-                                                                       self._id, text_x1, text_x2, check_y_text_ending,
-                                                                       check_y_text_starter)
-
+                                                                           self._id, text_x1, text_x2,
+                                                                           check_y_text_ending, check_y_text_starter)
+                    if item_text is None:
+                        logger.error("Did not get any text in inventory")
+                        # TODO: could this be running forever?
+                        trash += 1
+                        pass
                     logger.info("Found item {}", str(item_text))
                     match_one_item : bool = False
                     for text in not_allow:


### PR DESCRIPTION
Basically bugfixing for multiple issues

- Moved ScreenType enum to ocr/screen_type.py and also commented the values (which I hope I got right...)
- Changed naming of WorkerBase._check_windows to WorkerBase._ensure_pogo_topmost along with most of its body. Removed the == ScreenType.POGO check in the while-condition in order to handle all screens. This is achieved by also lifting conditions for the same-screen-checks to trigger for all ScreenType != ERROR
- Refactored WordToScreenMatching.detect_screentype with 2 new methods splitting up the previous logic (namely __evaluate_topmost_app and __handle_screentype). While doing so, I added all possible enum values to __handle_screentype in order to at least log the types. This construct should be thought over anyway considering WorkerBase._ensure_pogo_topmost handles certain enum values (e.g. .SN) while WordToScreenMatching.__handle_screentype handles stuff like PTC login... it's spaghetti
- Fixed an issue in WebsocketServer.__register where reconnects were handled with an asyncio.sleep... holding a lock
- Removed redundant close() calls on the websocket client in WebsocketServer.__register
- Added typing to WebsocketServer.__register. There was one case where a tuple was returned and another where nothing was returned at all. Meanwhile, the callee (WebsocketServer.handler) relied on a True/False decision on whether to continue work or stop handling the incoming connection
- Added logging regarding WebSocketClientProtocol.close() by wrapping it in a method
- Added usage of the WebSocketServerProtocol's close_timeout parameter - although that should be initialised with a value of 10 according to https://websockets.readthedocs.io/en/stable/_modules/websockets/server.html
- Added logging of exceptions regarding tesseract usage
- Added counting for both restart_pogo usages in WorkerBase in order to circumvent stackoverflows by calling reboot at a count of 2 restarts that way (sorta dirty workaround)