### PR TITLE
Update trs_status to use timestamps

### DIFF
--- a/mapadroid/db/DbWrapper.py
+++ b/mapadroid/db/DbWrapper.py
@@ -901,7 +901,7 @@ class DbWrapper:
 
     def save_status(self, data):
         logger.debug("dbWrapper::save_status")
-        literals = ['currentPos', 'lastPos']
+        literals = ['currentPos', 'lastPos', 'lastProtoDateTime']
         data['instance_id'] = self.instance_id
         self.autoexec_insert('trs_status', data, literals=literals, optype='ON DUPLICATE')
 

--- a/mapadroid/db/DbWrapper.py
+++ b/mapadroid/db/DbWrapper.py
@@ -927,19 +927,21 @@ class DbWrapper:
         }
         self.autoexec_insert('trs_status', data, literals=literals, optype='ON DUPLICATE')
 
+    #def update_trs_status_to_idle(self, dev_id):
+    def save_idle_status(self, dev_id, status):
+        data = {
+            'instance_id': self.instance_id,
+            'device_id': dev_id,
+            'idle': status
+        }
+        self.autoexec_insert('trs_status', data, optype='ON DUPLICATE')
+
     def download_status(self):
         logger.debug("dbWrapper::download_status")
-        sql = "SELECT trs.`device_id`, dev.`name`, trs.`routePos`, trs.`routeMax`, trs.`area_id`, sa.`name` AS 'rmname',\n" \
-              "sa.`mode`, trs.`rebootCounter`, trs.`init`, trs.`currentSleepTime`,\n" \
-              "trs.`rebootingOption`, trs.`restartCounter`, trs.`globalrebootcount`, trs.`globalrestartcount`,\n" \
-              "UNIX_TIMESTAMP(trs.`lastPogoRestart`) AS 'lastPogoRestart',\n" \
-              "UNIX_TIMESTAMP(trs.`lastProtoDateTime`) AS 'lastProtoDateTime',\n" \
-              "UNIX_TIMESTAMP(trs.`lastPogoReboot`) AS 'lastPogoReboot',\n" \
-              "CONCAT(ROUND(x(trs.`currentPos`), 5), ', ', ROUND(y(trs.`currentPos`), 5)) AS 'currentPos',\n" \
-              "CONCAT(ROUND(x(trs.`lastPos`), 5), ', ', ROUND(y(trs.`lastPos`), 5)) AS 'lastPos'\n" \
-              "FROM `trs_status` trs\n" \
-              "INNER JOIN `settings_device` dev ON dev.`device_id` = trs.`device_id`\n" \
-              "LEFT JOIN `settings_area` sa ON sa.`area_id` = trs.`area_id`"
+        sql = "SELECT `device_id`, `name`, `routePos`, `routeMax`, `area_id`, `rmname`, `mode`, `rebootCounter`,\n"\
+              "`init`, `currentSleepTime`, `rebootingOption`, `restartCounter`, `globalrebootcount`,\n"\
+              "`globalrestartcount`, `lastPogoRestart`, `lastProtoDateTime`, `currentPos`, `lastPos`\n"\
+              "FROM `v_trs_status`"
         workers = self.autofetch_all(sql)
         return workers
 
@@ -982,14 +984,6 @@ class DbWrapper:
             })
 
         return cells
-
-    def update_trs_status_to_idle(self, dev_id):
-        data = {
-            'instance_id': self.instance_id,
-            'device_id': dev_id,
-            'area_id': -1
-        }
-        self.autoexec_insert('trs_status', data)
 
     def get_instance_id(self, instance_name=None):
         if instance_name is None:

--- a/mapadroid/utils/version.py
+++ b/mapadroid/utils/version.py
@@ -13,7 +13,7 @@ from mapadroid.utils.data_manager.dm_exceptions import (
     UpdateIssue
 )
 
-current_version = 22
+current_version = 23
 
 
 class MADVersion(object):
@@ -820,6 +820,43 @@ class MADVersion(object):
                         continue
                     row[field] = 0 if row[field].lower() == 'false' else 1
                 self.dbwrapper.autoexec_insert('trs_status', row, literals=point_fields)
