### PR TITLE
Websocket rework

### DIFF
--- a/mapadroid/madmin/routes/control.py
+++ b/mapadroid/madmin/routes/control.py
@@ -79,7 +79,7 @@ class control(object):
         screens_phone = []
         ws_connected_phones = []
         if self._ws_server is not None:
-            phones = self._ws_server.get_reg_origins().copy()
+            phones = self._ws_server.get_reg_origins()
         else:
             phones = []
         devicemappings = self._mapping_manager.get_all_devicemappings()
@@ -241,7 +241,7 @@ class control(object):
                               str(real_click_y),
                               str(real_click_xe), str(real_click_ye), str(origin))
             temp_comm = self._ws_server.get_origin_communicator(origin)
-            temp_comm.touchandhold(int(real_click_x), int(
+            temp_comm.touch_and_hold(int(real_click_x), int(
                 real_click_y), int(real_click_xe), int(real_click_ye))
 
         time.sleep(2)
@@ -273,12 +273,12 @@ class control(object):
             temp_comm = self._ws_server.get_origin_communicator(origin)
             if restart:
                 self._logger.info('MADMin: trying to restart game on {}', str(origin))
-                temp_comm.restartApp("com.nianticlabs.pokemongo")
+                temp_comm.restart_app("com.nianticlabs.pokemongo")
 
                 time.sleep(1)
             else:
                 self._logger.info('MADMin: trying to stop game on {}', str(origin))
-                temp_comm.stopApp("com.nianticlabs.pokemongo")
+                temp_comm.stop_app("com.nianticlabs.pokemongo")
 
             self._logger.info('MADMin: WS command successfully ({})', str(origin))
         time.sleep(2)
@@ -318,7 +318,7 @@ class control(object):
             self._logger.info('MADMin: ADB shell command successfully ({})', str(origin))
         else:
             temp_comm = self._ws_server.get_origin_communicator(origin)
-            temp_comm.resetAppdata("com.nianticlabs.pokemongo")
+            temp_comm.reset_app_data("com.nianticlabs.pokemongo")
         return redirect(url_for('get_phonescreens'), code=302)
 
     @auth_required
@@ -338,7 +338,7 @@ class control(object):
                           str(coords[0]), str(coords[1]), str(origin))
         try:
             temp_comm = self._ws_server.get_origin_communicator(origin)
-            temp_comm.setLocation(coords[0], coords[1], 0)
+            temp_comm.set_location(coords[0], coords[1], 0)
             if int(sleeptime) > 0:
                 self._logger.info("MADmin: Set additional sleeptime: {} ({})",
                                   str(sleeptime), str(origin))
@@ -366,7 +366,7 @@ class control(object):
             self._logger.info('MADMin: Send text successfully ({})', str(origin))
         else:
             temp_comm = self._ws_server.get_origin_communicator(origin)
-            temp_comm.sendText(text)
+            temp_comm.send_text(text)
 
         time.sleep(2)
         return self.take_screenshot(origin, useadb)
@@ -389,9 +389,9 @@ class control(object):
         else:
             temp_comm = self._ws_server.get_origin_communicator(origin)
             if command == 'home':
-                temp_comm.homeButton()
+                temp_comm.home_button()
             elif command == 'back':
-                temp_comm.backButton()
+                temp_comm.back_button()
 
         time.sleep(2)
         return self.take_screenshot(origin, useadb)

--- a/mapadroid/madmin/routes/control.py
+++ b/mapadroid/madmin/routes/control.py
@@ -13,6 +13,7 @@ from mapadroid.madmin.functions import (
 )
 from mapadroid.utils import MappingManager
 from mapadroid.utils.adb import ADBConnect
+from mapadroid.utils.collections import Location
 from mapadroid.utils.functions import (creation_date, generate_phones, image_resize)
 from mapadroid.utils.logging import logger
 from mapadroid.utils.madGlobals import ScreenshotType
@@ -338,7 +339,7 @@ class control(object):
                           str(coords[0]), str(coords[1]), str(origin))
         try:
             temp_comm = self._ws_server.get_origin_communicator(origin)
-            temp_comm.set_location(coords[0], coords[1], 0)
+            temp_comm.set_location(Location(coords[0], coords[1]), 0)
             if int(sleeptime) > 0:
                 self._logger.info("MADmin: Set additional sleeptime: {} ({})",
                                   str(sleeptime), str(origin))
@@ -366,7 +367,7 @@ class control(object):
             self._logger.info('MADMin: Send text successfully ({})', str(origin))
         else:
             temp_comm = self._ws_server.get_origin_communicator(origin)
-            temp_comm.send_text(text)
+            temp_comm.enter_text(text)
 
         time.sleep(2)
         return self.take_screenshot(origin, useadb)

--- a/mapadroid/mitm_receiver/MITMReceiver.py
+++ b/mapadroid/mitm_receiver/MITMReceiver.py
@@ -140,9 +140,11 @@ class MITMReceiver(Process):
         logger.debug4("Proto data received from {}: {}".format(origin, str(data)))
         if isinstance(data, list):
             # list of protos... we hope so at least....
+            logger.info("Receiving list of protos")
             for proto in data:
                 self.__handle_proto_data_dict(origin, proto)
         elif isinstance(data, dict):
+            logger.info("Receiving single proto")
             # single proto, parse it...
             self.__handle_proto_data_dict(origin, data)
 

--- a/mapadroid/mitm_receiver/MitmMapper.py
+++ b/mapadroid/mitm_receiver/MitmMapper.py
@@ -157,6 +157,8 @@ class MitmMapper(object):
         return updated
 
     def set_injection_status(self, origin, status=True):
+        if not self.__injected[origin] and status is True:
+            logger.info("Worker {} is injected now", str(origin))
         self.__injected[origin] = status
 
     def get_injection_status(self, origin):

--- a/mapadroid/mitm_receiver/MitmMapper.py
+++ b/mapadroid/mitm_receiver/MitmMapper.py
@@ -157,7 +157,7 @@ class MitmMapper(object):
         return updated
 
     def set_injection_status(self, origin, status=True):
-        if not self.__injected[origin] and status is True:
+        if origin not in self.__injected or not self.__injected[origin] and status is True:
             logger.info("Worker {} is injected now", str(origin))
         self.__injected[origin] = status
 

--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -384,13 +384,13 @@ class WordToScreenMatching(object):
         # username
         self._communicator.click(self._width / 2, username_y)
         time.sleep(.5)
-        self._communicator.sendText(ptc.username)
+        self._communicator.send_text(ptc.username)
         self._communicator.click(100, 100)
         time.sleep(2)
         # password
         self._communicator.click(self._width / 2, password_y)
         time.sleep(.5)
-        self._communicator.sendText(ptc.password)
+        self._communicator.send_text(ptc.password)
         self._communicator.click(100, 100)
         time.sleep(2)
         # button
@@ -411,7 +411,7 @@ class WordToScreenMatching(object):
         click_y = (self._height / 1.69) + self._screenshot_y_offset
         logger.debug('Click ' + str(click_x) + ' / ' + str(click_y))
         self._communicator.click(click_x, click_y)
-        self._communicator.touchandhold(click_x, click_y, click_x, click_y - (self._height / 2), 200)
+        self._communicator.touch_and_hold(click_x, click_y, click_x, click_y - (self._height / 2), 200)
         time.sleep(1)
         self._communicator.click(click_x, click_y)
         time.sleep(1)
@@ -421,7 +421,7 @@ class WordToScreenMatching(object):
         time.sleep(1)
 
     def detect_screentype(self) -> ScreenType:
-        topmostapp = self._communicator.topmostApp()
+        topmostapp = self._communicator.topmost_app()
         if not topmostapp:
             return ScreenType.ERROR
 
@@ -449,7 +449,7 @@ class WordToScreenMatching(object):
 
         logger.info('Listening to Dr. blabla - please wait')
 
-        self._communicator.backButton()
+        self._communicator.back_button()
         time.sleep(3)
         return ScreenType.UNDEFINED
 

--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -384,13 +384,13 @@ class WordToScreenMatching(object):
         # username
         self._communicator.click(self._width / 2, username_y)
         time.sleep(.5)
-        self._communicator.send_text(ptc.username)
+        self._communicator.enter_text(ptc.username)
         self._communicator.click(100, 100)
         time.sleep(2)
         # password
         self._communicator.click(self._width / 2, password_y)
         time.sleep(.5)
-        self._communicator.send_text(ptc.password)
+        self._communicator.enter_text(ptc.password)
         self._communicator.click(100, 100)
         time.sleep(2)
         # button

--- a/mapadroid/route/RouteManagerBase.py
+++ b/mapadroid/route/RouteManagerBase.py
@@ -21,6 +21,7 @@ from mapadroid.utils.data_manager.modules.routecalc import RouteCalc
 from mapadroid.utils.geo import get_distance_of_two_points_in_meters
 from mapadroid.utils.logging import logger
 from mapadroid.utils.walkerArgs import parseArgs
+from mapadroid.worker.WorkerType import WorkerType
 
 args = parseArgs()
 
@@ -66,7 +67,7 @@ class RouteManagerBase(ABC):
         self._max_radius: float = max_radius
         self._max_coords_within_radius: int = max_coords_within_radius
         self.settings: dict = settings
-        self.mode = mode
+        self.mode: WorkerType = mode
         self._is_started: bool = False
         self._first_started = False
         self._current_route_round_coords: List[Location] = []
@@ -1102,7 +1103,7 @@ class RouteManagerBase(ABC):
     def get_init(self) -> bool:
         return self.init
 
-    def get_mode(self):
+    def get_mode(self) -> WorkerType:
         return self.mode
 
     def get_settings(self) -> Optional[dict]:

--- a/mapadroid/route/RouteManagerFactory.py
+++ b/mapadroid/route/RouteManagerFactory.py
@@ -5,19 +5,21 @@ from mapadroid.route.RouteManagerIV import RouteManagerIV
 from mapadroid.route.RouteManagerLeveling import RouteManagerLeveling
 from mapadroid.route.RouteManagerQuests import RouteManagerQuests
 from mapadroid.route.RouteManagerRaids import RouteManagerRaids
+from mapadroid.worker.WorkerType import WorkerType
 
 
 class RouteManagerFactory:
     @staticmethod
     def get_routemanager(db_wrapper, dbm, area_id, coords, max_radius, max_coords_within_radius,
                          path_to_include_geofence,
-                         path_to_exclude_geofence: Optional[int], routefile: str, mode: Optional[str] = None,
+                         path_to_exclude_geofence: Optional[int], routefile: str,
+                         mode: WorkerType = WorkerType.UNDEFINED,
                          init: bool = False, name: str = "unknown", settings=None,
                          coords_spawns_known: bool = False,
                          level: bool = False, calctype: str = "optimized", useS2: bool = False,
                          S2level: int = 15, joinqueue=None):
 
-        if mode == "raids_mitm":
+        if mode == WorkerType.RAID_MITM.value:
             route_manager = RouteManagerRaids(db_wrapper, dbm, area_id, coords, max_radius,
                                               max_coords_within_radius,
                                               path_to_include_geofence, path_to_exclude_geofence, routefile,
@@ -25,7 +27,7 @@ class RouteManagerFactory:
                                               joinqueue=joinqueue,
                                               useS2=useS2, S2level=S2level
                                               )
-        elif mode == "mon_mitm":
+        elif mode == WorkerType.MON_MITM.value:
             route_manager = RouteManagerMon(db_wrapper, dbm, area_id, coords, max_radius,
                                             max_coords_within_radius,
                                             path_to_include_geofence, path_to_exclude_geofence, routefile,
@@ -33,20 +35,20 @@ class RouteManagerFactory:
                                             joinqueue=joinqueue,
                                             coords_spawns_known=coords_spawns_known
                                             )
-        elif mode == "iv_mitm":
+        elif mode == WorkerType.IV_MITM.value:
             route_manager = RouteManagerIV(db_wrapper, dbm, area_id, coords, 0, 99999999,
                                            path_to_include_geofence, path_to_exclude_geofence, routefile,
                                            mode=mode, settings=settings, init=False, name=name,
                                            joinqueue=joinqueue
                                            )
-        elif mode == "idle":
+        elif mode == WorkerType.IDLE.value:
             route_manager = RouteManagerRaids(db_wrapper, dbm, area_id, coords, max_radius,
                                               max_coords_within_radius,
                                               path_to_include_geofence, path_to_exclude_geofence, routefile,
                                               mode=mode, settings=settings, init=init, name=name,
                                               joinqueue=joinqueue
                                               )
