### PR TITLE
Fix #673 - calculate mon_mitm prioQ every 10 minutes

### DIFF
--- a/route/RouteManagerBase.py
+++ b/route/RouteManagerBase.py
@@ -524,13 +524,11 @@ class RouteManagerBase(ABC):
             delete_before = time.time() - self.remove_from_queue_backlog
         else:
             delete_before = 0
-        len_before = len(latest)
-        latest = [to_keep for to_keep in latest if not to_keep[0] < delete_before]
-        len_after = len(latest)
-        if len_after < len_before:
-            logger.warning("Dropped from {} to {} because of remove_from_queue_backlog. "
-                           "Make sure you have enough workers for your size of the area or "
-                           "adjust the size of the area itself.", len_before, len_after)
+        if self.mode == "mon_mitm":
+            delete_after = time.time() + 600
+            latest = [to_keep for to_keep in latest if not to_keep[0] < delete_before and not to_keep[0] > delete_after]
+        else:
+            latest = [to_keep for to_keep in latest if not to_keep[0] < delete_before]
         # TODO: sort latest by modified flag of event
         if cluster:
             merged = self.clustering_helper.get_clustered(latest)

--- a/route/RouteManagerMon.py
+++ b/route/RouteManagerMon.py
@@ -4,7 +4,7 @@ from utils.logging import logger
 
 class RouteManagerMon(RouteManagerBase):
     def _priority_queue_update_interval(self):
-        return 3540
+        return 600
 
     def _get_coords_after_finish_route(self) -> bool:
         self._init_route_queue()


### PR DESCRIPTION
fixes #673: large areas can get stuck clustering a huge amount of events. The effort of clustering probably rises exponentially with the number of events, thus it can be an issue.

It's more a quick workaround than a full fix. A pretter fix would somehow dynamically find an acceptable prioQ calculation interval, but the 10 minute interval will cut the number of events to cluster into 1/6 of the previous number and should quickly help affected users.

Removing the warning is easier than going through the latest list two times. Warnings will still show up from events being dropped during the scanning process, so this one shouldn't be strictly required.