+        if self._version < 23:
+            # Store as TIMESTAMP as it will handle everything with epoch
+            fields = ['lastProtoDateTime', 'lastPogoRestart', 'lastPogoReboot']
+            for field in fields:
+                sql = "ALTER TABLE `trs_status` CHANGE `%s` `%s` TIMESTAMP NULL DEFAULT NULL;"
+                try:
+                    self.dbwrapper.execute(sql % (field, field,), commit=True)
+                except Exception as e:
+                    logger.exception("Unexpected error: {}", e)
+            # Add an idle identifier since we can no longer set area names
+            sql = 'ALTER TABLE `trs_status` ADD `idle` TINYINT NULL DEFAULT 0 AFTER `area_id`;'
+            try:
+                self.dbwrapper.execute(sql, commit=True)
+            except Exception as e:
+                logger.exception("Unexpected error: {}", e)
+            sql = """
+                CREATE VIEW `v_trs_status` AS
+                    SELECT trs.`device_id`, dev.`name`, trs.`routePos`, trs.`routeMax`, trs.`area_id`,
+                    IF(trs.`idle` = 1, 'Idle', IFNULL(sa.`name`, 'Idle')) AS 'rmname',
+                    IF(trs.`idle` = 1, 'Idle', IFNULL(sa.`mode`, 'Idle')) AS 'mode',
+                    trs.`rebootCounter`, trs.`init`, trs.`currentSleepTime`,
+                    trs.`rebootingOption`, trs.`restartCounter`, trs.`globalrebootcount`, trs.`globalrestartcount`,
+                    UNIX_TIMESTAMP(trs.`lastPogoRestart`) AS 'lastPogoRestart',
+                    UNIX_TIMESTAMP(trs.`lastProtoDateTime`) AS 'lastProtoDateTime',
+                    UNIX_TIMESTAMP(trs.`lastPogoReboot`) AS 'lastPogoReboot',
+                    CONCAT(ROUND(ST_X(trs.`currentPos`), 5), ', ', ROUND(ST_Y(trs.`currentPos`), 5)) AS 'currentPos',
+                    CONCAT(ROUND(ST_X(trs.`lastPos`), 5), ', ', ROUND(ST_Y(trs.`lastPos`), 5)) AS 'lastPos',
+                    `currentPos` AS 'currentPos_raw',
+                    `lastPos` AS 'lastPos_raw'
+                    FROM `trs_status` trs
+                    INNER JOIN `settings_device` dev ON dev.`device_id` = trs.`device_id`
+                    LEFT JOIN `settings_area` sa ON sa.`area_id` = trs.`area_id`
+                """
+            try:
+                self.dbwrapper.execute(sql, commit=True)
+            except Exception as e:
+                logger.exception("Unexpected error: {}", e)
         self.set_version(current_version)
 
     def set_version(self, version):

--- a/mapadroid/utils/version.py
+++ b/mapadroid/utils/version.py
@@ -754,72 +754,88 @@ class MADVersion(object):
             except Exception as e:
                 logger.exception("Unexpected error: {}", e)
         if self._version < 22:
