### PR TITLE
Route breakout per worker

### DIFF
--- a/madmin/routes/map.py
+++ b/madmin/routes/map.py
@@ -15,6 +15,7 @@ from utils.questGen import generate_quest
 from utils.s2Helper import S2Helper
 from utils.logging import logger
 from utils.language import i8ln
+from route.RouteManagerBase import RoutePoolEntry
 
 cache = Cache(config={'CACHE_TYPE': 'simple'})
 
@@ -100,29 +101,16 @@ class map(object):
         for routemanager in routemanager_names:
             mode = self._mapping_manager.routemanager_get_mode(routemanager)
             name = self._mapping_manager.routemanager_get_name(routemanager)
-            route: Optional[List[Location]] = self._mapping_manager.routemanager_get_current_route(routemanager)
+            (route, workers) = self._mapping_manager.routemanager_get_current_route(routemanager)
 
             if route is None:
                 continue
-            route_serialized = []
             s2cells = {}
-
-            for location in route:
-                route_serialized.append([
-                    getCoordFloat(location.lat), getCoordFloat(location.lng)
-                ])
-
-                if mode == "raids_mitm":
-                    cells = S2Helper.get_S2cells_from_circle(location.lat, location.lng, 490)
-                    for cell in cells:
-                        s2cells[str(cell.id())] = S2Helper.coords_of_cell(cell.id())
-
-            routeexport.append({
-                "name": name,
-                "mode": mode,
-                "coordinates": route_serialized,
-                "s2cells": s2cells
-            })
+            routeexport.append(get_routepool_route(name, mode, route))
+            if len(workers) > 1:
+                for worker, worker_route in workers.items():
+                    disp_name = '%s - %s' % (name, worker,)
+                    routeexport.append(get_routepool_route(disp_name, mode, worker_route))
 
         return jsonify(routeexport)
 
@@ -386,3 +374,27 @@ class map(object):
             pass
         return redirect(url_for('map'), code=302)
 
+def get_routepool_route(name, mode, coords):
+    (parsed_coords, s2cells) = get_routepool_coords(coords, mode)
+    return {
+        "name": name,
+        "mode": mode,
+        "coordinates": parsed_coords,
+        "s2cells": s2cells
+    }
+
+def get_routepool_coords(coord_list, mode):
+    route_serialized = []
+    s2cells = {}
+    prepared_coords = coord_list
+    if isinstance(coord_list, RoutePoolEntry):
+        prepared_coords = coord_list.subroute
+    for location in prepared_coords:
+        route_serialized.append([
+            getCoordFloat(location.lat), getCoordFloat(location.lng)
+        ])
+        if mode == "raids_mitm":
+            cells = S2Helper.get_S2cells_from_circle(location.lat, location.lng, 490)
+            for cell in cells:
+                s2cells[str(cell.id())] = S2Helper.coords_of_cell(cell.id())
+    return (route_serialized, s2cells)

--- a/route/RouteManagerBase.py
+++ b/route/RouteManagerBase.py
@@ -1062,8 +1062,8 @@ class RouteManagerBase(ABC):
     def get_settings(self) -> Optional[dict]:
         return self.settings
 
-    def get_current_route(self) -> List[Location]:
-        return self._route
+    def get_current_route(self) -> Optional[Tuple[List[Location], Dict[str, List[Location]]]]:
+        return (self._route, self._routepool)
 
     def get_current_prioroute(self) -> List[Location]:
         return self._prio_queue

--- a/utils/MappingManager.py
+++ b/utils/MappingManager.py
@@ -279,7 +279,7 @@ class MappingManager:
         else:
             return None
 
-    def routemanager_get_current_route(self, routemanager_name: str) -> Optional[List[Location]]:
+    def routemanager_get_current_route(self, routemanager_name: str) -> Optional[Tuple[List[Location], Dict[str, List[Location]]]]:
         routemanager = self.__fetch_routemanager(routemanager_name)
         return routemanager.get_current_route() if routemanager is not None else None
 


### PR DESCRIPTION
Implementation of FR #479 

If an area has multiple workers the map will show the full route and the routearea each workers responsibility.  The device names will be appended to the area name to indicate its a subroute.
![image](https://user-images.githubusercontent.com/13160095/72294843-5f129f80-3624-11ea-83e1-a45a62c8d4da.png)