-        elif mode == "pokestops":
+        elif mode == WorkerType.STOPS.value:
             if level:
                 route_manager = RouteManagerLeveling(db_wrapper, dbm, area_id, coords, max_radius,
                                                      max_coords_within_radius,

--- a/mapadroid/utils/CustomTypes.py
+++ b/mapadroid/utils/CustomTypes.py
@@ -1,0 +1,3 @@
+from typing import Union
+
+MessageTyping = Union[str, bytes]

--- a/mapadroid/utils/MappingManager.py
+++ b/mapadroid/utils/MappingManager.py
@@ -14,6 +14,7 @@ from mapadroid.route.RouteManagerFactory import RouteManagerFactory
 from mapadroid.utils.collections import Location
 from mapadroid.utils.logging import logger
 from mapadroid.utils.s2Helper import S2Helper
+from mapadroid.worker.WorkerType import WorkerType
 
 mode_mapping = {
     "raids_mitm": {
@@ -253,9 +254,9 @@ class MappingManager:
         routemanager = self.__fetch_routemanager(routemanager_name)
         return routemanager.get_level_mode() if routemanager is not None else None
 
-    def routemanager_get_mode(self, routemanager_name: str) -> Optional[str]:
+    def routemanager_get_mode(self, routemanager_name: str) -> WorkerType:
         routemanager = self.__fetch_routemanager(routemanager_name)
-        return routemanager.get_mode() if routemanager is not None else None
+        return routemanager.get_mode() if routemanager is not None else WorkerType.UNDEFINED.value
 
     def routemanager_get_name(self, routemanager_name: str) -> Optional[str]:
         routemanager = self.__fetch_routemanager(routemanager_name)

--- a/mapadroid/utils/collections.py
+++ b/mapadroid/utils/collections.py
@@ -7,3 +7,4 @@ Relation = collections.namedtuple(
 Trash = collections.namedtuple('Trash', ['x', 'y'])
 Login_PTC = collections.namedtuple('PTC', ['username', 'password'])
 Login_GGL = collections.namedtuple('GGL', ['username'])
+OutgoingMessage = collections.namedtuple('OutgoingMessage', ['id', 'message'])

--- a/mapadroid/utils/madGlobals.py
+++ b/mapadroid/utils/madGlobals.py
@@ -8,6 +8,10 @@ class WebsocketWorkerRemovedException(Exception):
     pass
 
 
+class WebsocketWorkerConnectionClosedException(Exception):
+    pass
+
+
 class WebsocketWorkerTimeoutException(Exception):
     pass
 

--- a/mapadroid/utils/updater.py
+++ b/mapadroid/utils/updater.py
@@ -547,11 +547,11 @@ class deviceUpdater(object):
             elif jobtype == jobType.REBOOT:
                 return ws_conn.reboot()
             elif jobtype == jobType.RESTART:
-                return ws_conn.restartApp("com.nianticlabs.pokemongo")
+                return ws_conn.restart_app("com.nianticlabs.pokemongo")
             elif jobtype == jobType.STOP:
-                return ws_conn.stopApp("com.nianticlabs.pokemongo")
+                return ws_conn.stop_app("com.nianticlabs.pokemongo")
             elif jobtype == jobType.START:
-                return ws_conn.startApp("com.nianticlabs.pokemongo")
+                return ws_conn.start_app("com.nianticlabs.pokemongo")
             elif jobtype == jobType.PASSTHROUGH:
                 command = self._log[str(item)]['file']
                 returning = ws_conn.passthrough(command).replace('\r', '').replace('\n', '').replace('  ', '')

--- a/mapadroid/utils/updater.py
+++ b/mapadroid/utils/updater.py
@@ -5,7 +5,7 @@ import re
 import time
 from datetime import datetime, timedelta
 from enum import Enum
-from multiprocessing import Queue
+from multiprocessing import Queue, Event
 from queue import Empty
 from threading import RLock, Thread
 
@@ -61,12 +61,18 @@ class deviceUpdater(object):
         self.kill_old_jobs()
         self.load_automatic_jobs()
 
+        self._stop_updater_threads: Event = Event()
         self.t_updater = []
         for i in range(self._args.job_thread_count):
             t = Thread(name='apk_updater-{}'.format(str(i)), target=self.process_update_queue, args=(i,))
             t.daemon = True
             self.t_updater.append(t)
             t.start()
+
+    def stop_updater(self):
+        self._stop_updater_threads.set()
+        for thread in self.t_updater:
+            thread.join()
 
     def init_jobs(self):
         self._commands = {}
@@ -146,13 +152,17 @@ class deviceUpdater(object):
     def process_update_queue(self, threadnumber):
         logger.info("Starting Device Job processor thread No {}".format(str(threadnumber)))
         time.sleep(10)
-        while True:
+        while not self._stop_updater_threads.is_set():
             try:
                 jobstatus = jobReturn.UNKNOWN
                 try:
-                    item = self._update_queue.get()
+                    # item = self._update_queue.get()
+                    item = self._update_queue.get_nowait()
                 except Empty:
-                    time.sleep(2)
+                    time.sleep(1)
+                    continue
+                if item is None:
+                    time.sleep(1)
                     continue
 
                 if item not in self._log:
@@ -384,6 +394,7 @@ class deviceUpdater(object):
                 break
 
             time.sleep(2)
+        logger.info("Updater thread stopped")
 
     @logger.catch()
     def preadd_job(self, origin, job, id_, type, globalid=None):

--- a/mapadroid/websocket/AbstractCommunicator.py
+++ b/mapadroid/websocket/AbstractCommunicator.py
@@ -1,0 +1,170 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from mapadroid.utils.CustomTypes import MessageTyping
+from mapadroid.utils.collections import Location
+from mapadroid.utils.madGlobals import ScreenshotType
+
+
+class AbstractCommunicator(ABC):
+    @abstractmethod
+    def cleanup(self) -> None:
+        """
+        Cleanup connection
+        :return:
+        """
+        pass
+
+    @abstractmethod
+    def install_apk(self, timeout: float, filepath: str = None, data=None) -> bool:
+        pass
+
+    @abstractmethod
+    def start_app(self, package_name: str) -> bool:
+        pass
+
+    @abstractmethod
+    def stop_app(self, package_name: str) -> bool:
+        pass
+
+    @abstractmethod
+    def passthrough(self, command) -> Optional[MessageTyping]:
+        pass
+
+    @abstractmethod
+    def reboot(self) -> bool:
+        pass
+
+    @abstractmethod
+    def restart_app(self, package_name: str) -> bool:
+        pass
+
+    @abstractmethod
+    def reset_app_data(self, package_name: str) -> bool:
+        pass
+
+    @abstractmethod
+    def clear_app_cache(self, package_name: str) -> bool:
+        pass
+
+    @abstractmethod
+    def magisk_off(self, package_name: str) -> None:
+        pass
+
+    @abstractmethod
+    def magisk_on(self, package_name: str) -> None:
+        pass
+
+    @abstractmethod
+    def turn_screen_on(self) -> bool:
+        pass
+
+    @abstractmethod
+    def click(self, x: int, y: int) -> bool:
+        pass
+
+    @abstractmethod
+    def swipe(self, x1: int, y1: int, x2: int, y2: int) -> Optional[MessageTyping]:
+        pass
+
+    @abstractmethod
+    def touch_and_hold(self, x1: int, y1: int, x2: int, y2: int, duration: int = 3000) -> bool:
+        """
+
+        :param x1: From x
+        :param y1: From y
+        :param x2: To x
+        :param y2: To y
+        :param duration: in ms
+        :return: success indicator
+        """
+        pass
+
+    @abstractmethod
+    def get_screensize(self) -> Optional[MessageTyping]:
+        pass
+
+    @abstractmethod
+    def uiautomator(self) -> Optional[MessageTyping]:
+        """
+        :return: Output of `uiautomator` shipped with android (or is it busybox?)
+        """
+        pass
+
+    @abstractmethod
+    def get_screenshot(self, path: str, quality: int = 70,
+                       screenshot_type: ScreenshotType = ScreenshotType.JPEG) -> bool:
+        """
+
+        :param path: the screenshot is to be stored at
+        :param quality: of the screenshot (compression)
+        :param screenshot_type: whether it's jpeg or png
+        :return: boolean indicating success or failure
+        """
+        pass
+
+    @abstractmethod
+    def back_button(self) -> bool:
+        pass
+
+    @abstractmethod
+    def home_button(self) -> bool:
+        """
+        Keyevent 3
+        :return:
+        """
+        pass
+
+    @abstractmethod
+    def enter_button(self) -> bool:
+        """
+        Keyevent 61
+        :return:
+        """
+        pass
+
+    @abstractmethod
+    def enter_text(self, text: str) -> bool:
+        pass
+
+    @abstractmethod
+    def is_screen_on(self) -> bool:
+        """
+        Determine whether the screen is turned on
+        :return:
+        """
+        pass
+
+    @abstractmethod
+    def is_pogo_topmost(self) -> bool:
+        pass
+
+    @abstractmethod
+    def topmost_app(self) -> Optional[MessageTyping]:
+        """
+        Return the app / activity that is currently shown
+        :return:
+        """
+        pass
+
+    @abstractmethod
+    def set_location(self, location: Location, altitude: float) -> Optional[MessageTyping]:
+        pass
+
+    @abstractmethod
+    def terminate_connection(self) -> bool:
+        """
+        Gracefully terminate the connection (tell the partner to close)
+        :return:
+        """
+
+    @abstractmethod
+    def walk_from_to(self, location_from: Location, location_to: Location, speed: float) -> Optional[MessageTyping]:
+        """
+
+        :param location_from:
+        :param location_to:
+        :param speed: in km/h
+        :return:
+        """
+        pass

--- a/mapadroid/websocket/WebsocketConnectedClientEntry.py
+++ b/mapadroid/websocket/WebsocketConnectedClientEntry.py
@@ -3,7 +3,7 @@ import math
 import queue
 import time
 from threading import Thread
-from typing import NamedTuple, Optional, Dict
+from typing import Optional, Dict
 
 import websockets
 

--- a/mapadroid/websocket/WebsocketConnectedClientEntry.py
+++ b/mapadroid/websocket/WebsocketConnectedClientEntry.py
@@ -1,0 +1,128 @@
+import asyncio
+import math
+import queue
+import time
+from threading import Thread
+from typing import NamedTuple, Optional, Dict
+
+import websockets
+
+from mapadroid.utils.CustomTypes import MessageTyping
+from mapadroid.utils.logging import logger
+from mapadroid.utils.madGlobals import WebsocketWorkerRemovedException, WebsocketWorkerTimeoutException, \
+    WebsocketWorkerConnectionClosedException
+from mapadroid.worker.AbstractWorker import AbstractWorker
+
+
+class ReceivedMessageEntry:
+    def __init__(self):
+        # TODO: consider timestamp of when the message was waited for to cleanup?
+        self.message: Optional[MessageTyping] = None
+        self.message_received_event: asyncio.Event = asyncio.Event()
+
+
+class WebsocketConnectedClientEntry:
+    def __init__(self, origin: str, worker_thread: Optional[Thread], worker_instance: Optional[AbstractWorker],
+                 websocket_client_connection: Optional[websockets.WebSocketClientProtocol],
+                 loop_running: asyncio.AbstractEventLoop):
+        self.origin: str = origin
+        self.worker_thread: Optional[Thread] = worker_thread
+        self.worker_instance: Optional[AbstractWorker] = worker_instance
+        self.websocket_client_connection: Optional[websockets.WebSocketClientProtocol] = websocket_client_connection
+        self.loop_running: asyncio.AbstractEventLoop = loop_running
+        self.fail_counter: int = 0
+        self.send_queue: queue.Queue = queue.Queue()
+        self.received_messages: Dict[int, ReceivedMessageEntry] = {}
+        self.received_mutex: asyncio.Lock = asyncio.Lock()
+        self.message_id_counter: int = 0
+        self.message_id_mutex: asyncio.Lock = asyncio.Lock()
+        # store a timestamp in order to cleanup (soft-states)
+        self.last_message_received_at: float = 0
+
+    async def set_message_response(self, message_id: int, message: MessageTyping) -> None:
+        async with self.received_mutex:
+            message_entry = self.received_messages.get(message_id, None)
+            if message_entry is not None:
+                message_entry.message_received_event.set()
+                message_entry.message = message
+                self.last_message_received_at = time.time()
+
+    def send_and_wait(self, message: MessageTyping, timeout: float, worker_instance: AbstractWorker,
+                      byte_command: Optional[int] = None) -> Optional[MessageTyping]:
+        future = asyncio.run_coroutine_threadsafe(
+            self.send_and_wait_async(message, timeout, worker_instance, byte_command=byte_command),
+            self.loop_running)
+        return future.result()
+
+    async def send_and_wait_async(self, message: MessageTyping, timeout: float, worker_instance: AbstractWorker,
+                                  byte_command: Optional[int] = None) -> Optional[MessageTyping]:
+        if self.worker_instance is None or self.worker_instance != worker_instance and worker_instance != 'madmin':
+            # TODO: consider changing this...
+            raise WebsocketWorkerRemovedException
+        elif self.websocket_client_connection.closed:
+            raise WebsocketWorkerConnectionClosedException
+
+        # install new ReceivedMessageEntry
+        message_id: int = await self.__get_new_message_id()
+        new_entry = ReceivedMessageEntry()
+        async with self.received_mutex:
+            self.received_messages[message_id] = new_entry
+
+        if isinstance(message, bytes):
+            logger.debug("{} sending binary: {}", self.origin, str(message[:10]))
+        else:
+            logger.debug("{} sending command: {}", self.origin, message.strip())
+        # send message
+        await self.__send_message(message_id, message, byte_command)
+
+        # wait for it to trigger...
+        logger.debug("Timeout towards {}: {}", self.origin, str(timeout))
+        response = None
+        try:
+            event_triggered = await asyncio.wait_for(new_entry.message_received_event.wait(), timeout=timeout)
+            if event_triggered:
+                logger.debug("Received answer from {} in time, popping response", self.origin)
+                self.fail_counter = 0
+                if isinstance(new_entry.message, str):
+                    logger.debug("Response to {}: {}",
+                                 str(id), str(new_entry.message.strip()))
+                else:
+                    logger.debug("Received binary data to {}, starting with {}", str(
+                        id), str(new_entry.message[:10]))
+                response = new_entry.message
+        except asyncio.TimeoutError:
+            logger.warning("Timeout, increasing timeout-counter of {}", self.origin)
+            # TODO: why is the user removed here?
+            self.fail_counter += 1
+            if self.fail_counter > 5:
+                logger.error("5 consecutive timeouts to {} or origin is not longer connected, cleanup",
+                             str(id))
+                raise WebsocketWorkerTimeoutException
+        finally:
+            async with self.received_mutex:
+                self.received_messages.pop(message_id)
+        return response
+
+    async def __send_message(self, message_id: int, message: MessageTyping,
+                             byte_command: Optional[int] = None) -> None:
+        if isinstance(message, str):
+            to_be_sent: str = u"%s;%s" % (str(message_id), message)
+            logger.debug("To be sent to {}: {}", self.origin, to_be_sent.strip())
+        elif byte_command is not None:
+            to_be_sent: bytes = (int(message_id)).to_bytes(4, byteorder='big')
+            to_be_sent += (int(byte_command)).to_bytes(4, byteorder='big')
+            to_be_sent += message
+            logger.debug("To be sent to {} (message ID: {}): {}", id, message_id, str(to_be_sent[:10]))
+        else:
+            logger.error("Tried to send invalid message (bytes without byte command or no byte/str passed)")
+            return
+        await self.websocket_client_connection.send(to_be_sent)
+
+    async def __get_new_message_id(self) -> int:
+        async with self.message_id_mutex:
+            self.message_id_counter += 1
+            self.message_id_counter = int(math.fmod(self.message_id_counter, 100000))
+            if self.message_id_counter == 100000:
+                self.message_id_counter = 1
+            new_message_id = self.message_id_counter
+        return new_message_id

--- a/mapadroid/websocket/WebsocketServer.py
+++ b/mapadroid/websocket/WebsocketServer.py
@@ -199,7 +199,7 @@ class WebsocketServer(object):
 
                 entry.websocket_client_connection = websocket_client_connection
                 # TODO: also change the worker's Communicator? idk yet
-                if entry.worker_thread.is_alive():
+                if entry.worker_thread.is_alive() and not entry.worker_instance.is_stopping():
                     logger.info("Worker thread of {} still alive, continue as usual", origin)
                     # TODO: does this need more handling? probably update communicator or whatever?
                 else:
@@ -213,6 +213,7 @@ class WebsocketServer(object):
         try:
             if not entry.worker_thread.is_alive():
                 entry.worker_thread.start()
+            # TODO: we need to somehow check threads and synchronize connection status with worker status?
             async with self.__users_connecting_mutex:
                 self.__users_connecting.remove(origin)
             receiver_task = asyncio.ensure_future(

--- a/mapadroid/websocket/WebsocketServer.py
+++ b/mapadroid/websocket/WebsocketServer.py
@@ -202,7 +202,7 @@ class WebsocketServer(object):
                 if entry.worker_thread.is_alive() and not entry.worker_instance.is_stopping():
                     logger.info("Worker thread of {} still alive, continue as usual", origin)
                     # TODO: does this need more handling? probably update communicator or whatever?
-                elif not entry.worker_instance.is_stopping():
+                elif not entry.worker_thread.is_alive():
                     logger.info("Old thread is dead, trying to start a new one for {}", origin)
                     if not await self.__add_worker_and_thread_to_entry(entry, origin):
                         async with self.__users_connecting_mutex:
@@ -214,7 +214,7 @@ class WebsocketServer(object):
                     # random sleep to not have clients try again in sync
                     await asyncio.sleep(rand.uniform(3, 15))
                     async with self.__users_connecting_mutex:
-                        logger.debug("Removing {} from users_connecting")
+                        logger.debug("Removing {} from users_connecting", origin)
                         self.__users_connecting.remove(origin)
                     return
 

--- a/mapadroid/websocket/WebsocketServer.py
+++ b/mapadroid/websocket/WebsocketServer.py
@@ -1,6 +1,7 @@
 import functools
 import queue
 import time
+from random import random
 from threading import Thread, current_thread, Lock, Event
 from typing import Dict, Optional, Set, KeysView, Coroutine
 
@@ -210,7 +211,8 @@ class WebsocketServer(object):
                 else:
                     logger.info("Old thread is about to stop. Wait a little and have {} reconnect",
                                 origin)
-                    await asyncio.sleep(5)
+                    # random sleep to not have clients try again in sync
+                    await asyncio.sleep(random.uniform(3, 15))
                     async with self.__users_connecting_mutex:
                         self.__users_connecting.remove(origin)
                     return

--- a/mapadroid/websocket/WebsocketServer.py
+++ b/mapadroid/websocket/WebsocketServer.py
@@ -2,7 +2,7 @@ import functools
 import queue
 import time
 from threading import Thread, current_thread, Lock, Event
-from typing import Dict, Optional, Set, KeysView, Coroutine
+from typing import Dict, Optional, Set, KeysView, Coroutine, List
 import random as rand
 
 import websockets
@@ -340,8 +340,19 @@ class WebsocketServer(object):
         await websocket_client_connection.close()
         logger.info("Connection to device {} closed", origin_of_worker)
 
-    def get_reg_origins(self) -> KeysView[str]:
-        return self.__current_users.keys()
+    async def get_connected_origins(self) -> List[str]:
+        async with self.__current_users_mutex
+            origins_connected: List[str] = []
+            for origin, entry in self.__current_users:
+                if entry.websocket_client_connection.open:
+                    origins_connected.append(origin)
+            return origins_connected
+
+    def get_reg_origins(self) -> List[str]:
+        future = asyncio.run_coroutine_threadsafe(
+            self.get_connected_origins(),
+            self.__loop)
+        return future.result()
 
     def get_origin_communicator(self, origin: str) -> Optional[AbstractCommunicator]:
         # TODO: this should probably lock?

--- a/mapadroid/websocket/WebsocketServer.py
+++ b/mapadroid/websocket/WebsocketServer.py
@@ -122,6 +122,8 @@ class WebsocketServer(object):
             self.__internal_worker_join_thread.join()
         # TODO: this could block forever, should we just place a timeout and have daemon = True handle it all anyway?
         self.__worker_shutdown_queue.join()
+        self.__loop.call_soon_threadsafe(self.__loop.stop)
+
         logger.info("Stopped websocket server")
 
     def __internal_worker_join(self):

--- a/mapadroid/websocket/WebsocketServer.py
+++ b/mapadroid/websocket/WebsocketServer.py
@@ -343,7 +343,7 @@ class WebsocketServer(object):
     async def get_connected_origins(self) -> List[str]:
         async with self.__current_users_mutex:
             origins_connected: List[str] = []
-            for origin, entry in self.__current_users:
+            for origin, entry in self.__current_users.items():
                 if entry.websocket_client_connection.open:
                     origins_connected.append(origin)
             return origins_connected

--- a/mapadroid/websocket/WebsocketServer.py
+++ b/mapadroid/websocket/WebsocketServer.py
@@ -218,6 +218,9 @@ class WebsocketServer(object):
             receiver_task = asyncio.ensure_future(
                 self.__client_message_receiver(origin, entry))
             await receiver_task
+        except Exception as e:
+            logger.opt(exception=True).error("Other unhandled exception during registration of {}: {}",
+                                             origin, e)
         # also check if thread is already running to not start it again. If it is not alive, we need to create it..
         finally:
             logger.info("Awaiting unregister of {}", origin)

--- a/mapadroid/websocket/WebsocketServer.py
+++ b/mapadroid/websocket/WebsocketServer.py
@@ -152,7 +152,11 @@ class WebsocketServer(object):
             # logger.info("All done with {}", str(
             #    websocket_client_connection.request_headers.get_all("Origin")[0]))
             # TODO: cleanup thread is not really desired, I'd prefer to only restart a worker if the route changes :(
-            entry.worker_thread.join()
+            # entry.worker_thread.join() is blocking the entire loop, do not do that! We need to tidy stuff up elsewhere
+            while entry.worker_thread.is_alive():
+                await asyncio.sleep(1)
+                if not entry.worker_thread.is_alive():
+                    entry.worker_thread.join()
         logger.info("Done with connection from {} ({})", origin, websocket_client_connection.remote_address)
 
     async def __get_new_worker(self, origin: str):

--- a/mapadroid/websocket/WebsocketServer.py
+++ b/mapadroid/websocket/WebsocketServer.py
@@ -54,7 +54,7 @@ class WebsocketServer(object):
                                                              self.__db_wrapper, self.__pogo_window_manager)
 
         # asyncio loop for the entire server
-        self.__loop: Optional[asyncio.AbstractEventLoop] = None
+        self.__loop: Optional[asyncio.AbstractEventLoop] = asyncio.new_event_loop()
         self.__loop_tid: int = -1
         self.__loop_mutex = Lock()
         self.__worker_shutdown_queue: queue.Queue[Thread] = queue.Queue()
@@ -78,6 +78,7 @@ class WebsocketServer(object):
 
     def start_server(self) -> None:
         logger.info("Starting websocket-server...")
+
         logger.debug("Device mappings: {}", str(self.__mapping_manager.get_all_devicemappings()))
 
         asyncio.set_event_loop(self.__loop)

--- a/mapadroid/websocket/WebsocketServer.py
+++ b/mapadroid/websocket/WebsocketServer.py
@@ -154,7 +154,6 @@ class WebsocketServer(object):
     async def __connection_handler(self, websocket_client_connection: websockets.WebSocketClientProtocol,
                                    path: str) -> None:
         if self.__stop_server.is_set():
-            await self.__close_websocket_client_connection("stopping...", websocket_client_connection)
             return
         # check auth and stuff TODO
         origin: Optional[str] = await self.__authenticate_connection(websocket_client_connection)

--- a/mapadroid/websocket/WebsocketServer.py
+++ b/mapadroid/websocket/WebsocketServer.py
@@ -192,7 +192,7 @@ class WebsocketServer(object):
                 if entry.websocket_client_connection.open:
                     logger.error("Old connection open while a new one is attempted to be established, "
                                  "aborting handling of connection from {}", origin)
-                    await asyncio.sleep(10)
+                    await asyncio.sleep(random.uniform(10, 15))
                     async with self.__users_connecting_mutex:
                         self.__users_connecting.remove(origin)
                     return
@@ -214,9 +214,9 @@ class WebsocketServer(object):
                     # random sleep to not have clients try again in sync
                     await asyncio.sleep(random.uniform(3, 15))
                     async with self.__users_connecting_mutex:
+                        logger.debug("Removing {} from users_connecting")
                         self.__users_connecting.remove(origin)
                     return
-
 
             self.__current_users[origin] = entry
         try:

--- a/mapadroid/websocket/WebsocketServer.py
+++ b/mapadroid/websocket/WebsocketServer.py
@@ -1,9 +1,9 @@
 import functools
 import queue
 import time
-from random import random
 from threading import Thread, current_thread, Lock, Event
 from typing import Dict, Optional, Set, KeysView, Coroutine
+import random as rand
 
 import websockets
 import asyncio
@@ -192,7 +192,7 @@ class WebsocketServer(object):
                 if entry.websocket_client_connection.open:
                     logger.error("Old connection open while a new one is attempted to be established, "
                                  "aborting handling of connection from {}", origin)
-                    await asyncio.sleep(random.uniform(10, 15))
+                    await asyncio.sleep(rand.uniform(10, 15))
                     async with self.__users_connecting_mutex:
                         self.__users_connecting.remove(origin)
                     return
@@ -212,7 +212,7 @@ class WebsocketServer(object):
                     logger.info("Old thread is about to stop. Wait a little and have {} reconnect",
                                 origin)
                     # random sleep to not have clients try again in sync
-                    await asyncio.sleep(random.uniform(3, 15))
+                    await asyncio.sleep(rand.uniform(3, 15))
                     async with self.__users_connecting_mutex:
                         logger.debug("Removing {} from users_connecting")
                         self.__users_connecting.remove(origin)

--- a/mapadroid/websocket/WebsocketServer.py
+++ b/mapadroid/websocket/WebsocketServer.py
@@ -341,7 +341,7 @@ class WebsocketServer(object):
         logger.info("Connection to device {} closed", origin_of_worker)
 
     async def get_connected_origins(self) -> List[str]:
-        async with self.__current_users_mutex
+        async with self.__current_users_mutex:
             origins_connected: List[str] = []
             for origin, entry in self.__current_users:
                 if entry.websocket_client_connection.open:

--- a/mapadroid/websocket/WebsocketServer.py
+++ b/mapadroid/websocket/WebsocketServer.py
@@ -1,32 +1,22 @@
-import asyncio
-import collections
-import functools
-import logging
-import math
-import queue
-import sys
-import time
-from threading import Event, Thread, current_thread, Lock
-from typing import Optional
+from threading import Thread, current_thread, Lock, Event
+from typing import Dict, Optional, Set
 
 import websockets
+import asyncio
 
-from mapadroid.utils import MappingManager
+from mapadroid.db.DbWrapper import DbWrapper
+from mapadroid.mitm_receiver.MitmMapper import MitmMapper
+from mapadroid.ocr.pogoWindows import PogoWindows
+from mapadroid.utils.CustomTypes import MessageTyping
+from mapadroid.utils.MappingManager import MappingManager
 from mapadroid.utils.authHelper import check_auth
+from mapadroid.utils.data_manager import DataManager
 from mapadroid.utils.logging import logger, InterceptHandler
-from mapadroid.utils.madGlobals import (
-    WebsocketWorkerRemovedException,
-    WebsocketWorkerTimeoutException,
-    WrongAreaInWalker
-)
-from mapadroid.utils.routeutil import pre_check_value
-from mapadroid.worker.WorkerConfigmode import WorkerConfigmode
-from mapadroid.worker.WorkerMITM import WorkerMITM
-from mapadroid.worker.WorkerQuests import WorkerQuests
-from mapadroid.utils.data_manager.dm_exceptions import DataManagerException
+import logging
 
-OutgoingMessage = collections.namedtuple('OutgoingMessage', ['id', 'message'])
-Location = collections.namedtuple('Location', ['lat', 'lng'])
+from mapadroid.websocket.WebsocketConnectedClientEntry import WebsocketConnectedClientEntry
+from mapadroid.worker.AbstractWorker import AbstractWorker
+from mapadroid.worker.WorkerFactory import WorkerFactory
 
 logging.getLogger('websockets.server').setLevel(logging.DEBUG)
 logging.getLogger('websockets.protocol').setLevel(logging.DEBUG)
@@ -35,677 +25,220 @@ logging.getLogger('websockets.protocol').addHandler(InterceptHandler())
 
 
 class WebsocketServer(object):
-    def __init__(self, args, mitm_mapper, db_wrapper, mapping_manager, pogoWindowManager,
-                 data_manager, configmode=False):
-        self.__current_users = {}
-        self.__users_connecting = []
-
-        self.__stop_server = Event()
-
-        self.args = args
-        self.__listen_address = args.ws_ip
-        self.__listen_port = int(args.ws_port)
-
-        self.__received = {}
-        self.__requests = {}
-
-        self.__users_mutex: Optional[asyncio.Lock] = None
-        self.__id_mutex: Optional[asyncio.Lock] = None
-        self.__send_queue: Optional[asyncio.Queue] = None
-        self.__received_mutex: Optional[asyncio.Lock] = None
-        self.__requests_mutex: Optional[asyncio.Lock] = None
-
-        self.__db_wrapper = db_wrapper
+    def __init__(self, args, mitm_mapper: MitmMapper, db_wrapper: DbWrapper, mapping_manager: MappingManager,
+                 pogo_window_manager: PogoWindows, data_manager: DataManager, enable_configmode: bool = False):
+        self.__args = args
+        self.__db_wrapper: DbWrapper = db_wrapper
         self.__mapping_manager: MappingManager = mapping_manager
-        self.__pogoWindowManager = pogoWindowManager
-        self.__mitm_mapper = mitm_mapper
-        self.__data_manager = data_manager
+        self.__pogo_window_manager: PogoWindows = pogo_window_manager
+        self.__data_manager: DataManager = data_manager
+        self.__mitm_mapper: MitmMapper = mitm_mapper
+        self.__enable_configmode: bool = enable_configmode
 
-        self.__next_id = 0
-        self._configmode = configmode
+        # Event to signal that the server is to be stopped. Used to not accept new connections for example
+        self.__stop_server: Event = Event()
 
-        self.__loop = None
-        self.__loop_tid = None
+        # Dict keeping currently running connections and workers for management
+        # Do think twice before plainly accessing, there's locks to be used
+        self.__current_users: Dict[str, WebsocketConnectedClientEntry] = {}
+        self.__current_users_mutex: asyncio.Lock = asyncio.Lock()
+        self.__users_connecting: Set[str] = set()
+        self.__users_connecting_mutex: asyncio.Lock = asyncio.Lock()
+
+        self.__worker_factory: WorkerFactory = WorkerFactory(self.__args, self.__mapping_manager, self.__mitm_mapper,
+                                                             self.__db_wrapper, self.__pogo_window_manager)
+
+        # asyncio loop for the entire server
+        self.__loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
+        self.__loop_tid: int = -1
         self.__loop_mutex = Lock()
-        self.__worker_shutdown_queue: queue.Queue = queue.Queue()
-        self.__internal_worker_join_thread: Thread = Thread(name='worker_join_thread',
-                                                            target=self.__internal_worker_join)
-        self.__internal_worker_join_thread.daemon = True
-        self.__internal_worker_join_thread.start()
 
-    def _add_task_to_loop(self, coro):
-        f = functools.partial(self.__loop.create_task, coro)
-        if current_thread() == self.__loop_tid:
-            # We can call directly if we're not going between threads.
-            return f()
-        else:
-            # We're in a non-event loop thread so we use a Future
-            # to get the task from the event loop thread once
-            # it's ready.
-            return self.__loop.call_soon_threadsafe(f)
-
-    def __internal_worker_join(self):
-        while not self.__stop_server.is_set():
-            try:
-                next_item: Optional[Thread] = self.__worker_shutdown_queue.get_nowait()
-            except queue.Empty:
-                time.sleep(1)
-                continue
-            if next_item is not None:
-                logger.info("Trying to join worker thread")
-                try:
-                    next_item.join(10)
-                except RuntimeError as e:
-                    logger.warning(
-                        "Caught runtime error trying to join thread, the thread likely did not start "
-                        "at all. Exact message: {}", e)
-                if next_item.is_alive():
-                    logger.debug("Error while joining worker thread - requeue it")
-                    self.__worker_shutdown_queue.put(next_item)
-                else:
-                    logger.debug("Done with worker thread, moving on")
-                self.__worker_shutdown_queue.task_done()
-                logger.info("Done joining worker thread")
-
-    async def __setup_first_loop(self):
-        self.__users_mutex = asyncio.Lock()
-        self.__id_mutex = asyncio.Lock()
-        self.__send_queue: asyncio.Queue = asyncio.Queue()
-        self.__received_mutex = asyncio.Lock()
-        self.__requests_mutex = asyncio.Lock()
-
-    def start_server(self):
-        logger.info("Starting websocket server...")
-        self.__loop = asyncio.new_event_loop()
-
+    def start_server(self) -> None:
+        logger.info("Starting websocket-server...")
         logger.debug("Device mappings: {}", str(self.__mapping_manager.get_all_devicemappings()))
 
         asyncio.set_event_loop(self.__loop)
-        self._add_task_to_loop(self.__setup_first_loop())
+        # the type-check here is sorta wrong, not entirely sure why
+        # noinspection PyTypeChecker
         self.__loop.run_until_complete(
-            websockets.serve(self.handler, self.__listen_address, self.__listen_port, max_size=2 ** 25,
+            websockets.serve(self.__connection_handler, self.__args.ws_ip, int(self.__args.ws_port), max_size=2 ** 25,
                              close_timeout=10))
         self.__loop_tid = current_thread()
         self.__loop.run_forever()
-        logger.info("Websocketserver stopping...")
+        logger.info("Websocket-server stopping...")
 
-    async def __internal_stop_server(self):
-        self.__stop_server.set()
-        async with self.__users_mutex:
-            for id, worker in self.__current_users.items():
-                await self.__close_websocket_client_connection(id, worker[2])
-
-        if self.__loop is not None:
-            self.__loop.call_soon_threadsafe(self.__loop.stop)
-
-        self.__internal_worker_join_thread.join()
-
-    @staticmethod
-    async def __close_websocket_client_connection(id_of_worker: str,
-                                                  websocket_client_connection: websockets.WebSocketClientProtocol) \
+    async def __connection_handler(self, websocket_client_connection: websockets.WebSocketClientProtocol, path: str) \
             -> None:
-        logger.info('Closing connections to device {}.', id_of_worker)
-        await websocket_client_connection.close()
-        logger.info("Connection to device {} closed", id_of_worker)
-
-    def stop_server(self):
-        with self.__loop_mutex:
-            future = asyncio.run_coroutine_threadsafe(self.__internal_stop_server(), self.__loop)
-        future.result()
-
-    async def handler(self, websocket_client_connection: websockets.WebSocketClientProtocol, path):
         if self.__stop_server.is_set():
             await self.__close_websocket_client_connection("stopping...", websocket_client_connection)
             return
-
-        logger.info("Waiting for connection...")
-        # wait for a connection...
-        try:
-            continue_work: bool = await self.__register(websocket_client_connection)
-            if not continue_work:
-                logger.error("Failed registering client, closing connection")
-                await self.__close_websocket_client_connection("Failed...", websocket_client_connection)
-                return
-        except DataManagerException:
-            if websocket_client_connection.open:
-                await self.__close_websocket_client_connection("DataManagerException...",
-                                                               websocket_client_connection)
+        # check auth and stuff TODO
+        origin: Optional[str] = await self.__authenticate_connection(websocket_client_connection)
+        if origin is None:
+            # failed auth, stop connection
+            await self.__close_websocket_client_connection("Stopping due to failed auth...",
+                                                           websocket_client_connection)
             return
 
-        consumer_task = asyncio.ensure_future(
-            self.__consumer_handler(websocket_client_connection))
-        producer_task = asyncio.ensure_future(
-            self.__producer_handler(websocket_client_connection))
-        done, pending = await asyncio.wait(
-            [producer_task, consumer_task],
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-        logger.debug("consumer or producer of {} stopped, cancelling pending tasks", str(
-            websocket_client_connection.request_headers.get_all("Origin")[0]))
-        for task in pending:
-            task.cancel()
-        logger.info("Awaiting unregister of {}", str(
-            websocket_client_connection.request_headers.get_all("Origin")[0]))
-        await self.__unregister(websocket_client_connection)
-        logger.info("All done with {}", str(
-            websocket_client_connection.request_headers.get_all("Origin")[0]))
+        async with self.__users_connecting_mutex:
+            if origin in self.__users_connecting:
+                logger.info("Client {} is already connecting".format(origin))
+                return
+            else:
+                self.__users_connecting.add(origin)
+        # check if the origin is already handed to an instance and just switch the connection if the thread is still
+        # running
+        async with self.__current_users_mutex:
+            entry = self.__current_users.get(origin, None)
+            if entry is None:
+                logger.info("Need to start a new worker thread for {}", origin)
 
-    @logger.catch()
-    async def __register(self, websocket_client_connection: websockets.WebSocketClientProtocol) -> bool:
+                entry = WebsocketConnectedClientEntry(origin=origin,
+                                                      websocket_client_connection=websocket_client_connection,
+                                                      worker_instance=None,
+                                                      worker_thread=None,
+                                                      loop_running=self.__loop)
+                worker: Optional[AbstractWorker] = await self.__worker_factory \
+                    .get_worker_using_settings(origin, self.__enable_configmode, websocket_client_entry=entry)
+                if worker is None:
+                    return
+                new_worker_thread = Thread(
+                    name='worker_%s' % origin, target=worker.start_worker)
+
+                new_worker_thread.daemon = True
+                entry.worker_thread = new_worker_thread
+                entry.worker_instance = worker
+            else:
+                logger.info("There is a worker thread entry present, handling accordingly")
+                if entry.websocket_client_connection.open:
+                    logger.error("Old connection open while a new one is attempted to be established, "
+                                 "aborting handling")
+                    async with self.__users_connecting_mutex:
+                        self.__users_connecting.remove(origin)
+                    return
+
+                entry.websocket_client_connection = websocket_client_connection
+                # TODO: also change the worker's Communicator? idk yet
+                if entry.worker_thread.is_alive():
+                    logger.info("Worker thread still alive, continue as usual")
+                    # TODO: does this need more handling? probably update communicator or whatever?
+                else:
+                    worker: Optional[AbstractWorker] = await self.__worker_factory \
+                        .get_worker_using_settings(origin, self.__enable_configmode, entry)
+                    if worker is None:
+                        # TODO: handle properly
+                        return
+                    new_worker_thread = Thread(
+                        name='worker_%s' % origin, target=worker.start_worker)
+
+                    new_worker_thread.daemon = True
+                    entry.worker_instance = worker
+                    entry.worker_thread = new_worker_thread
+
+            self.__current_users[origin] = entry
+        try:
+            if not entry.worker_thread.is_alive():
+                entry.worker_thread.start()
+            async with self.__users_connecting_mutex:
+                self.__users_connecting.remove(origin)
+            receiver_task = asyncio.ensure_future(
+                self.__client_message_receiver(origin, entry))
+            await receiver_task
+        # also check if thread is already running to not start it again. If it is not alive, we need to create it..
+        finally:
+            logger.info("Awaiting unregister of {}", str(
+                websocket_client_connection.request_headers.get_all("Origin")[0]))
+            # await self.__unregister(websocket_client_connection)
+            # logger.info("All done with {}", str(
+            #    websocket_client_connection.request_headers.get_all("Origin")[0]))
+            # TODO: cleanup thread is not really desired, I'd prefer to only restart a worker if the route changes :(
+            entry.worker_thread.join()
+        logger.info("Done with connection from {} ({})", origin, websocket_client_connection.remote_address)
+
+    async def __get_new_worker(self, origin: str):
+        # fetch worker from factory...
+        # TODO: determine which to use....
+        pass
+
+    async def __authenticate_connection(self, websocket_client_connection: websockets.WebSocketClientProtocol) \
+            -> Optional[str]:
+        """
+        :param websocket_client_connection:
+        :return: origin (string) if the auth and everything else checks out, else None to signal abort
+        """
         try:
             origin = str(
                 websocket_client_connection.request_headers.get_all("Origin")[0])
         except IndexError:
             logger.warning("Client from {} tried to connect without Origin header", str(
                 websocket_client_connection.request_headers.get_all("Origin")[0]))
-            return False
+            return None
+
         if not self.__data_manager.is_device_active(origin):
             logger.warning('Origin %s is currently paused.  Unpause through MADmin to begin working', origin)
-            return False
+            return None
         logger.info("Client {} registering", str(origin))
         if self.__mapping_manager is None or origin not in self.__mapping_manager.get_all_devicemappings().keys():
             logger.warning("Register attempt of unknown origin: {}. "
                            "Have you forgot to hit 'APPLY SETTINGS' in MADmin?".format(origin))
-            return False
+            return None
 
-        if origin in self.__users_connecting:
-            logger.info("Client {} is already connecting".format(origin))
-            return False
-
-        auths = self.__mapping_manager.get_auths()
-        authBase64 = None
-        if auths:
+        valid_auths = self.__mapping_manager.get_auths()
+        auth_base64 = None
+        if valid_auths:
             try:
-                authBase64 = str(
+                auth_base64 = str(
                     websocket_client_connection.request_headers.get_all("Authorization")[0])
             except IndexError:
                 logger.warning("Client from {} tried to connect without auth header", str(
                     websocket_client_connection.request_headers.get_all("Origin")[0]))
-                return False
+                return None
+        if valid_auths and auth_base64 and not check_auth(auth_base64, self.__args, valid_auths):
+            logger.warning("Invalid auth details received from {}", str(
+                websocket_client_connection.request_headers.get_all("Origin")[0]))
+            return None
+        return origin
 
-        worker_already_connected: bool = False
-        async with self.__users_mutex:
-            logger.debug("Checking if {} is already present", str(origin))
-            if origin in self.__current_users:
-                logger.warning(
-                    "Worker with origin {} is already running, killing the running one and have client reconnect",
-                    str(origin))
-                self.__current_users.get(origin)[1].stop_worker()
-                worker_already_connected = True
-            else:
-                self.__users_connecting.append(origin)
-
-        if worker_already_connected:
-            ## todo: do this better :D
-            logger.debug("Old worker thread is still alive - waiting 20 seconds")
-            await asyncio.sleep(20)
-            logger.info("Reconnect ...")
-            return False
-
-        # reset pref. error counter if exist
-        await self.__reset_fail_counter(origin)
-        try:
-            if auths and authBase64 and not check_auth(authBase64, self.args, auths):
-                logger.warning("Invalid auth details received from {}", str(
-                    websocket_client_connection.request_headers.get_all("Origin")[0]))
-                return False
-            logger.info("Starting worker {}".format(origin))
-            if self._configmode:
-                dev_id = self.__mapping_manager.get_all_devicemappings()[origin]['device_id']
-                devicesettings = self.__mapping_manager.get_devicesettings_of(origin)
-                client_mapping = self.__mapping_manager.get_devicemappings_of(origin)
-                walker_area_array = client_mapping["walker"]
-                walker_index = devicesettings.get('walker_area_index', 0)
-                walker_settings = walker_area_array[walker_index]
-                area_id = walker_settings['walkerarea']
-                worker = WorkerConfigmode(args=self.args,
-                                          dev_id=dev_id,
-                                          id=origin,
-                                          websocket_handler=self,
-                                          walker=None,
-                                          mapping_manager=self.__mapping_manager,
-                                          mitm_mapper=self.__mitm_mapper,
-                                          db_wrapper=self.__db_wrapper,
-                                          area_id=area_id,
-                                          routemanager_name=None)
-                logger.debug("Starting worker for {}", str(origin))
-                new_worker_thread = Thread(
-                    name='worker_%s' % origin, target=worker.start_worker)
-                async with self.__users_mutex:
-                    self.__current_users[origin] = [
-                        new_worker_thread, worker, websocket_client_connection, 0]
-                return True
-
-            last_known_state = {}
-            client_mapping = self.__mapping_manager.get_devicemappings_of(origin)
-            devicesettings = self.__mapping_manager.get_devicesettings_of(origin)
-            logger.info("Setting up routemanagers for {}", str(origin))
-
-            if client_mapping.get("walker", None) is not None:
-                if devicesettings is not None and "walker_area_index" not in devicesettings:
-                    logger.debug("Initializing devicesettings")
-                    self.__mapping_manager.set_devicesetting_value_of(origin, 'walker_area_index', 0)
-                    self.__mapping_manager.set_devicesetting_value_of(origin, 'finished', False)
-                    self.__mapping_manager.set_devicesetting_value_of(origin, 'last_action_time', None)
-                    self.__mapping_manager.set_devicesetting_value_of(origin, 'last_cleanup_time', None)
-                    self.__mapping_manager.set_devicesetting_value_of(origin, 'job', False)
-                    await asyncio.sleep(
-                        1)  # give the settings a moment... (dirty "workaround" against race condition)
-                walker_index = devicesettings.get('walker_area_index', 0)
-
-                if walker_index > 0:
-                    # check status of last area
-                    if not devicesettings.get('finished', False):
-                        logger.info(
-                            'Something wrong with last round - get back to old area')
-                        walker_index -= 1
-                        self.__mapping_manager.set_devicesetting_value_of(origin, 'walker_area_index',
-                                                                          walker_index)
-                        # devicesettings['walker_area_index'] = walker_index
-
-                walker_area_array = client_mapping["walker"]
-                walker_settings = walker_area_array[walker_index]
-
-                # preckeck walker setting
-                while not pre_check_value(walker_settings) and walker_index - 1 <= len(walker_area_array):
-                    walker_area_name = walker_area_array[walker_index]['walkerarea']
-                    logger.info(
-                        '{} not using area {} - Walkervalue out of range', str(origin),
-                        str(self.__mapping_manager.routemanager_get_name(walker_area_name)))
-                    if walker_index >= len(walker_area_array) - 1:
-                        logger.error(
-                            'Could not find any working area at this time - check your mappings for device: {}',
-                            str(origin))
-                        walker_index = 0
-                        self.__mapping_manager.set_devicesetting_value_of(origin, 'walker_area_index',
-                                                                          walker_index)
-                        walker_settings = walker_area_array[walker_index]
-                        return False
-                    walker_index += 1
-                    self.__mapping_manager.set_devicesetting_value_of(origin, 'walker_area_index',
-                                                                      walker_index)
-                    walker_settings = walker_area_array[walker_index]
-
-                devicesettings = self.__mapping_manager.get_devicesettings_of(origin)
-                logger.debug("Checking walker_area_index length")
-                if (devicesettings.get("walker_area_index", None) is None
-                        or devicesettings['walker_area_index'] >= len(walker_area_array)):
-                    # check if array is smaller than expected - f.e. on the fly changes in mappings.json
-                    self.__mapping_manager.set_devicesetting_value_of(origin, 'walker_area_index', 0)
-                    self.__mapping_manager.set_devicesetting_value_of(origin, 'finished', False)
-                    walker_index = 0
-
-                walker_area_name = walker_area_array[walker_index]['walkerarea']
-
-                if walker_area_name not in self.__mapping_manager.get_all_routemanager_names():
-                    raise WrongAreaInWalker()
-
-                logger.debug('Devicesettings {}: {}', str(origin), devicesettings)
-                logger.info('{} using walker area {} [{}/{}]', str(origin), str(
-                    self.__mapping_manager.routemanager_get_name(walker_area_name)), str(walker_index + 1),
-                            str(len(walker_area_array)))
-                walker_routemanager_mode = self.__mapping_manager.routemanager_get_mode(walker_area_name)
-                self.__mapping_manager.set_devicesetting_value_of(origin, 'walker_area_index',
-                                                                  walker_index + 1)
-                self.__mapping_manager.set_devicesetting_value_of(origin, 'finished', False)
-                if walker_index >= len(walker_area_array) - 1:
-                    self.__mapping_manager.set_devicesetting_value_of(origin, 'walker_area_index', 0)
-
-                # set global mon_iv
-                routemanager_settings = self.__mapping_manager.routemanager_get_settings(walker_area_name)
-                if routemanager_settings is not None:
-                    client_mapping['mon_ids_iv'] = \
-                        self.__mapping_manager.get_monlist(routemanager_settings.get("mon_ids_iv", None),
-                                                           walker_area_name)
-            else:
-                walker_routemanager_mode = None
-
-            if "last_location" not in devicesettings:
-                devicesettings['last_location'] = Location(0.0, 0.0)
-
-            logger.debug("Setting up worker for {}", str(origin))
-            dev_id = self.__mapping_manager.get_all_devicemappings()[origin]['device_id']
-            area_id = walker_settings['walkerarea']
-            worker = None
-            if walker_routemanager_mode is None:
-                pass
-            elif walker_routemanager_mode in ["raids_mitm", "mon_mitm", "iv_mitm"]:
-                worker = WorkerMITM(self.args, dev_id, origin, last_known_state, self, area_id=area_id,
-                                    routemanager_name=walker_area_name,
-                                    mitm_mapper=self.__mitm_mapper, mapping_manager=self.__mapping_manager,
-                                    db_wrapper=self.__db_wrapper,
-                                    pogo_window_manager=self.__pogoWindowManager, walker=walker_settings)
-            elif walker_routemanager_mode in ["pokestops"]:
-                worker = WorkerQuests(self.args, dev_id, origin, last_known_state, self, area_id=area_id,
-                                      routemanager_name=walker_area_name,
-                                      mitm_mapper=self.__mitm_mapper, mapping_manager=self.__mapping_manager,
-                                      db_wrapper=self.__db_wrapper,
-                                      pogo_window_manager=self.__pogoWindowManager,
-                                      walker=walker_settings)
-            elif walker_routemanager_mode in ["idle"]:
-                worker = WorkerConfigmode(self.args, dev_id, origin, self, walker=walker_settings,
-                                          mapping_manager=self.__mapping_manager,
-                                          mitm_mapper=self.__mitm_mapper,
-                                          db_wrapper=self.__db_wrapper, area_id=area_id,
-                                          routemanager_name=walker_area_name)
-            else:
-                logger.error("Mode not implemented")
-                sys.exit(1)
-
-            if worker is None:
-                logger.error("Invalid walker mode for {}. Closing connection".format(str(origin)))
-                return False
-            else:
-                logger.debug("Starting worker for {}", str(origin))
-                new_worker_thread = Thread(
-                    name='worker_%s' % origin, target=worker.start_worker)
-
-                new_worker_thread.daemon = True
-                async with self.__users_mutex:
-                    self.__current_users[origin] = [new_worker_thread, worker, websocket_client_connection, 0]
-                new_worker_thread.start()
-        except WrongAreaInWalker:
-            logger.error('Unknown Area in Walker settings - check config')
-            return False
-        except Exception as e:
-            logger.opt(exception=True).error("Other unhandled exception during registration of {}: {}",
-                                             origin, e)
-            return False
-        finally:
-            async with self.__users_mutex:
-                self.__users_connecting.remove(origin)
-            await asyncio.sleep(5)
-            logger.info("Done handling register of origin ", origin)
-        return True
-
-    async def __unregister(self, websocket_client_connection: websockets.WebSocketClientProtocol):
-        # worker_thread: Thread = None
-        async with self.__users_mutex:
-            worker_id = str(websocket_client_connection.request_headers.get_all("Origin")[0])
-            worker = self.__current_users.get(worker_id, None)
-            if worker is not None:
-                worker[1].stop_worker()
-                self.__current_users.pop(worker_id)
-        logger.info("Worker {} unregistered", str(worker_id))
-        self.__worker_shutdown_queue.put(worker[0])
-        # TODO ? worker_thread.join()
-
-    def force_disconnect(self, origin):
-        worker = self.__current_users.get(origin, None)
-        if worker is not None:
-            worker[1]._internal_cleanup()
-
-    async def __producer_handler(self, websocket_client_connection: websockets.WebSocketClientProtocol):
-        while websocket_client_connection.open:
-            # logger.debug("Connection still open, trying to send next message")
-            # retrieve next message from queue to be sent, block if empty
-            next = None
-            while next is None and websocket_client_connection.open:
-                logger.debug("Fetching next message to send")
-                next = await self.__retrieve_next_send(websocket_client_connection)
-                if next is None:
-                    # logger.debug("next is None, stopping connection...")
-                    return
-                await self.__send_specific(websocket_client_connection, next.id, next.message)
-
-    async def __send_specific(self, websocket_client_connection: websockets.WebSocketClientProtocol, id,
-                              message):
-        # await websocket_client_connection.send(message)
-        try:
-            user = None
-            async with self.__users_mutex:
-                for key, value in self.__current_users.items():
-                    if key == id and value[2].open:
-                        user = value
-            if user is not None:
-                await user[2].send(message)
-        except Exception as e:
-            logger.error("Failed sending message in send_specific: {}".format(str(e)))
-
-    async def __retrieve_next_send(self, websocket_client_connection: websockets.WebSocketClientProtocol):
-        found = None
-        while found is None and websocket_client_connection.open:
-            try:
-                found = self.__send_queue.get_nowait()
-            except Exception as e:
-                await asyncio.sleep(0.02)
-        if not websocket_client_connection.open:
-            logger.debug(
-                "retrieve_next_send: connection closed, returning None")
-        return found
-
-    async def __consumer_handler(self, websocket_client_connection: websockets.WebSocketClientProtocol):
-        if websocket_client_connection is None:
+    async def __client_message_receiver(self, origin: str, client_entry: WebsocketConnectedClientEntry) -> None:
+        if client_entry is None:
             return
-        worker_id = str(
-            websocket_client_connection.request_headers.get_all("Origin")[0])
-        logger.info("Consumer handler of {} starting", str(worker_id))
-        while websocket_client_connection.open:
+        logger.info("Consumer handler of {} starting", origin)
+        while client_entry.websocket_client_connection.open:
             message = None
             try:
-                message = await asyncio.wait_for(websocket_client_connection.recv(), timeout=4.0)
-            except asyncio.TimeoutError as te:
+                message = await asyncio.wait_for(client_entry.websocket_client_connection.recv(), timeout=4.0)
+            except asyncio.TimeoutError:
                 await asyncio.sleep(0.02)
             except websockets.exceptions.ConnectionClosed as cc:
+                # TODO: cleanup needed here? better suited for the handler
                 logger.warning(
-                    "Connection to {} was closed, stopping worker", str(worker_id))
-                async with self.__users_mutex:
-                    worker = self.__current_users.get(worker_id, None)
-                if worker is not None:
-                    # TODO: do it abruptly in the worker, maybe set a flag to be checked for in send_and_wait to
-                    # TODO: throw an exception
-                    worker[1].stop_worker()
-                await self.__internal_clean_up_user(worker_id, None)
+                    "Connection to {} was closed, stopping receiver. Exception: ", origin, cc)
                 return
 
             if message is not None:
-                await self.__on_message(message)
+                await self.__on_message(client_entry, message)
         logger.warning(
-            "Connection of {} closed in consumer_handler", str(worker_id))
+            "Connection of {} closed in __client_message_receiver", str(origin))
 
-    async def __internal_clean_up_user(self, worker_id, worker_instance):
-        """
-        :param worker_id: The ID/Origin of the worker
-        :param worker_instance: None if the cleanup is called from within the websocket server
-        :return:
-        """
-        async with self.__users_mutex:
-            if worker_id in self.__current_users.keys() and (worker_instance is None
-                                                             or self.__current_users[worker_id][
-                                                                 1] == worker_instance):
-                if self.__current_users[worker_id][2].open:
-                    await self.__close_websocket_client_connection(worker_id,
-                                                                   self.__current_users[worker_id][2])
-                # self.__current_users.pop(worker_id)
-                # logger.info("Info of {} removed in websocket", str(worker_id))
-
-    def clean_up_user(self, worker_id, worker_instance):
-        logger.debug2("Cleanup of {} called with ref {}".format(worker_id, str(worker_instance)))
-        with self.__loop_mutex:
-            future = asyncio.run_coroutine_threadsafe(
-                self.__internal_clean_up_user(worker_id, worker_instance), self.__loop)
-        future.result()
-
-    async def __on_message(self, message):
-        id = -1
-        response = None
+    @staticmethod
+    async def __on_message(client_entry: WebsocketConnectedClientEntry, message: MessageTyping) -> None:
+        response: Optional[MessageTyping] = None
         if isinstance(message, str):
             logger.debug("Receiving message: {}", str(message.strip()))
             splitup = message.split(";", 1)
-            id = int(splitup[0])
+            message_id = int(splitup[0])
             response = splitup[1]
         else:
             logger.debug("Received binary values.")
-            id = int.from_bytes(message[:4], byteorder='big', signed=False)
+            message_id = int.from_bytes(message[:4], byteorder='big', signed=False)
             response = message[4:]
-        await self.__set_response(id, response)
-        if not await self.__set_event(id):
-            # remove the response again - though that is kinda stupid
-            await self.__pop_response(id)
+        await client_entry.set_message_response(message_id, response)
 
-    async def __set_event(self, id):
-        result = False
-        async with self.__requests_mutex:
-            if id in self.__requests:
-                self.__requests[id].set()
-                result = True
-            else:
-                # the request has already been deleted due to a timeout...
-                logger.error("Request has already been deleted...")
-        return result
+    @staticmethod
+    async def __close_websocket_client_connection(origin_of_worker: str,
+                                                  websocket_client_connection: websockets.WebSocketClientProtocol) \
+            -> None:
+        logger.info('Closing connections to device {}.', origin_of_worker)
+        await websocket_client_connection.close()
+        logger.info("Connection to device {} closed", origin_of_worker)
 
-    async def __set_response(self, id, message):
-        async with self.__received_mutex:
-            self.__received[id] = message
-
-    async def __pop_response(self, id):
-        async with self.__received_mutex:
-            message = self.__received.pop(id)
-        return message
-
-    async def __get_new_message_id(self):
-        async with self.__id_mutex:
-            self.__next_id += 1
-            self.__next_id = int(math.fmod(self.__next_id, 100000))
-            if self.__next_id == 100000:
-                self.__next_id = 1
-            toBeReturned = self.__next_id
-        return toBeReturned
-
-    async def __send(self, id, to_be_sent):
-        next_message = OutgoingMessage(id, to_be_sent)
-        await self.__send_queue.put(next_message)
-
-    async def __send_and_wait_internal(self, id, worker_instance, message, timeout, byte_command: int = None):
-        async with self.__users_mutex:
-            user_entry = self.__current_users.get(id, None)
-
-        if user_entry is None or user_entry[1] != worker_instance and worker_instance != 'madmin':
-            raise WebsocketWorkerRemovedException
-
-        message_id = await self.__get_new_message_id()
-        message_event = asyncio.Event()
-        message_event.clear()
-
-        await self.__set_request(message_id, message_event)
-
-        if isinstance(message, str):
-            to_be_sent: str = u"%s;%s" % (str(message_id), message)
-            logger.debug("To be sent to {}: {}", id, to_be_sent.strip())
-        elif byte_command is not None:
-            to_be_sent: bytes = (int(message_id)).to_bytes(4, byteorder='big')
-            to_be_sent += (int(byte_command)).to_bytes(4, byteorder='big')
-            to_be_sent += message
-            logger.debug("To be sent to {} (message ID: {}): {}", id, message_id, str(to_be_sent[:10]))
-        else:
-            logger.fatal("Tried to send invalid message (bytes without byte command or no byte/str passed)")
-            return None
-        await self.__send(id, to_be_sent)
-
-        # now wait for the response!
-        result = None
-        logger.debug("Timeout towards {}: {}", id, str(timeout))
-        event_triggered = None
-        try:
-            event_triggered = await asyncio.wait_for(message_event.wait(), timeout=timeout)
-        except asyncio.TimeoutError as te:
-            logger.warning("Timeout, increasing timeout-counter of {}", id)
-            # TODO: why is the user removed here?
-            new_count = await self.__increase_fail_counter(id)
-            if new_count > 5:
-                logger.error("5 consecutive timeouts to {} or origin is not longer connected, cleanup",
-                             str(id))
-                await self.__internal_clean_up_user(id, None)
-                await self.__reset_fail_counter(id)
-                await self.__remove_request(message_id)
-                raise WebsocketWorkerTimeoutException
-
-        if event_triggered:
-            logger.debug("Received answer in time, popping response")
-            await self.__reset_fail_counter(id)
-            await self.__remove_request(message_id)
-            result = await self.__pop_response(message_id)
-            if isinstance(result, str):
-                logger.debug("Response to {}: {}",
-                             str(id), str(result.strip()))
-            else:
-                logger.debug("Received binary data to {}, starting with {}", str(
-                    id), str(result[:10]))
-        else:
-            logger.warning("Did not received answer in time from {}", id)
-
-        return result
-
-    def send_and_wait(self, id, worker_instance, message, timeout, byte_command: int = None):
-        if isinstance(message, bytes):
-            logger.debug("{} sending binary: {}", str(id), str(message[:10]))
-        else:
-            logger.debug("{} sending command: {}", str(id), message.strip())
-        try:
-            # future: Handle = self._add_task_to_loop(self.__send_and_wait_internal(id, worker_instance, message,
-            #                                                                       timeout))
-            logger.debug("Appending send_and_wait to {}".format(str(self.__loop)))
-            with self.__loop_mutex:
-                future = asyncio.run_coroutine_threadsafe(
-                    self.__send_and_wait_internal(id, worker_instance, message, timeout,
-                                                  byte_command=byte_command),
-                    self.__loop)
-            result = future.result()
-        except WebsocketWorkerRemovedException:
-            logger.error("Worker {} was removed, propagating exception".format(id))
-            raise WebsocketWorkerRemovedException
-        except WebsocketWorkerTimeoutException:
-            logger.error("Sending message failed due to timeout ({})".format(id))
-            raise WebsocketWorkerTimeoutException
-        return result
-
-    async def __set_request(self, id, event):
-        async with self.__requests_mutex:
-            self.__requests[id] = event
-
-    async def __reset_fail_counter(self, id):
-        async with self.__users_mutex:
-            if id in self.__current_users.keys():
-                self.__current_users[id][3] = 0
-
-    async def __increase_fail_counter(self, id):
-        async with self.__users_mutex:
-            if id in self.__current_users.keys():
-                new_count = self.__current_users[id][3] + 1
-                self.__current_users[id][3] = new_count
-            else:
-                new_count = 100
-        return new_count
-
-    async def __remove_request(self, message_id):
-        async with self.__requests_mutex:
-            self.__requests.pop(message_id)
-
-    def get_reg_origins(self):
-        return self.__current_users
-
-    def get_origin_communicator(self, origin):
-        if self.__current_users.get(origin, None) is not None:
-            return self.__current_users[origin][1].get_communicator()
-        return None
-
-    def set_geofix_sleeptime_worker(self, origin, sleeptime):
-        if self.__current_users.get(origin, None) is not None:
-            return self.__current_users[origin][1].set_geofix_sleeptime(sleeptime)
-        return False
-
-    def trigger_worker_check_research(self, origin):
-        if self.__current_users.get(origin, None) is not None:
-            return self.__current_users[origin][1].trigger_check_research()
-        return False
-
-    def set_update_sleeptime_worker(self, origin, sleeptime):
-        if self.__current_users.get(origin, None) is not None:
-            return self.__current_users[origin][1].set_geofix_sleeptime(sleeptime)
-        return False
-
-    def set_job_activated(self, origin):
-        self.__mapping_manager.set_devicesetting_value_of(origin, 'job', True)
-
-    def set_job_deactivated(self, origin):
-        self.__mapping_manager.set_devicesetting_value_of(origin, 'job', False)

--- a/mapadroid/websocket/communicator.py
+++ b/mapadroid/websocket/communicator.py
@@ -5,7 +5,8 @@ from mapadroid.utils.CustomTypes import MessageTyping
 from mapadroid.utils.collections import Location
 from mapadroid.utils.geo import get_distance_of_two_points_in_meters
 from mapadroid.utils.logging import logger
-from mapadroid.utils.madGlobals import ScreenshotType, WebsocketWorkerConnectionClosedException
+from mapadroid.utils.madGlobals import ScreenshotType, WebsocketWorkerConnectionClosedException, \
+    WebsocketWorkerTimeoutException
 from mapadroid.websocket.AbstractCommunicator import AbstractCommunicator
 from mapadroid.websocket.WebsocketConnectedClientEntry import WebsocketConnectedClientEntry
 from mapadroid.worker.AbstractWorker import AbstractWorker
@@ -28,7 +29,10 @@ class Communicator(AbstractCommunicator):
     def cleanup(self) -> None:
         logger.info(
             "Communicator of {} calling exit to cleanup worker in websocket", str(self.worker_id))
-        self.terminate_connection()
+        try:
+            self.terminate_connection()
+        except (WebsocketWorkerConnectionClosedException, WebsocketWorkerTimeoutException):
+            logger.info("Communicator-cleanup of {} resulted in timeout or connection has already been closed")
 
     def __runAndOk(self, command, timeout) -> bool:
         return self.__run_and_ok_bytes(command, timeout)

--- a/mapadroid/websocket/communicator.py
+++ b/mapadroid/websocket/communicator.py
@@ -1,44 +1,45 @@
 from threading import Lock
+from typing import Optional
 
+from mapadroid.utils.CustomTypes import MessageTyping
 from mapadroid.utils.geo import get_distance_of_two_points_in_meters
 from mapadroid.utils.logging import logger
-from mapadroid.utils.madGlobals import ScreenshotType
+from mapadroid.utils.madGlobals import ScreenshotType, WebsocketWorkerConnectionClosedException
+from mapadroid.websocket.WebsocketConnectedClientEntry import WebsocketConnectedClientEntry
 
 
 class Communicator:
     UPDATE_INTERVAL = 0.4
 
-    def __init__(self, websocket_handler, worker_id: str, worker_instance_ref, command_timeout: float):
+    def __init__(self, websocket_client_entry: WebsocketConnectedClientEntry, worker_id: str, worker_instance_ref,
+                 command_timeout: float):
         # Throws ValueError if unable to connect!
         # catch in code using this class
         self.worker_id: str = worker_id
         self.worker_instance_ref = worker_instance_ref
-        self.websocket_handler = websocket_handler
+        self.websocket_client_entry = websocket_client_entry
         self.__command_timeout: float = command_timeout
         self.__sendMutex = Lock()
 
     def cleanup_websocket(self):
         logger.info(
-            "Communicator of {} acquiring lock to cleanup worker in websocket", str(self.worker_id))
-        self.__sendMutex.acquire()
-        try:
-            logger.info("Communicator of {} calling cleanup", str(self.worker_id))
-            self.websocket_handler.clean_up_user(
-                self.worker_id, self.worker_instance_ref)
-        finally:
-            self.__sendMutex.release()
+            "Communicator of {} calling exit to cleanup worker in websocket", str(self.worker_id))
+        self.terminate_connection()
 
     def __runAndOk(self, command, timeout) -> bool:
         return self.__run_and_ok_bytes(command, timeout)
 
+    def __run_get_gesponse(self, message: MessageTyping, timeout: float = None) -> Optional[MessageTyping]:
+        with self.__sendMutex:
+            timeout = self.__command_timeout if timeout is None else timeout
+            return self.websocket_client_entry.send_and_wait(message, timeout=timeout,
+                                                             worker_instance=self.worker_instance_ref)
+
     def __run_and_ok_bytes(self, message, timeout: float, byte_command: int = None) -> bool:
-        self.__sendMutex.acquire()
-        try:
-            result = self.websocket_handler.send_and_wait(
-                self.worker_id, self.worker_instance_ref, message, timeout, byte_command=byte_command)
+        with self.__sendMutex:
+            result = self.websocket_client_entry.send_and_wait(message, timeout, self.worker_instance_ref,
+                                                               byte_command=byte_command)
             return result is not None and "OK" == result.strip()
-        finally:
-            self.__sendMutex.release()
 
     def install_apk(self, timeout: float, filepath: str = None, data=None) -> bool:
         if not data:
@@ -57,11 +58,10 @@ class Communicator:
         else:
             return True
 
-    def passthrough(self, command):
-        response = self.websocket_handler.send_and_wait(self.worker_id,
-                                                        self.worker_instance_ref,
-                                                        "passthrough {}".format(command),
-                                                        self.__command_timeout)
+    def passthrough(self, command) -> Optional[MessageTyping]:
+        response = self.websocket_client_entry.send_and_wait("passthrough {}".format(command),
+                                                             self.__command_timeout,
+                                                             self.worker_instance_ref)
         return response
 
     def reboot(self) -> bool:
@@ -76,11 +76,11 @@ class Communicator:
     def clearAppCache(self, package_name) -> bool:
         return self.__runAndOk("more cache {}\r\n".format(package_name), self.__command_timeout)
 
-    def magisk_off(self, package_name) -> bool:
-        return self.passthrough("su -c magiskhide --rm {}".format(package_name))
+    def magisk_off(self, package_name) -> None:
+        self.passthrough("su -c magiskhide --rm {}".format(package_name))
 
-    def magisk_on(self, package_name) -> bool:
-        return self.passthrough("su -c magiskhide --add {}".format(package_name))
+    def magisk_on(self, package_name) -> None:
+        self.passthrough("su -c magiskhide --add {}".format(package_name))
 
     def turnScreenOn(self) -> bool:
         return self.__runAndOk("more screen on\r\n", self.__command_timeout)
@@ -89,11 +89,10 @@ class Communicator:
         return self.__runAndOk("screen click {} {}\r\n".format(str(int(round(x))), str(int(round(y)))),
                                self.__command_timeout)
 
-    def swipe(self, x1, y1, x2, y2):
-        return self.websocket_handler.send_and_wait(
-            self.worker_id, self.worker_instance_ref, "touch swipe {} {} {} {}\r\n".format(
-                str(int(round(x1))), str(int(round(y1))), str(int(round(x2))), str(int(round(y2)))),
-            self.__command_timeout)
+    def swipe(self, x1, y1, x2, y2) -> Optional[MessageTyping]:
+        return self.__run_get_gesponse("touch swipe {} {} {} {}\r\n".format(
+                str(int(round(x1))), str(int(round(y1))), str(int(round(x2))), str(int(round(y2))))
+        )
 
     def touchandhold(self, x1, y1, x2, y2, time: int = 3000) -> bool:
         return self.__runAndOk("touch swipe {} {} {} {} {}".format(
@@ -101,17 +100,11 @@ class Communicator:
             str(int(time)))
             , self.__command_timeout)
 
-    def getscreensize(self) -> str:
-        response = self.websocket_handler.send_and_wait(self.worker_id, self.worker_instance_ref,
-                                                        "screen size",
-                                                        self.__command_timeout)
-        return response
+    def getscreensize(self) -> Optional[MessageTyping]:
+        return self.__run_get_gesponse("screen size")
 
     def uiautomator(self) -> str:
-        response = self.websocket_handler.send_and_wait(self.worker_id, self.worker_instance_ref,
-                                                        "more uiautomator",
-                                                        self.__command_timeout)
-        return response
+        return self.__run_get_gesponse("more uiautomator")
 
     def get_screenshot(self, path, quality: int = 70,
                        screenshot_type: ScreenshotType = ScreenshotType.JPEG) -> bool:
@@ -123,15 +116,7 @@ class Communicator:
         if screenshot_type == ScreenshotType.PNG:
             screenshot_type_str = "png"
 
-        self.__sendMutex.acquire()
-        try:
-            encoded = self.websocket_handler.send_and_wait(
-                self.worker_id, self.worker_instance_ref,
-                "screen capture {} {}\r\n".format(screenshot_type_str, quality),
-                self.__command_timeout
-            )
-        finally:
-            self.__sendMutex.release()
+        encoded = self.__run_get_gesponse("screen capture {} {}\r\n".format(screenshot_type_str, quality))
         if encoded is None:
             return False
         elif isinstance(encoded, str):
@@ -165,57 +150,28 @@ class Communicator:
         return self.__runAndOk("touch text " + str(text), self.__command_timeout)
 
     def isScreenOn(self) -> bool:
-        self.__sendMutex.acquire()
-        try:
-            state = self.websocket_handler.send_and_wait(self.worker_id, self.worker_instance_ref,
-                                                         "more state screen\r\n", self.__command_timeout)
-            if state is None:
-                return False
-            return "on" in state
-        finally:
-            self.__sendMutex.release()
+        state = self.__run_get_gesponse("more state screen\r\n")
+        if state is None:
+            return False
+        return "on" in state
 
     def isPogoTopmost(self) -> bool:
-        self.__sendMutex.acquire()
-        try:
-            topmost = self.websocket_handler.send_and_wait(self.worker_id, self.worker_instance_ref,
-                                                           "more topmost app\r\n", self.__command_timeout)
-            if topmost is None:
-                return False
-            return "com.nianticlabs.pokemongo" in topmost
-        finally:
-            self.__sendMutex.release()
+        topmost = self.__run_get_gesponse("more topmost app\r\n")
+        if topmost is None:
+            return False
+        return "com.nianticlabs.pokemongo" in topmost
 
-    def topmostApp(self) -> str:
-        self.__sendMutex.acquire()
-        try:
-            topmost = self.websocket_handler.send_and_wait(self.worker_id, self.worker_instance_ref,
-                                                           "more topmost app\r\n", self.__command_timeout)
-            if topmost is None:
-                return False
-            return topmost
-        finally:
-            self.__sendMutex.release()
+    def topmostApp(self) -> Optional[MessageTyping]:
+        return self.__run_get_gesponse("more topmost app\r\n")
 
     def setLocation(self, lat, lng, alt):
-        self.__sendMutex.acquire()
-        try:
-            response = self.websocket_handler.send_and_wait(self.worker_id, self.worker_instance_ref,
-                                                            "geo fix {} {} {}\r\n".format(
-                                                                lat, lng, alt),
-                                                            self.__command_timeout)
-            return response
-        finally:
-            self.__sendMutex.release()
+        return self.__run_get_gesponse("geo fix {} {} {}\r\n".format(lat, lng, alt))
 
     def terminate_connection(self):
-        self.__sendMutex.acquire()
         try:
-            response = self.websocket_handler.send_and_wait(
-                self.worker_id, self.worker_instance_ref, "exit\r\n", 5)
-            return response
-        finally:
-            self.__sendMutex.release()
+            return self.__run_get_gesponse("exit\r\n", timeout=5)
+        except WebsocketWorkerConnectionClosedException:
+            logger.info("Cannot gracefully terminate connection of {}, it's already been closed", self.worker_id)
 
     # coords need to be float values
     # speed integer with km/h
@@ -223,19 +179,13 @@ class Communicator:
     # This blocks!
     #######
     def walkFromTo(self, startLat, startLng, destLat, destLng, speed):
-        with self.__sendMutex:
-            # calculate the time it will take to walk and add it to the timeout!
-            distance = get_distance_of_two_points_in_meters(
-                startLat, startLng, destLat, destLng)
-            # speed is in kmph, distance in m
-            # we want m/s -> speed / 3.6
-            speed_meters = speed / 3.6
-            seconds_traveltime = distance / speed_meters
-            response = self.websocket_handler.send_and_wait(self.worker_id, self.worker_instance_ref,
-                                                            "geo walk {} {} {} {} {}\r\n".format(startLat,
-                                                                                                 startLng,
-                                                                                                 destLat,
-                                                                                                 destLng,
-                                                                                                 speed),
-                                                            self.__command_timeout + seconds_traveltime)
-            return response
+        # calculate the time it will take to walk and add it to the timeout!
+        distance = get_distance_of_two_points_in_meters(
+            startLat, startLng, destLat, destLng)
+        # speed is in kmph, distance in m
+        # we want m/s -> speed / 3.6
+        speed_meters = speed / 3.6
+        seconds_traveltime = distance / speed_meters
+        return self.__run_get_gesponse("geo walk {} {} {} {} {}\r\n".format(startLat, startLng, destLat, destLng,
+                                                                            speed),
+                                       self.__command_timeout + seconds_traveltime)

--- a/mapadroid/websocket/communicator.py
+++ b/mapadroid/websocket/communicator.py
@@ -2,26 +2,30 @@ from threading import Lock
 from typing import Optional
 
 from mapadroid.utils.CustomTypes import MessageTyping
+from mapadroid.utils.collections import Location
 from mapadroid.utils.geo import get_distance_of_two_points_in_meters
 from mapadroid.utils.logging import logger
 from mapadroid.utils.madGlobals import ScreenshotType, WebsocketWorkerConnectionClosedException
+from mapadroid.websocket.AbstractCommunicator import AbstractCommunicator
 from mapadroid.websocket.WebsocketConnectedClientEntry import WebsocketConnectedClientEntry
+from mapadroid.worker.AbstractWorker import AbstractWorker
 
 
-class Communicator:
+class Communicator(AbstractCommunicator):
     UPDATE_INTERVAL = 0.4
 
-    def __init__(self, websocket_client_entry: WebsocketConnectedClientEntry, worker_id: str, worker_instance_ref,
+    def __init__(self, websocket_client_entry: WebsocketConnectedClientEntry, worker_id: str,
+                 worker_instance_ref: Optional[AbstractWorker],
                  command_timeout: float):
         # Throws ValueError if unable to connect!
         # catch in code using this class
         self.worker_id: str = worker_id
-        self.worker_instance_ref = worker_instance_ref
+        self.worker_instance_ref: Optional[AbstractWorker] = worker_instance_ref
         self.websocket_client_entry = websocket_client_entry
         self.__command_timeout: float = command_timeout
         self.__sendMutex = Lock()
 
-    def cleanup_websocket(self):
+    def cleanup(self) -> None:
         logger.info(
             "Communicator of {} calling exit to cleanup worker in websocket", str(self.worker_id))
         self.terminate_connection()
@@ -47,10 +51,10 @@ class Communicator:
                 data = file.read()  # if you only wanted to read 512 bytes, do .read(512)
         return self.__run_and_ok_bytes(message=data, timeout=timeout, byte_command=1)
 
-    def startApp(self, package_name):
+    def start_app(self, package_name: str) -> bool:
         return self.__runAndOk("more start {}\r\n".format(package_name), self.__command_timeout)
 
-    def stopApp(self, package_name):
+    def stop_app(self, package_name: str) -> bool:
         if not self.__runAndOk("more stop {}\r\n".format(package_name), self.__command_timeout):
             logger.error(
                 "Failed stopping {}, please check if SU has been granted", package_name)
@@ -67,46 +71,46 @@ class Communicator:
     def reboot(self) -> bool:
         return self.__runAndOk("more reboot now\r\n", self.__command_timeout)
 
-    def restartApp(self, package_name) -> bool:
+    def restart_app(self, package_name: str) -> bool:
         return self.__runAndOk("more restart {}\r\n".format(package_name), self.__command_timeout)
 
-    def resetAppdata(self, package_name) -> bool:
+    def reset_app_data(self, package_name: str) -> bool:
         return self.__runAndOk("more reset {}\r\n".format(package_name), self.__command_timeout)
 
-    def clearAppCache(self, package_name) -> bool:
+    def clear_app_cache(self, package_name: str) -> bool:
         return self.__runAndOk("more cache {}\r\n".format(package_name), self.__command_timeout)
 
-    def magisk_off(self, package_name) -> None:
+    def magisk_off(self, package_name: str) -> None:
         self.passthrough("su -c magiskhide --rm {}".format(package_name))
 
-    def magisk_on(self, package_name) -> None:
+    def magisk_on(self, package_name: str) -> None:
         self.passthrough("su -c magiskhide --add {}".format(package_name))
 
-    def turnScreenOn(self) -> bool:
+    def turn_screen_on(self) -> bool:
         return self.__runAndOk("more screen on\r\n", self.__command_timeout)
 
-    def click(self, x, y) -> bool:
+    def click(self, x: int, y: int) -> bool:
         return self.__runAndOk("screen click {} {}\r\n".format(str(int(round(x))), str(int(round(y)))),
                                self.__command_timeout)
 
-    def swipe(self, x1, y1, x2, y2) -> Optional[MessageTyping]:
+    def swipe(self, x1: int, y1: int, x2: int, y2: int) -> Optional[MessageTyping]:
         return self.__run_get_gesponse("touch swipe {} {} {} {}\r\n".format(
                 str(int(round(x1))), str(int(round(y1))), str(int(round(x2))), str(int(round(y2))))
         )
 
-    def touchandhold(self, x1, y1, x2, y2, time: int = 3000) -> bool:
+    def touch_and_hold(self, x1: int, y1: int, x2: int, y2: int, duration: int = 3000) -> bool:
         return self.__runAndOk("touch swipe {} {} {} {} {}".format(
             str(int(round(x1))), str(int(round(y1))), str(int(round(x2))), str(int(round(y2))),
-            str(int(time)))
+            str(int(duration)))
             , self.__command_timeout)
 
-    def getscreensize(self) -> Optional[MessageTyping]:
+    def get_screensize(self) -> Optional[MessageTyping]:
         return self.__run_get_gesponse("screen size")
 
-    def uiautomator(self) -> str:
+    def uiautomator(self) -> Optional[MessageTyping]:
         return self.__run_get_gesponse("more uiautomator")
 
-    def get_screenshot(self, path, quality: int = 70,
+    def get_screenshot(self, path: str, quality: int = 70,
                        screenshot_type: ScreenshotType = ScreenshotType.JPEG) -> bool:
         if quality < 10 or quality > 100:
             logger.error("Invalid quality value passed for screenshots")
@@ -137,55 +141,58 @@ class Communicator:
             logger.debug("Done storing, returning")
             return True
 
-    def backButton(self) -> bool:
+    def back_button(self) -> bool:
         return self.__runAndOk("screen back\r\n", self.__command_timeout)
 
-    def homeButton(self) -> bool:
+    def home_button(self) -> bool:
         return self.__runAndOk("touch keyevent 3", self.__command_timeout)
 
-    def enterButton(self) -> bool:
+    def enter_button(self) -> bool:
         return self.__runAndOk("touch keyevent 61", self.__command_timeout)
 
-    def sendText(self, text):
+    def enter_text(self, text: str) -> bool:
         return self.__runAndOk("touch text " + str(text), self.__command_timeout)
 
-    def isScreenOn(self) -> bool:
+    def is_screen_on(self) -> bool:
         state = self.__run_get_gesponse("more state screen\r\n")
         if state is None:
             return False
         return "on" in state
 
-    def isPogoTopmost(self) -> bool:
+    def is_pogo_topmost(self) -> bool:
         topmost = self.__run_get_gesponse("more topmost app\r\n")
         if topmost is None:
             return False
         return "com.nianticlabs.pokemongo" in topmost
 
-    def topmostApp(self) -> Optional[MessageTyping]:
+    def topmost_app(self) -> Optional[MessageTyping]:
         return self.__run_get_gesponse("more topmost app\r\n")
 
-    def setLocation(self, lat, lng, alt):
-        return self.__run_get_gesponse("geo fix {} {} {}\r\n".format(lat, lng, alt))
+    def set_location(self, location: Location, altitude: float) -> Optional[MessageTyping]:
+        return self.__run_get_gesponse("geo fix {} {} {}\r\n".format(location.lat, location.lng, altitude))
 
-    def terminate_connection(self):
+    def terminate_connection(self) -> bool:
         try:
-            return self.__run_get_gesponse("exit\r\n", timeout=5)
+            return self.__runAndOk("exit\r\n", timeout=5)
         except WebsocketWorkerConnectionClosedException:
             logger.info("Cannot gracefully terminate connection of {}, it's already been closed", self.worker_id)
+            return True
 
     # coords need to be float values
     # speed integer with km/h
     #######
     # This blocks!
     #######
-    def walkFromTo(self, startLat, startLng, destLat, destLng, speed):
+    def walk_from_to(self, location_from: Location, location_to: Location, speed: float) -> Optional[MessageTyping]:
         # calculate the time it will take to walk and add it to the timeout!
         distance = get_distance_of_two_points_in_meters(
-            startLat, startLng, destLat, destLng)
+            location_from.lat, location_from.lng,
+            location_to.lat, location_to.lng)
         # speed is in kmph, distance in m
         # we want m/s -> speed / 3.6
         speed_meters = speed / 3.6
         seconds_traveltime = distance / speed_meters
-        return self.__run_get_gesponse("geo walk {} {} {} {} {}\r\n".format(startLat, startLng, destLat, destLng,
+        return self.__run_get_gesponse("geo walk {} {} {} {} {}\r\n".format(location_from.lat, location_from.lng,
+                                                                            location_to.lat, location_to.lng,
                                                                             speed),
                                        self.__command_timeout + seconds_traveltime)

--- a/mapadroid/worker/AbstractWorker.py
+++ b/mapadroid/worker/AbstractWorker.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+
+
+class AbstractWorker(ABC):
+    @abstractmethod
+    def start_worker(self):
+        pass
+
+    @abstractmethod
+    def stop_worker(self):
+        pass

--- a/mapadroid/worker/AbstractWorker.py
+++ b/mapadroid/worker/AbstractWorker.py
@@ -17,6 +17,10 @@ class AbstractWorker(ABC):
         pass
 
     @abstractmethod
+    def is_stopping(self) -> bool:
+        pass
+
+    @abstractmethod
     def set_geofix_sleeptime(self, sleeptime: int) -> bool:
         pass
 

--- a/mapadroid/worker/AbstractWorker.py
+++ b/mapadroid/worker/AbstractWorker.py
@@ -1,11 +1,41 @@
 from abc import ABC, abstractmethod
 
+from mapadroid.websocket.AbstractCommunicator import AbstractCommunicator
+
 
 class AbstractWorker(ABC):
+    def __init__(self, origin: str, communicator: AbstractCommunicator):
+        self._origin: str = origin
+        self._communicator: AbstractCommunicator = communicator
+
     @abstractmethod
     def start_worker(self):
         pass
 
     @abstractmethod
     def stop_worker(self):
+        pass
+
+    @abstractmethod
+    def set_geofix_sleeptime(self, sleeptime: int) -> bool:
+        pass
+
+    @property
+    def communicator(self) -> AbstractCommunicator:
+        return self._communicator
+
+    @communicator.setter
+    def communicator(self, value: AbstractCommunicator) -> None:
+        raise RuntimeError("Replacing communicator is not supported")
+
+    @property
+    def origin(self) -> str:
+        return self._origin
+
+    @origin.setter
+    def origin(self, value: str) -> None:
+        raise RuntimeError("Replacing origin is not supported")
+
+    @abstractmethod
+    def trigger_check_research(self) -> None:
         pass

--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -9,6 +9,7 @@ from mapadroid.ocr.pogoWindows import PogoWindows
 from mapadroid.utils import MappingManager
 from mapadroid.utils.logging import logger
 from mapadroid.utils.madGlobals import InternalStopWorkerException
+from mapadroid.websocket.AbstractCommunicator import AbstractCommunicator
 from mapadroid.worker.WorkerBase import WorkerBase
 
 Location = collections.namedtuple('Location', ['lat', 'lng'])
@@ -24,12 +25,12 @@ class LatestReceivedType(Enum):
 
 
 class MITMBase(WorkerBase):
-    def __init__(self, args, dev_id, origin, last_known_state, websocket_handler,
+    def __init__(self, args, dev_id, origin, last_known_state, communicator: AbstractCommunicator,
                  mapping_manager: MappingManager,
                  area_id: int, routemanager_name: str, db_wrapper, mitm_mapper: MitmMapper,
                  pogoWindowManager: PogoWindows,
                  NoOcr=False, walker=None):
-        WorkerBase.__init__(self, args, dev_id, origin, last_known_state, websocket_handler,
+        WorkerBase.__init__(self, args, dev_id, origin, last_known_state, communicator,
                             mapping_manager=mapping_manager, area_id=area_id,
                             routemanager_name=routemanager_name,
                             db_wrapper=db_wrapper, NoOcr=True,
@@ -143,7 +144,7 @@ class MITMBase(WorkerBase):
         return data_requested
 
     def _start_pogo(self) -> bool:
-        pogo_topmost = self._communicator.isPogoTopmost()
+        pogo_topmost = self._communicator.is_pogo_topmost()
         if pogo_topmost:
             return True
         self._mitm_mapper.set_injection_status(self._origin, False)

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -762,6 +762,9 @@ class WorkerBase(AbstractWorker):
         self._wait_pogo_start_delay()
         return start_result
 
+    def is_stopping(self) -> bool:
+        return self._stop_worker_event.is_set()
+
     def _stop_pogo(self):
         attempts = 0
         stop_result = self._communicator.stop_app("com.nianticlabs.pokemongo")

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -318,7 +318,6 @@ class WorkerBase(AbstractWorker):
             logger.info("Stopping worker's asyncio loop")
             self.loop.call_soon_threadsafe(self.loop.stop)
             self._async_io_looper_thread.join()
-            time.sleep(10)
 
         self._communicator.cleanup()
 

--- a/mapadroid/worker/WorkerConfigmode.py
+++ b/mapadroid/worker/WorkerConfigmode.py
@@ -10,13 +10,14 @@ from mapadroid.utils.logging import logger
 from mapadroid.utils.madGlobals import (
     WebsocketWorkerRemovedException,
     WebsocketWorkerTimeoutException,
-    InternalStopWorkerException
-)
+    InternalStopWorkerException,
+    WebsocketWorkerConnectionClosedException)
 from mapadroid.utils.routeutil import check_walker_value_type
 from mapadroid.websocket.communicator import Communicator
+from mapadroid.worker.AbstractWorker import AbstractWorker
 
 
-class WorkerConfigmode(object):
+class WorkerConfigmode(AbstractWorker):
     def __init__(self, args, dev_id, id, websocket_handler, walker, mapping_manager,
                  mitm_mapper: MitmMapper, db_wrapper: DbWrapper, area_id: int, routemanager_name: str):
         self._args = args
@@ -144,7 +145,8 @@ class WorkerConfigmode(object):
             if killpogo:
                 try:
                     self._start_pogo()
-                except (WebsocketWorkerRemovedException, WebsocketWorkerTimeoutException):
+                except (WebsocketWorkerRemovedException, WebsocketWorkerTimeoutException,
+                        WebsocketWorkerConnectionClosedException):
                     logger.error("Timeout during init of worker {}", str(self._origin))
             return False
         else:
@@ -217,7 +219,7 @@ class WorkerConfigmode(object):
             return True
         try:
             start_result = self._communicator.reboot()
-        except WebsocketWorkerRemovedException:
+        except (WebsocketWorkerRemovedException, WebsocketWorkerConnectionClosedException):
             logger.error(
                 "Could not reboot due to client already having disconnected")
             start_result = False

--- a/mapadroid/worker/WorkerConfigmode.py
+++ b/mapadroid/worker/WorkerConfigmode.py
@@ -79,6 +79,9 @@ class WorkerConfigmode(AbstractWorker):
             self._stop_worker_event.set()
             logger.warning("Worker {} stop called", str(self._origin))
 
+    def is_stopping(self) -> bool:
+        return self._stop_worker_event.is_set()
+
     def set_geofix_sleeptime(self, sleeptime: int):
         return True
 

--- a/mapadroid/worker/WorkerFactory.py
+++ b/mapadroid/worker/WorkerFactory.py
@@ -1,0 +1,212 @@
+import asyncio
+from typing import Optional, NamedTuple
+
+from mapadroid.db.DbWrapper import DbWrapper
+from mapadroid.mitm_receiver.MitmMapper import MitmMapper
+from mapadroid.ocr.pogoWindows import PogoWindows
+from mapadroid.utils.MappingManager import MappingManager
+from mapadroid.utils.collections import Location
+from mapadroid.utils.madGlobals import WrongAreaInWalker
+from mapadroid.utils.routeutil import pre_check_value
+from mapadroid.websocket.WebsocketConnectedClientEntry import WebsocketConnectedClientEntry
+from mapadroid.worker.AbstractWorker import AbstractWorker
+from mapadroid.worker.WorkerConfigmode import WorkerConfigmode
+from mapadroid.worker.WorkerMITM import WorkerMITM
+from mapadroid.worker.WorkerQuests import WorkerQuests
+from mapadroid.worker.WorkerType import WorkerType
+from mapadroid.utils.logging import logger
+
+
+class WalkerConfiguration(NamedTuple):
+    walker_settings: dict
+    walker_index: int
+    walker_area_name: str
+    total_walkers_allowed_for_assigned_area: int
+
+
+class WorkerFactory:
+    def __init__(self, args, mapping_manager: MappingManager, mitm_mapper: MitmMapper, db_wrapper: DbWrapper,
+                 pogo_windows: PogoWindows):
+        self.__args = args
+        self.__mapping_manager: MappingManager = mapping_manager
+        self.__mitm_mapper: MitmMapper = mitm_mapper
+        self.__db_wrapper: DbWrapper = db_wrapper
+        self.__pogo_windows: PogoWindows = pogo_windows
+
+    async def __get_walker_index(self, devicesettings, origin):
+        walker_index = devicesettings.get('walker_area_index', 0)
+        if walker_index > 0:
+            # check status of last area
+            if not devicesettings.get('finished', False):
+                logger.info(
+                    'Something wrong with last round - get back to old area')
+                walker_index -= 1
+                self.__mapping_manager.set_devicesetting_value_of(origin, 'walker_area_index',
+                                                                  walker_index)
+        return walker_index
+
+    async def __initalize_devicesettings(self, origin):
+        logger.debug("Initializing devicesettings")
+        self.__mapping_manager.set_devicesetting_value_of(origin, 'walker_area_index', 0)
+        self.__mapping_manager.set_devicesetting_value_of(origin, 'finished', False)
+        self.__mapping_manager.set_devicesetting_value_of(origin, 'last_action_time', None)
+        self.__mapping_manager.set_devicesetting_value_of(origin, 'last_cleanup_time', None)
+        self.__mapping_manager.set_devicesetting_value_of(origin, 'job', False)
+        await asyncio.sleep(1)  # give the settings a moment... (dirty "workaround" against race condition)
+
+    async def __get_walker_settings(self, origin: str, client_mapping: dict, devicesettings: dict) \
+            -> Optional[WalkerConfiguration]:
+        walker_area_array = client_mapping.get("walker", None)
+        if walker_area_array is None:
+            logger.error("No valid walker could be found for {}", origin)
+            return None
+
+        if devicesettings is not None and "walker_area_index" not in devicesettings:
+            await self.__initalize_devicesettings(origin)
+        walker_index = await self.__get_walker_index(devicesettings, origin)
+
+        walker_settings: dict = walker_area_array[walker_index]
+
+        # preckeck walker setting
+        walker_area_name = walker_area_array[walker_index]['walkerarea']
+        while not pre_check_value(walker_settings) and walker_index - 1 <= len(walker_area_array):
+            walker_area_name = walker_area_array[walker_index]['walkerarea']
+            logger.info(
+                '{} not using area {} - Walkervalue out of range', str(origin),
+                str(self.__mapping_manager.routemanager_get_name(walker_area_name)))
+            if walker_index >= len(walker_area_array) - 1:
+                logger.error(
+                    'Could not find any working area at this time - check your mappings for device: {}',
+                    str(origin))
+                walker_index = 0
+                self.__mapping_manager.set_devicesetting_value_of(origin, 'walker_area_index',
+                                                                  walker_index)
+                return None
+            walker_index += 1
+            self.__mapping_manager.set_devicesetting_value_of(origin, 'walker_area_index',
+                                                              walker_index)
+            walker_settings = walker_area_array[walker_index]
+
+        logger.debug("Checking walker_area_index length")
+        if walker_index >= len(walker_area_array):
+            # check if array is smaller than expected - f.e. on the fly changes in mappings.json
+            self.__mapping_manager.set_devicesetting_value_of(origin, 'walker_area_index', 0)
+            self.__mapping_manager.set_devicesetting_value_of(origin, 'finished', False)
+            walker_index = 0
+
+        walker_configuration = WalkerConfiguration(walker_area_name=walker_area_name, walker_index=walker_index,
+                                                   walker_settings=walker_settings,
+                                                   total_walkers_allowed_for_assigned_area=len(walker_area_array))
+        return walker_configuration
+
+    async def __prep_settings(self, origin: str) -> Optional[WalkerConfiguration]:
+        last_known_state = {}
+        client_mapping = self.__mapping_manager.get_devicemappings_of(origin)
+        devicesettings = self.__mapping_manager.get_devicesettings_of(origin)
+        logger.info("Setting up routemanagers for {}", str(origin))
+
+        walker_configuration: Optional[WalkerConfiguration] = await self.__get_walker_settings(origin, client_mapping,
+                                                                                               devicesettings)
+        if walker_configuration is None:
+            # logging is done in __get_walker_settings...
+            return None
+
+        if walker_configuration.walker_area_name not in self.__mapping_manager.get_all_routemanager_names():
+            raise WrongAreaInWalker()
+
+        logger.debug('Devicesettings {}: {}', str(origin), devicesettings)
+        logger.info('{} using walker area {} [{}/{}]', str(origin), str(
+            self.__mapping_manager.routemanager_get_name(walker_configuration.walker_area_name)),
+                    str(walker_configuration.walker_index + 1),
+                    str(walker_configuration.total_walkers_allowed_for_assigned_area))
+        return walker_configuration
+
+    async def __update_settings_of_origin(self, origin: str, walker_configuration: WalkerConfiguration):
+        self.__mapping_manager.set_devicesetting_value_of(origin, 'walker_area_index',
+                                                          walker_configuration.walker_index + 1)
+        self.__mapping_manager.set_devicesetting_value_of(origin, 'finished', False)
+        if walker_configuration.walker_index >= walker_configuration.total_walkers_allowed_for_assigned_area - 1:
+            self.__mapping_manager.set_devicesetting_value_of(origin, 'walker_area_index', 0)
+
+        if "last_location" not in self.__mapping_manager.get_devicesettings_of(origin):
+            # TODO: I hope this does not cause issues...
+            self.__mapping_manager.set_devicesetting_value_of(origin, "last_location", Location(0.0, 0.0))
+
+    async def get_worker_using_settings(self, origin: str, enable_configmode: bool,
+                                        websocket_client_entry: WebsocketConnectedClientEntry) \
+            -> Optional[AbstractWorker]:
+        if enable_configmode:
+            return self.get_configmode_worker(origin, websocket_client_entry)
+
+        # not a configmore worker, move on adjusting devicesettings etc
+        # TODO: get worker
+        walker_configuration: Optional[WalkerConfiguration] = await self.__prep_settings(origin)
+        if walker_configuration is None:
+            logger.error("Failed to find a walker configuration for {}", origin)
+            return None
+        logger.debug("Setting up worker for {}", str(origin))
+        await self.__update_settings_of_origin(origin, walker_configuration)
+
+        dev_id = self.__mapping_manager.get_all_devicemappings()[origin]['device_id']
+        area_id = walker_configuration.walker_settings['walkerarea']
+        walker_routemanager_mode: WorkerType = self.__mapping_manager.routemanager_get_mode(
+            walker_configuration.walker_area_name
+        )
+        if dev_id is None or area_id is None or walker_routemanager_mode == WorkerType.UNDEFINED:
+            logger.error("Failed to instantiate worker for {} due to invalid settings found", origin)
+            return None
+
+        # we can finally create an instance of the worker, bloody hell...
+        # TODO: last_known_state has never been used and got kinda deprecated due to devicesettings...
+        return self.get_worker(origin, walker_routemanager_mode, websocket_client_entry, dev_id, {}, area_id,
+                               walker_configuration.walker_settings, walker_configuration.walker_area_name)
+
+    def get_worker(self, origin: str, worker_type: WorkerType, websocket_client_entry: WebsocketConnectedClientEntry,
+                   dev_id: str, last_known_state: dict, area_id: int,
+                   walker_settings: dict, walker_area_name: str) -> Optional[AbstractWorker]:
+        if origin is None or worker_type is None or worker_type == WorkerType.UNDEFINED:
+            return None
+        elif worker_type in [WorkerType.CONFIGMODE, WorkerType.CONFIGMODE.value]:
+            logger.error("WorkerFactory::get_worker called with configmode arg, use get_configmode_worker instead")
+            return None
+        # TODO: validate all values
+        elif worker_type in [WorkerType.IV_MITM, WorkerType.IV_MITM.value,
+                             WorkerType.MON_MITM, WorkerType.MON_MITM.value,
+                             WorkerType.RAID_MITM, WorkerType.RAID_MITM.value]:
+            return WorkerMITM(self.__args, dev_id, origin, last_known_state, websocket_client_entry, area_id=area_id,
+                              routemanager_name=walker_area_name, mitm_mapper=self.__mitm_mapper,
+                              mapping_manager=self.__mapping_manager, db_wrapper=self.__db_wrapper,
+                              pogo_window_manager=self.__pogo_windows, walker=walker_settings)
+        elif worker_type in [WorkerType.STOPS, WorkerType.STOPS.value]:
+            return WorkerQuests(self.__args, dev_id, origin, last_known_state, websocket_client_entry, area_id=area_id,
+                                routemanager_name=walker_area_name, mitm_mapper=self.__mitm_mapper,
+                                mapping_manager=self.__mapping_manager, db_wrapper=self.__db_wrapper,
+                                pogo_window_manager=self.__pogo_windows, walker=walker_settings)
+        elif worker_type in [WorkerType.IDLE, WorkerType.IDLE.value]:
+            return WorkerConfigmode(self.__args, dev_id, origin, websocket_client_entry, walker=walker_settings,
+                                    mapping_manager=self.__mapping_manager, mitm_mapper=self.__mitm_mapper,
+                                    db_wrapper=self.__db_wrapper, area_id=area_id, routemanager_name=walker_area_name)
+        else:
+            logger.error("WorkerFactor::get_worker failed to create a worker...")
+            return None
+
+    def get_configmode_worker(self, origin: str, websocket_client_entry: WebsocketConnectedClientEntry):
+        dev_id = self.__mapping_manager.get_all_devicemappings()[origin]['device_id']
+        devicesettings = self.__mapping_manager.get_devicesettings_of(origin)
+        client_mapping = self.__mapping_manager.get_devicemappings_of(origin)
+        walker_area_array = client_mapping["walker"]
+        walker_index = devicesettings.get('walker_area_index', 0)
+        walker_settings = walker_area_array[walker_index]
+        area_id = walker_settings['walkerarea']
+        worker = WorkerConfigmode(args=self.__args,
+                                  dev_id=dev_id,
+                                  id=origin,
+                                  websocket_handler=websocket_client_entry,
+                                  walker=None,
+                                  mapping_manager=self.__mapping_manager,
+                                  mitm_mapper=self.__mitm_mapper,
+                                  db_wrapper=self.__db_wrapper,
+                                  area_id=area_id,
+                                  routemanager_name=None)
+        return worker
+

--- a/mapadroid/worker/WorkerFactory.py
+++ b/mapadroid/worker/WorkerFactory.py
@@ -43,6 +43,8 @@ class WorkerFactory:
                 walker_index -= 1
                 self.__mapping_manager.set_devicesetting_value_of(origin, 'walker_area_index',
                                                                   walker_index)
+            else:
+                logger.debug('Previous area was finished, move on')
         return walker_index
 
     async def __initalize_devicesettings(self, origin):
@@ -69,8 +71,7 @@ class WorkerFactory:
 
         # preckeck walker setting
         walker_area_name = walker_area_array[walker_index]['walkerarea']
-        while not pre_check_value(walker_settings) and walker_index - 1 <= len(walker_area_array):
-            walker_area_name = walker_area_array[walker_index]['walkerarea']
+        while not pre_check_value(walker_settings) and walker_index < len(walker_area_array):
             logger.info(
                 '{} not using area {} - Walkervalue out of range', str(origin),
                 str(self.__mapping_manager.routemanager_get_name(walker_area_name)))
@@ -86,6 +87,7 @@ class WorkerFactory:
             self.__mapping_manager.set_devicesetting_value_of(origin, 'walker_area_index',
                                                               walker_index)
             walker_settings = walker_area_array[walker_index]
+            walker_area_name = walker_area_array[walker_index]['walkerarea']
 
         logger.debug("Checking walker_area_index length")
         if walker_index >= len(walker_area_array):

--- a/mapadroid/worker/WorkerQuests.py
+++ b/mapadroid/worker/WorkerQuests.py
@@ -10,6 +10,7 @@ from mapadroid.db.DbWrapper import DbWrapper
 from mapadroid.mitm_receiver.MitmMapper import MitmMapper
 from mapadroid.ocr.pogoWindows import PogoWindows
 from mapadroid.utils import MappingManager
+from mapadroid.utils.collections import Location
 from mapadroid.utils.geo import (
     get_distance_of_two_points_in_meters,
     get_lat_lng_offsets_by_distance
@@ -20,6 +21,7 @@ from mapadroid.utils.madGlobals import (
     WebsocketWorkerRemovedException,
     WebsocketWorkerTimeoutException
 )
+from mapadroid.websocket.AbstractCommunicator import AbstractCommunicator
 from mapadroid.worker.MITMBase import MITMBase, LatestReceivedType
 
 PROTO_NUMBER_FOR_GMO = 106
@@ -44,11 +46,12 @@ class WorkerQuests(MITMBase):
     def _valid_modes(self):
         return ["pokestops"]
 
-    def __init__(self, args, dev_id, id, last_known_state, websocket_handler, mapping_manager: MappingManager,
+    def __init__(self, args, dev_id, id, last_known_state, communicator: AbstractCommunicator,
+                 mapping_manager: MappingManager,
                  area_id: int, routemanager_name: str, db_wrapper: DbWrapper,
                  pogo_window_manager: PogoWindows, walker,
                  mitm_mapper: MitmMapper):
-        MITMBase.__init__(self, args, dev_id, id, last_known_state, websocket_handler,
+        MITMBase.__init__(self, args, dev_id, id, last_known_state, communicator,
                           mapping_manager=mapping_manager, routemanager_name=routemanager_name,
                           area_id=area_id,
                           db_wrapper=db_wrapper, NoOcr=False,
@@ -145,8 +148,8 @@ class WorkerQuests(MITMBase):
                 or (self.last_location.lat == 0.0 and self.last_location.lng == 0.0)):
             logger.debug("main: Teleporting...")
             self._transporttype = 0
-            self._communicator.setLocation(
-                self.current_location.lat, self.current_location.lng, 0)
+            self._communicator.set_location(
+                Location(self.current_location.lat, self.current_location.lng), 0)
             # the time we will take as a starting point to wait for data...
             cur_time = math.floor(time.time())
 
@@ -250,9 +253,7 @@ class WorkerQuests(MITMBase):
             delay_used = distance / speed
             logger.info("main: Walking {} m, this will take {} seconds", distance, delay_used)
             self._transporttype = 1
-            self._communicator.walkFromTo(self.last_location.lat, self.last_location.lng,
-                                          self.current_location.lat,
-                                          self.current_location.lng, speed)
+            self._communicator.walk_from_to(self.last_location, self.current_location, speed)
             # the time we will take as a starting point to wait for data...
             cur_time = math.floor(time.time())
             delay_used = self.get_devicesettings_value('post_walk_delay', 7)
@@ -271,18 +272,16 @@ class WorkerQuests(MITMBase):
                                                            float(self.current_location.lng) + lng_offset)
             logger.info("Walking roughly: {}", str(to_walk))
             time.sleep(0.3)
-            self._communicator.walkFromTo(self.current_location.lat,
-                                          self.current_location.lng,
-                                          self.current_location.lat + lat_offset,
-                                          self.current_location.lng + lng_offset,
-                                          11)
+            self._communicator.walk_from_to(self.current_location,
+                                            Location(self.current_location.lat + lat_offset,
+                                                     self.current_location.lng + lng_offset),
+                                            11)
             logger.debug("Walking back")
             time.sleep(0.3)
-            self._communicator.walkFromTo(self.current_location.lat + lat_offset,
-                                          self.current_location.lng + lng_offset,
-                                          self.current_location.lat,
-                                          self.current_location.lng,
-                                          11)
+            self._communicator.walk_from_to(Location(self.current_location.lat + lat_offset,
+                                                     self.current_location.lng + lng_offset),
+                                            self.current_location,
+                                            11)
             logger.debug("Done walking")
             time.sleep(1)
             delay_used -= (to_walk / 3.05) - 1.  # We already waited for a bit because of this walking part
@@ -471,7 +470,7 @@ class WorkerQuests(MITMBase):
                 if error_counter > 3:
                     stop_inventory_clear.set()
                 logger.warning('Find no item to delete - scrolling ({} times)', str(error_counter))
-                self._communicator.touchandhold(int(200), int(600), int(200), int(100))
+                self._communicator.touch_and_hold(int(200), int(600), int(200), int(100))
                 time.sleep(5)
 
             trashcancheck = self._get_trash_positions()
@@ -512,7 +511,7 @@ class WorkerQuests(MITMBase):
                         self._communicator.click(int(trashcancheck[trash].x), int(trashcancheck[trash].y))
                         time.sleep(1 + int(delayadd))
 
-                        self._communicator.touchandhold(
+                        self._communicator.touch_and_hold(
                             click_x1, click_y, click_x2, click_y, click_duration)
                         time.sleep(1)
 

--- a/mapadroid/worker/WorkerType.py
+++ b/mapadroid/worker/WorkerType.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class WorkerType(Enum):
+    UNDEFINED = None
+    RAID_MITM = "raids_mitm"
+    MON_MITM = "mon_mitm"
+    IV_MITM = "iv_mitm"
+    STOPS = "pokestops"
+    IDLE = "idle"
+    CONFIGMODE = "configmode"
+

--- a/start.py
+++ b/start.py
@@ -177,11 +177,12 @@ if __name__ == "__main__":
 
     mapping_manager_manager = None
     mapping_manager: Optional[MappingManager] = None
-
+    pogoWindowManager = None
     ws_server = None
     t_ws = None
     t_file_watcher = None
     t_whw = None
+    device_Updater = None
 
     if args.only_scan or args.only_routes:
         MappingManagerManager.register('MappingManager', MappingManager)
@@ -201,7 +202,6 @@ if __name__ == "__main__":
             # TODO: shutdown managers properly...
             sys.exit(0)
 
-        pogoWindowManager = None
         jobstatus: dict = {}
         MitmMapperManager.register('MitmMapper', MitmMapper)
         mitm_mapper_manager = MitmMapperManager()
@@ -291,10 +291,15 @@ if __name__ == "__main__":
             terminate_mad.set()
             # now cleanup all threads...
             # TODO: check against args or init variables to None...
+            if device_Updater is not None:
+                device_Updater.stop_updater()
             if t_whw is not None:
+                logger.info("Waiting for webhook-thread to exit")
                 t_whw.join()
             if ws_server is not None:
+                logger.info("Stopping websocket server")
                 ws_server.stop_server()
+                logger.info("Waiting for websocket-thread to exit")
                 t_ws.join()
             if mitm_receiver_process is not None:
                 # mitm_receiver_thread.kill()

--- a/start.py
+++ b/start.py
@@ -291,6 +291,15 @@ if __name__ == "__main__":
             terminate_mad.set()
             # now cleanup all threads...
             # TODO: check against args or init variables to None...
+            if mitm_receiver_process is not None:
+                # mitm_receiver_thread.kill()
+                logger.info("Trying to stop receiver")
+                mitm_receiver_process.shutdown()
+                logger.debug("MITM child threads successfully shutdown.  Terminating parent thread")
+                mitm_receiver_process.terminate()
+                logger.debug("Trying to join MITMReceiver")
+                mitm_receiver_process.join()
+                logger.debug("MITMReceiver joined")
             if device_Updater is not None:
                 device_Updater.stop_updater()
             if t_whw is not None:
@@ -301,15 +310,6 @@ if __name__ == "__main__":
                 ws_server.stop_server()
                 logger.info("Waiting for websocket-thread to exit")
                 t_ws.join()
-            if mitm_receiver_process is not None:
-                # mitm_receiver_thread.kill()
-                logger.info("Trying to stop receiver")
-                mitm_receiver_process.shutdown()
-                logger.debug("MITM child threads successfully shutdown.  Terminating parent thread")
-                mitm_receiver_process.terminate()
-                logger.debug("Trying to join MITMReceiver")
-                mitm_receiver_process.join()
-                logger.debug("MITMReceiver joined")
             if mapping_manager_manager is not None:
                 mapping_manager_manager.shutdown()
             if mitm_mapper_manager is not None:


### PR DESCRIPTION
Since my original implementation of the websocket was a little confusing and wasteful, I kinda refactored it...
Meanwhile, I tried to add as much typing as I could (probably still missing some here and there, not too sure) and added a couple TODO comments.
Especially the handler of websocket connections has a TODO regarding cleanup, since we could reuse a running worker by just replacing the connection associated in the new WebsocketConnectedClientEntry-instance. We could, for example, add a method waiting for a new connection (with a timeout of e.g. one minute ofc to not get stuck forever) in case a WebsocketWorkerConnectionClosedException (new, raised when the connection to be used to send is not open anymore) is raised in a worker.

Also, I added AbstractWorker and AbstractCommunicator to break some circular dependencies while also providing a common base class for WorkerBase (and thus all other workers) and WorkerConfigmode

As a result, the websocket should scale a little better than before (way less sleeps, no iterating the workers for each send etc) while being more readable (the old handler/register was way too long).
Also, moving workers to use asyncio would probably be a good idea