-            existing_data = self.dbwrapper.autofetch_all("SELECT * FROM `trs_status`")
-            sql = "DROP TABLE IF EXISTS`trs_status`"
-            try:
-                self.dbwrapper.execute(sql, commit=True)
-            except Exception as e:
-                logger.exception("Unexpected error: {}", e)
-            new_table = """
-                CREATE TABLE `trs_status` (
-                 `instance_id` INT UNSIGNED NOT NULL,
-                 `device_id` INT UNSIGNED NOT NULL,
-                 `currentPos` POINT DEFAULT NULL,
-                 `lastPos` POINT DEFAULT NULL,
-                 `routePos` INT DEFAULT NULL,
-                 `routeMax` INT DEFAULT NULL,
-                 `area_id` INT UNSIGNED DEFAULT NULL,
-                 `rebootCounter` INT DEFAULT NULL,
-                 `lastProtoDateTime` DATETIME DEFAULT NULL,
-                 `lastPogoRestart` DATETIME DEFAULT NULL,
-                 `init` TINYINT(1) DEFAULT NULL,
-                 `rebootingOption` TINYINT(1) DEFAULT NULL,
-                 `restartCounter` INT DEFAULT NULL,
-                 `lastPogoReboot` DATETIME DEFAULT NULL,
-                 `globalrebootcount` INT DEFAULT 0,
-                 `globalrestartcount` INT DEFAULT 0,
-                 `currentSleepTime` INT NOT NULL DEFAULT 0,
-                 PRIMARY KEY (`device_id`),
-                 CONSTRAINT `fk_ts_dev_id`
-                    FOREIGN KEY (`device_id`)
-                    REFERENCES `settings_device` (`device_id`)
-                    ON DELETE CASCADE,
-                 CONSTRAINT `fk_ts_instance`
-                     FOREIGN KEY (`instance_id`)
-                     REFERENCES `madmin_instance` (`instance_id`)
-                     ON DELETE CASCADE,
-                 CONSTRAINT `fk_ts_areaid`
-                     FOREIGN KEY (`area_id`)
-                     REFERENCES `settings_area` (`area_id`)
-                     ON DELETE CASCADE
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
-            """
-            try:
-                self.dbwrapper.execute(new_table, commit=True)
-            except Exception as e:
-                logger.exception("Unexpected error: {}", e)
-            point_fields = ['currentPos', 'lastPos']
-            bool_fields = ['rebootingOption', 'init']
-            for row in existing_data:
-                dev_id_sql = "SELECT `device_id` FROM `settings_device` WHERE `name` = %s and `instance_id` = %s"
-                dev_id = self.dbwrapper.autofetch_value(dev_id_sql, args=(row['origin'], row['instance_id']))
-                del row['origin']
-                row['device_id'] = dev_id
+            sql = "SELECT COUNT(*) FROM `information_schema`.`views` WHERE `TABLE_NAME` = 'v_trs_status'"
+            count = self.dbwrapper.autofetch_value(sql)
+            # We only want to perform the update if the view doesnt exist.  Prevent the bad queries against incorrect
+            # table structures
+            if not count:
+                existing_data = {}
+                sql = "SELECT trs.`instance_id`, trs.`origin`, trs.`currentPos`, trs.`lastPos`, trs.`routePos`,"\
+                      "trs.`routeMax`, trs.`routemanager`, trs.`rebootCounter`, trs.`lastProtoDateTime`,"\
+                      "trs.`lastPogoRestart`, trs.`init`, trs.`rebootingOption`, trs.`restartCounter`, trs.`globalrebootcount`,"\
+                      "trs.`globalrestartcount`, trs.`lastPogoReboot`, trs.`currentSleepTime`\n"\
+                      "FROM `trs_status` trs"
                 try:
-                    row['area_id'] = int(row['routemanager'])
-                    del row['routemanager']
+                    existing_data = self.dbwrapper.autofetch_all(sql)
                 except:
-                    continue
-                for field in point_fields:
-                    if not row[field]:
+                    pass
+                if not existing_data:
+                    existing_data = {}
+                sql = "DROP TABLE IF EXISTS `trs_status`"
+                try:
+                    self.dbwrapper.execute(sql, commit=True)
+                except Exception as e:
+                    logger.exception("Unexpected error: {}", e)
+                new_table = """
+                    CREATE TABLE `trs_status` (
+                     `instance_id` INT UNSIGNED NOT NULL,
+                     `device_id` INT UNSIGNED NOT NULL,
+                     `currentPos` POINT DEFAULT NULL,
+                     `lastPos` POINT DEFAULT NULL,
+                     `routePos` INT DEFAULT NULL,
+                     `routeMax` INT DEFAULT NULL,
+                     `area_id` INT UNSIGNED DEFAULT NULL,
+                     `rebootCounter` INT DEFAULT NULL,
+                     `lastProtoDateTime` DATETIME DEFAULT NULL,
+                     `lastPogoRestart` DATETIME DEFAULT NULL,
+                     `init` TINYINT(1) DEFAULT NULL,
+                     `rebootingOption` TINYINT(1) DEFAULT NULL,
+                     `restartCounter` INT DEFAULT NULL,
+                     `lastPogoReboot` DATETIME DEFAULT NULL,
+                     `globalrebootcount` INT DEFAULT 0,
+                     `globalrestartcount` INT DEFAULT 0,
+                     `currentSleepTime` INT NOT NULL DEFAULT 0,
+                     PRIMARY KEY (`device_id`),
+                     CONSTRAINT `fk_ts_dev_id`
+                        FOREIGN KEY (`device_id`)
+                        REFERENCES `settings_device` (`device_id`)
+                        ON DELETE CASCADE,
+                     CONSTRAINT `fk_ts_instance`
+                         FOREIGN KEY (`instance_id`)
+                         REFERENCES `madmin_instance` (`instance_id`)
+                         ON DELETE CASCADE,
+                     CONSTRAINT `fk_ts_areaid`
+                         FOREIGN KEY (`area_id`)
+                         REFERENCES `settings_area` (`area_id`)
+                         ON DELETE CASCADE
+                    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+                """
+                try:
+                    self.dbwrapper.execute(new_table, commit=True)
+                except Exception as e:
+                    logger.exception("Unexpected error: {}", e)
+                point_fields = ['currentPos', 'lastPos']
+                bool_fields = ['rebootingOption', 'init']
+                for row in existing_data:
+                    dev_id_sql = "SELECT `device_id` FROM `settings_device` WHERE `name` = %s and `instance_id` = %s"
+                    dev_id = self.dbwrapper.autofetch_value(dev_id_sql, args=(row['origin'], row['instance_id']))
+                    del row['origin']
+                    row['device_id'] = dev_id
+                    try:
+                        row['area_id'] = int(row['routemanager'])
+                        del row['routemanager']
+                    except:
                         continue
