### PR TITLE
Clone the resource defition and defaults before modification

### DIFF
--- a/mapadroid/data_manager/__init__.py
+++ b/mapadroid/data_manager/__init__.py
@@ -50,7 +50,7 @@ class DataManager(object):
                 raise ModeUnknown(mode)
         else:
             resource_class = modules.MAPPINGS[section]
-        return resource_class
+        return copy.deepcopy(resource_class)
 
     def get_root_resource(self, section: str, **kwargs) -> Dict[int, Resource]:
         default_sort = kwargs.get('default_sort', None)

--- a/mapadroid/data_manager/modules/resource.py
+++ b/mapadroid/data_manager/modules/resource.py
@@ -1,3 +1,4 @@
+import copy
 from collections import UserDict
 import mysql
 from ..dm_exceptions import DependencyError, SaveIssue, UnknownIdentifier, UpdateIssue
@@ -327,7 +328,7 @@ class Resource(object):
                         defaults[field] = val['settings']['empty']
                     except KeyError:
                         continue
-                self._data[section] = ResourceTracker(self.configuration[section], self._data_manager,
+                self._data[section] = ResourceTracker(copy.deepcopy(self.configuration[section]), self._data_manager,
                                                       initialdata=defaults)
             except KeyError:
                 continue


### PR DESCRIPTION
Fix for #726
Previously the default configuration was being updated vs cloned.  This caused unintended consequences where resources could not successfully be created or updated if the original one was deleted