### PR TITLE
Alternate approach to fix login issues

### DIFF
--- a/mapadroid/websocket/communicator.py
+++ b/mapadroid/websocket/communicator.py
@@ -76,11 +76,11 @@ class Communicator:
     def clearAppCache(self, package_name) -> bool:
         return self.__runAndOk("more cache {}\r\n".format(package_name), self.__command_timeout)
 
-    def magisk_off(self, package_name) -> bool:
-        return self.passthrough("su -c magiskhide --rm {}".format(package_name))
+    def magisk_off(self) -> bool:
+        return self.passthrough("su -c magiskhide --disable")
 
-    def magisk_on(self, package_name) -> bool:
-        return self.passthrough("su -c magiskhide --add {}".format(package_name))
+    def magisk_on(self) -> bool:
+        return self.passthrough("su -c magiskhide --enable")
 
     def turnScreenOn(self) -> bool:
         return self.__runAndOk("more screen on\r\n", self.__command_timeout)


### PR DESCRIPTION
I was struggling a lot with SN failures or the game stuck at the login screen.
With the current approach, MAD would only restart the device which mostly did not solve the issue.
I found out that PoGo often is stuck during login if PD is already running.
Thus, now PD gets closed before PoGo is restarted and started afterwards again.
Furthermore, PoGo seems to "repair" the stuck at login screen issue if you kill it when it is stuck (Logout button appears) and just restart it.
I added the command to start the PD hook receiver service after launching the app to initiate the processing/injection.
Since clearing cache mostly does nothing, I don't do that most of the times anymore.
To be always on the "safe" side when restarting PoGo, the "magic" is always applied on PoGo restart.

Maybe not the prettiest solution, but works so far for me quite well.

Btw.: I have no idea if the Magisk hide toggling is really necessary. I did not do any intense testing there.