-                    point = row[field].split(",")
-                    row[field] = "POINT(%s,%s)" % (point[0], point[1])
-                for field in bool_fields:
-                    if not row[field]:
-                        continue
-                    row[field] = 0 if row[field].lower() == 'false' else 1
-                self.dbwrapper.autoexec_insert('trs_status', row, literals=point_fields)
+                    for field in point_fields:
+                        if not row[field]:
+                            continue
+                        point = row[field].split(",")
+                        row[field] = "POINT(%s,%s)" % (point[0], point[1])
+                    for field in bool_fields:
+                        if not row[field]:
+                            continue
+                        row[field] = 0 if row[field].lower() == 'false' else 1
+                    self.dbwrapper.autoexec_insert('trs_status', row, literals=point_fields)
         if self._version < 23:
             # Store as TIMESTAMP as it will handle everything with epoch
             fields = ['lastProtoDateTime', 'lastPogoRestart', 'lastPogoReboot']

--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -295,5 +295,6 @@ class MITMBase(WorkerBase):
             'currentSleepTime': self._current_sleep_time
         }
         if self._rec_data_time:
-            save_data['lastProtoDateTime'] = self._rec_data_time
+            save_data['lastProtoDateTime'] = 'NOW()'
+            self._rec_data_time = None
         self._db_wrapper.save_status(save_data)

--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -43,7 +43,7 @@ class MITMBase(WorkerBase):
         self._latest_encounter_update = 0
         self._encounter_ids = {}
         self._current_sleep_time = 0
