### PR TITLE
Change SUCCESS logging

### DIFF
--- a/mapadroid/mitm_receiver/MITMDataProcessor.py
+++ b/mapadroid/mitm_receiver/MITMDataProcessor.py
@@ -67,7 +67,7 @@ class MitmDataProcessor(Process):
             logger.debug4("Received payload: {}", data["payload"])
             if data_type == 106:
                 # process GetMapObject
-                logger.success("Processing GMO received from {}. Received at {}", str(
+                logger.info("Processing GMO received from {}. Received at {}", str(
                     origin), str(datetime.fromtimestamp(received_timestamp)))
 
                 if self.__application_args.weather:

--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -94,7 +94,7 @@ class MITMBase(WorkerBase):
             logger.warning("Mappings/Routemanagers have changed, stopping worker to be created again")
             raise InternalStopWorkerException
         if data_requested != LatestReceivedType.UNDEFINED:
-            logger.debug('Got the data requested...')
+            logger.success('Got the data requested')
             self._reboot_count = 0
             self._restart_count = 0
             self._rec_data_time = datetime.now()


### PR DESCRIPTION
In my opinion, "Got the data requested" is the "actual success" of the scanner/worker we usually care about.

As argued on discord:

With the change, you'll basically get one SUCCESS or one WARNING (timeout) per route step on mon/raid scans (outside of unusual errors) instead of possibly multiple successes with data that's not relevant for the active scan mode. The changed output also makes sense in pokestop (quest) mode.

I think it's a logical change and makes it a little easier to see how your scanning is doing at a glance at the logs.

Got 2 agreements and no objections on discord, so I went ahead 😄 