### PR TITLE
Remove filewatcher

### DIFF
--- a/configs/config.ini.example
+++ b/configs/config.ini.example
@@ -85,11 +85,6 @@
 #adb_server_ip:               # IP address of ADB server (Default: 127.0.0.1)
 #adb_server_port:             # Port of ADB server (Default: 5037)
 
-# auto reload mappings
-######################
-#auto_reload_config          # Auto reload mappings configuration
-#auto_reload_delay:           # Auto reload mappings configuration delay in seconds (Default: 60)
-
 # Game Stats
 ######################
 #game_stats                  # Generate worker stats

--- a/mapadroid/madmin/routes/config.py
+++ b/mapadroid/madmin/routes/config.py
@@ -383,6 +383,5 @@ class config(object):
 
     @auth_required
     def reload(self):
-        if not self._args.auto_reload_config:
-            self._mapping_mananger.update()
+        self._mapping_mananger.update()
         return redirect(url_for('settings_devices'), code=302)

--- a/mapadroid/utils/MappingManager.py
+++ b/mapadroid/utils/MappingManager.py
@@ -107,11 +107,6 @@ class MappingManager:
     def get_devicemappings_of(self, device_name: str) -> Optional[dict]:
         return self._devicemappings.get(device_name, None)
 
-    def set_devicemapping_value_of(self, device_name: str, key: str, value):
-        with self.__mappings_mutex:
-            if self._devicemappings.get(device_name, None) is not None:
-                self._devicemappings[device_name][key] = value
-
     def get_devicesettings_of(self, device_name: str) -> Optional[dict]:
         return self._devicemappings.get(device_name, None).get('settings', None)
 

--- a/mapadroid/utils/walkerArgs.py
+++ b/mapadroid/utils/walkerArgs.py
@@ -258,14 +258,6 @@ def parseArgs():
     parser.add_argument('-ld', '--lure_duration', default='30', type=int,
                         help='Lure duration in minutes. (Default: 30)')
 
-    # mappings.json auto reloader
-
-    parser.add_argument('-arc', '--auto_reload_config', action='store_true', default=False,
-                        help='Auto reload mappings configuration')
-
-    parser.add_argument('-ard', '--auto_reload_delay', default=60,
-                        help='Auto reload mappings configuration sleeptimer (Default: 60)')
-
     # stats
 
     parser.add_argument('-ggs', '--game_stats', action='store_true', default=False,


### PR DESCRIPTION
Remove filewatcher and related config arguments from MAD.  This feature has been deprecated as the configuration has been moved to the database.