-
+        self._db_wrapper.save_idle_status(dev_id, False)
         self._mitm_mapper.collect_location_stats(self._origin, self.current_location, 1, time.time(), 2, 0,
                                                  self._mapping_manager.routemanager_get_mode(
                                                      self._routemanager_name),

--- a/mapadroid/worker/WorkerConfigmode.py
+++ b/mapadroid/worker/WorkerConfigmode.py
@@ -49,7 +49,7 @@ class WorkerConfigmode(object):
         logger.info("Worker {} started in configmode", str(self._origin))
         self._mapping_manager.register_worker_to_routemanager(self._routemanager_name, self._origin)
         logger.debug("Setting device to idle for routemanager")
-        self._db_wrapper.update_trs_status_to_idle(self._dev_id)
+        self._db_wrapper.save_idle_status(self._dev_id, True)
         logger.debug("Device set to idle for routemanager {}", str(self._origin))
         while self.check_walker() and not self._stop_worker_event.is_set():
             position_type = self._mapping_manager.routemanager_get_position_type(self._routemanager_name,
@@ -136,7 +136,7 @@ class WorkerConfigmode(object):
                 self._stop_pogo()
                 killpogo = True
                 logger.debug("Setting device to idle for routemanager")
-                self._db_wrapper.update_trs_status_to_idle(self._dev_id)
+                self._db_wrapper.save_idle_status(self._dev_id, True)
                 logger.debug("Device set to idle for routemanager {}", str(self._origin))
             while check_walker_value_type(sleeptime) and not self._stop_worker_event.isSet():
                 time.sleep(1)

--- a/static/madmin/templates/status.html
+++ b/static/madmin/templates/status.html
@@ -13,7 +13,6 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.min.js"></script>
 <script>
     var dataTable;
-
     function setGrid(tableGridHtmlId, gridData) {
         if ($.fn.dataTable.isDataTable(tableGridHtmlId)) {
             dataTable.destroy();
@@ -21,39 +20,41 @@
         dataTable = $(tableGridHtmlId).DataTable({
             "data": gridData,
             "columns": [
-                { data: 'name', title: 'Origin',
-                  "fnCreatedCell": function (nTd, sData, oData, iRow, iCol) {
-                    $(nTd).html("<a href='{{ url_for('settings_devices') }}?id="+oData.device_id+"'>"+oData.name+"</a>");
-                  }
-                },
-                { data: 'lastProtoDateTime', title: 'Last Update' },
-                { data: 'currentSleepTime', title: 'Next Action' },
-                { data: 'rmname', title: 'Route',
-                  "fnCreatedCell": function (nTd, sData, oData, iRow, iCol) {
-                    if(oData.area_id != -1) {
-                      $(nTd).html("<a href='{{ url_for('settings_areas') }}?id="+oData.area_id+"&mode="+oData.mode+"'>"+oData.rmname+"</a>");
-                    } else {
-                      $(nTd).html('Idle');
+                {
+                    data: 'name', title: 'Origin',
+                    "render": function (data, type, oData) {
+                        return "<a href='{{ url_for('settings_devices') }}?id=" + oData.device_id + "'>" + oData.name + "</a>";
                     }
-                  }
                 },
-                { data: 'routeMax', title: 'Route Length' },
-                { data: 'init', title: 'Init Mode' },
-                { data: 'restartCounter', title: 'Restart Counter' },
-                { data: 'globalrestartcount', title: 'Total Restarts' },
-                { data: 'lastPogoRestart', title: 'Last Restart' },
-                { data: 'rebootingOption', title: 'Reboot Device' },
-                { data: 'rebootCounter', title: 'Reboot Counter' },
-                { data: 'globalrebootcount', title: 'Total Reboots' },
-                { data: 'lastPogoReboot', title: 'Last Reboot' },
-                { data: 'currentPos', title: 'Current Pos' },
-                { data: 'lastPos', title: 'Last Pos' }
+                {data: 'lastProtoDateTime', title: 'Last Update'},
+                {data: 'currentSleepTime', title: 'Next Action'},
+                {
+                    data: 'rmname', title: 'Route',
+                    "render": function (data, type, oData) {
+                        if (oData.rmname != 'Idle') {
+                            return "<a href='{{ url_for('settings_areas') }}?id=" + oData.area_id + "&mode=" + oData.mode + "'>" + oData.rmname + "</a>";
+                        } else {
+                            return 'Idle';
+                        }
+                    }
+                },
+                {data: 'routeMax', title: 'Route Length'},
+                {data: 'init', title: 'Init Mode'},
+                {data: 'restartCounter', title: 'Restart Counter'},
+                {data: 'globalrestartcount', title: 'Total Restarts'},
+                {data: 'lastPogoRestart', title: 'Last Restart'},
+                {data: 'rebootingOption', title: 'Reboot Device'},
+                {data: 'rebootCounter', title: 'Reboot Counter'},
+                {data: 'globalrebootcount', title: 'Total Reboots'},
+                {data: 'lastPogoReboot', title: 'Last Reboot'},
+                {data: 'currentPos', title: 'Current Pos'},
+                {data: 'lastPos', title: 'Last Pos'}
             ],
             "columnDefs": [
                 {
                     "targets": [5, 9],
                     "render": function (data, type, row) {
-                        return (parseInt(data) == 0 ? "False":"True");
+                        return (parseInt(data) == 0 ? "False" : "True");
                     }
                 },
                 {
@@ -63,11 +64,11 @@
                     }
                 },
                 {
-                    "targets": [1,8,12],
+                    "targets": [1, 8, 12],
                     "render": function (data, type, row) {
-                        var dateToShow = moment.utc(data*1000);
-                        if (dateToShow.isValid()) {
-                            return toHHMMSS(Math.abs(dateToShow.diff(moment.utc())/1000));
+                        var dateToShow = moment.utc(data * 1000);
+                        if (dateToShow.isValid() && data != null && data != undefined) {
+                            return toHHMMSS(Math.abs(dateToShow.diff(moment.utc()) / 1000));
                         }
                         return "None";
                     }
@@ -88,7 +89,7 @@
             localStorage.setItem( 'MAD_STATUS_' + settings.sInstance, JSON.stringify(data) )
             },
             "stateLoadCallback": function(settings) {
-            return JSON.parse( localStorage.getItem( 'MAD_STATUS_' + settings.sInstance ) )
+                return JSON.parse( localStorage.getItem( 'MAD_STATUS_' + settings.sInstance ) )
             }
         });
     }


### PR DESCRIPTION
The table, trs_status, was converted from datetime to timestamp.  This is to store all numbers in epoch vs the local timezone.  Setting the device idle mode now works correctly

Fixes:

- Adjust the columns to be TIMESTAMP so the values are stored as epoch (trs_status)
- Idle mode is now shown correctly and no longer produces invalid SQL during insert
- Links on the status page (device / area) now properly link when they are compressed / hidden on mobile