### PR TITLE
APK Database Cleanup

### DIFF
--- a/mapadroid/patcher/__init__.py
+++ b/mapadroid/patcher/__init__.py
@@ -26,6 +26,7 @@ MAD_UPDATES = OrderedDict([
     (21, 'patch_21'),
     (23, 'patch_23'),
     (24, 'patch_24'),
+    (25, 'patch_25'),
 ])
 
 

--- a/mapadroid/patcher/patch_25.py
+++ b/mapadroid/patcher/patch_25.py
@@ -23,3 +23,11 @@ class Patch(PatchBase):
             self._db.execute(sql, commit=True)
         except Exception:
             pass
+        sql = "DELETE fc\n"\
+              "FROM `filestore_chunks` fc\n"\
+              "LEFT JOIN `mad_apks` ma ON ma.`filestore_id` = fc.`filestore_id`\n"\
+              "WHERE ma.`filestore_id` IS NULL"
+        try:
+            self._db.execute(sql, commit=True)
+        except Exception:
+            pass

--- a/mapadroid/patcher/patch_25.py
+++ b/mapadroid/patcher/patch_25.py
@@ -1,0 +1,25 @@
+from ._patch_base import PatchBase
+
+
+class Patch(PatchBase):
+    name = 'Patch 25 - MADmin APK Cleanup'
+
+    def _execute(self):
+        # The key was incorrectly named a foreign key (fk).  Renaming to key (k)
+        sql = "ALTER TABLE `filestore_chunks` "\
+              "DROP INDEX `fk_fs_chunks`, "\
+              "ADD INDEX `k_fs_chunks` (`filestore_id`)"
+        try:
+            self._db.execute(sql, commit=True)
+        except Exception:
+            pass
+        # There was an issue where the chunk table was not being cleaned up.  Remove any chunks whose filestore_id
+        # no longer exists
+        sql = "DELETE fc\n"\
+              "FROM `filestore_chunks` fc\n"\
+              "LEFT JOIN `filestore_meta` fm ON fm.`filestore_id` = fc.`filestore_id`\n"\
+              "WHERE fm.`filestore_id` IS NULL"
+        try:
+            self._db.execute(sql, commit=True)
+        except Exception:
+            pass

--- a/mapadroid/patcher/patch_25.py
+++ b/mapadroid/patcher/patch_25.py
@@ -10,7 +10,7 @@ class Patch(PatchBase):
               "DROP INDEX `fk_fs_chunks`, "\
               "ADD INDEX `k_fs_chunks` (`filestore_id`)"
         try:
-            self._db.execute(sql, commit=True)
+            self._db.execute(sql, commit=True, suppress_log=True)
         except Exception:
             pass
         # There was an issue where the chunk table was not being cleaned up.  Remove any chunks whose filestore_id
@@ -23,9 +23,9 @@ class Patch(PatchBase):
             self._db.execute(sql, commit=True)
         except Exception:
             pass
-        sql = "DELETE fc\n"\
-              "FROM `filestore_chunks` fc\n"\
-              "LEFT JOIN `mad_apks` ma ON ma.`filestore_id` = fc.`filestore_id`\n"\
+        sql = "DELETE fm\n"\
+              "FROM `filestore_meta` fm\n"\
+              "LEFT JOIN `mad_apks` ma ON ma.`filestore_id` = fm.`filestore_id`\n"\
               "WHERE ma.`filestore_id` IS NULL"
         try:
             self._db.execute(sql, commit=True)

--- a/mapadroid/utils/apk_util.py
+++ b/mapadroid/utils/apk_util.py
@@ -229,7 +229,7 @@ class MADAPKImporter(object):
                 filestore_id = None
                 # Determine if we already have this file-type uploaded.  If so, remove it once the new one is
                 # completed and update the id
-                if self.mad_apk and self.apk_type and self.architecture:
+                if self.mad_apk and self.apk_type is not None and self.architecture is not None:
                     filestore_id_sql = "SELECT `filestore_id` FROM `mad_apks` WHERE `usage` = %s AND `arch` = %s"
                     filestore_id = self.dbc.autofetch_value(filestore_id_sql,
                                                             args=(self.apk_type, self.architecture,))

--- a/scripts/SQL/rocketmap.sql
+++ b/scripts/SQL/rocketmap.sql
@@ -8,7 +8,7 @@ CREATE TABLE `filestore_chunks` (
     `data` longblob,
     PRIMARY KEY (`chunk_id`),
     UNIQUE KEY `chunk_id` (`chunk_id`,`filestore_id`),
-    KEY `fk_fs_chunks` (`filestore_id`),
+    KEY `k_fs_chunks` (`filestore_id`),
     CONSTRAINT `fk_fs_chunks` FOREIGN KEY (`filestore_id`)
         REFERENCES `filestore_meta` (`filestore_id`)
         ON DELETE CASCADE


### PR DESCRIPTION
Fix for #719 

When a new MAD APK is uploaded it will not correctly clear out filestore_meta and filestore_chunks