### PR TITLE
Add s2 cells for raid route coordinates

### DIFF
--- a/madmin/routes/map.py
+++ b/madmin/routes/map.py
@@ -105,15 +105,23 @@ class map(object):
             if route is None:
                 continue
             route_serialized = []
+            s2cells = {}
 
             for location in route:
                 route_serialized.append([
                     getCoordFloat(location.lat), getCoordFloat(location.lng)
                 ])
+
+                if mode == "raids_mitm":
+                    cells = S2Helper.get_S2cells_from_circle(location.lat, location.lng, 490)
+                    for cell in cells:
+                        s2cells[str(cell.id())] = S2Helper.coords_of_cell(cell.id())
+
             routeexport.append({
                 "name": name,
                 "mode": mode,
-                "coordinates": route_serialized
+                "coordinates": route_serialized,
+                "s2cells": s2cells
             })
 
         return jsonify(routeexport)

--- a/madmin/static/js/madmin.js
+++ b/madmin/static/js/madmin.js
@@ -515,6 +515,16 @@ new Vue({
             coords.push(circle);
           });
 
+          Object.values(route.s2cells).forEach(function(cells) {
+            L.polygon(cells, {
+                pane: "routes",
+                color: color,
+                opacity: 0.3,
+                fillOpacity: 0,
+                weight: 1
+              }).addTo(group);
+          });
+
           var geojson = {
             "type": "LineString",
             "coordinates": $this.convertToLonLat(route.coordinates)
@@ -526,7 +536,7 @@ new Vue({
             style: {
               "color": color,
               "weight": 2,
-              "opacity": 0.5
+              "opacity": 0.4
             }
           }).addTo(group);
 
@@ -1445,9 +1455,8 @@ new Vue({
         var mon = $this.mons[key];
         var end = moment(mon["disappear_time"]*1000);
 
-        if (!now.isAfter(end)) {
+        if (!now.isAfter(end))
           return;
-        }
 
         map.removeLayer(leaflet_data["mons"][mon["encounter_id"]]);
         delete leaflet_data["mons"][mon["encounter_id"]];
@@ -1520,7 +1529,7 @@ new Vue({
       sidebar.close();
 
       if(setlat != 0 && setlng != 0) {
-          var circle = L.circle([setlat, setlng], {
+        var circle = L.circle([setlat, setlng], {
           color: 'blue',
           fillColor: 'blue',
           fillOpacity: 0.5,
@@ -1528,7 +1537,7 @@ new Vue({
         }).addTo(map);
 
         map.setView([setlat, setlng], 20);
-      };
+      }
 
       map.on('zoomend', this.l_event_zoomed);
       map.on('moveend', this.l_event_moveend);
@@ -1537,45 +1546,41 @@ new Vue({
         sidebar.close();
       });
 
-    var editableLayers = new L.FeatureGroup();
-    map.addLayer(editableLayers);
+      var editableLayers = new L.FeatureGroup();
+      map.addLayer(editableLayers);
 
-    var options = {
+      var options = {
         position: 'topright',
         draw: {
-            polyline: false,
-            polygon: {
-                allowIntersection: false,
-                drawError: {
-                    color: '#e1e100',
-                    message: '<strong>Oh snap!<strong> you can\'t draw that!'
-                },
-                shapeOptions: {
-                    color: '#ac00e6'
-                }
+          polyline: false,
+          polygon: {
+            allowIntersection: false,
+            drawError: {
+              color: '#e1e100',
+              message: '<strong>Oh snap!<strong> you can\'t draw that!'
             },
-            circle: false,
-            circlemarker: false,
-            rectangle: false,
-            line: false,
-            marker: false,
+            shapeOptions: {
+              color: '#ac00e6'
+            }
+          },
+          circle: false,
+          circlemarker: false,
+          rectangle: false,
+          line: false,
+          marker: false,
         },
         edit: {
-            featureGroup: editableLayers,
-            remove: false
+          featureGroup: editableLayers,
+          remove: false
         }
-    };
+      };
 
-    var drawControl = new L.Control.Draw(options);
-    map.addControl(drawControl);
+      var drawControl = new L.Control.Draw(options);
+      map.addControl(drawControl);
 
-    map.on(L.Draw.Event.CREATED, function (e) {
-        var type = e.layerType,
-            layer = e.layer;
-
-        if (type != "polygon") {
-          return;
-        }
+      map.on(L.Draw.Event.CREATED, function(e) {
+        var type = e.layerType;
+        var layer = e.layer;
 
         var fencename = prompt("Please enter name of fence", "");
         coords = loopCoords(layer.getLatLngs())
@@ -1583,21 +1588,21 @@ new Vue({
         layer.bindPopup('<b>' + fencename + '</b><br><a href=savefence?name=' + encodeURI(fencename) + '&coords=' + coords + '>Save to MAD</a>');
         editableLayers.addLayer(layer);
         layer.openPopup();
-    });
+      });
 
-    map.on('draw:edited', function (e) {
+      map.on('draw:edited', function(e) {
         var layers = e.layers;
-        layers.eachLayer(function (layer) {
-            coords = loopCoords(layer.getLatLngs())
-            layer._popup.setContent('<b>' + newfences[layer] + '</b><br><a href=savefence?name=' + encodeURI(newfences[layer]) + '&coords=' + coords + '>Save to MAD</a>')
-            layer.openPopup();
+        layers.eachLayer(function(layer) {
+          coords = loopCoords(layer.getLatLngs())
+          layer._popup.setContent('<b>' + newfences[layer] + '</b><br><a href=savefence?name=' + encodeURI(newfences[layer]) + '&coords=' + coords + '>Save to MAD</a>')
+          layer.openPopup();
         });
-    });
+      });
 
       // initial load
       this.map_fetch_everything();
 
-      // iuntervals
+      // intervals
       setInterval(this.map_fetch_everything, 6000);
       if (this.settings.cleanup) {
         this.cleanup();

--- a/madmin/templates/map.html
+++ b/madmin/templates/map.html
@@ -14,14 +14,14 @@ var setlat = {{ setlat }};
 var setlng = {{ setlng }};
 </script>
 <script defer src="https://use.fontawesome.com/releases/v5.8.2/js/all.js" integrity="sha384-DJ25uNYET2XCl5ZF++U8eNxPWqcKohUUBUpKGlNLMchM7q4Wjg2CUpjHLaL8yYPH" crossorigin="anonymous"></script>
-<script src="https://vuejs.org/js/vue.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.10/vue.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.19.0/axios.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.4/leaflet.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/leaflet-sidebar-v2@3.0.6/js/leaflet-sidebar.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/leaflet-easybutton@2/src/easy-button.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.js"></script>
-<script src="static/js/madmin.js"></script>
+<script src="static/js/madmin.js?1578414241"></script>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49074/71913218-364b5f80-3177-11ea-8ef9-1245377ea9ba.png)

Baiscally what this does is, it adds surrounding L15 S2cells to each raid route coordinate to make it more clear what is being scanned and what not. 

Todo but not actually blocking this to be merged:
- render cells in JS, not in Python on the server
- use correct, dynamic radius depending on the latitude (discussed on Discord)