### PR TITLE
Enable/Fix time sorting on status page and add optional checkmark

### DIFF
--- a/static/madmin/templates/status.html
+++ b/static/madmin/templates/status.html
@@ -12,13 +12,11 @@
 </style>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.min.js"></script>
 <script>
-    var dataTable;
-    function setGrid(tableGridHtmlId, gridData) {
-        if ($.fn.dataTable.isDataTable(tableGridHtmlId)) {
-            dataTable.destroy();
-        }
-        dataTable = $(tableGridHtmlId).DataTable({
-            "data": gridData,
+    var dataTable = $("#show-data").DataTable({
+            "ajax": {
+                "url": "get_status",
+                "dataSrc": ""
+            },
             "columns": [
                 {
                     data: 'name', title: 'Origin',
@@ -66,6 +64,7 @@
                 {
                     "targets": [1, 8, 12],
                     "render": function (data, type, row) {
+                        if (type == "sort") { return data; }
                         var dateToShow = moment.utc(data * 1000);
                         if (dateToShow.isValid() && data != null && data != undefined) {
                             return toHHMMSS(Math.abs(dateToShow.diff(moment.utc()) / 1000));
@@ -86,14 +85,12 @@
             "stateSave": true,
             "stateDuration": 0,                                    
             "stateSaveCallback": function(settings,data) {
-            localStorage.setItem( 'MAD_STATUS_' + settings.sInstance, JSON.stringify(data) )
+                localStorage.setItem( 'MAD_STATUS_' + settings.sInstance, JSON.stringify(data) )
             },
             "stateLoadCallback": function(settings) {
                 return JSON.parse( localStorage.getItem( 'MAD_STATUS_' + settings.sInstance ) )
             }
         });
-    }
-
     var toHHMMSS = (secs) => {
         var sec_num = parseInt(secs, 10)
         var hours   = Math.floor(sec_num / 3600)
@@ -105,30 +102,12 @@
             .filter((v,i) => v !== "00" || i > 0)
             .join(":")
     }
-
-    function getStatusData() {
-        return $.ajax({
-            type: "GET",
-            url: "get_status",
-            success: function (result) {
-                return result;
-            }
-        });
-    }
-
-    function reloadGrid() {
-        getStatusData().then(function (result) {
-            setGrid('#show-data', result);
-        });
-    }
-
+    
     $(document).ready(function () {
         $("#navstatus").addClass("active");
-
-        getStatusData().then(function (result) {
-            setGrid('#show-data', result);
-            setInterval(reloadGrid, 10000);
-        });
+        setInterval(function () {
+                dataTable.ajax.reload( null, false ); // user paging is not reset on reload
+        }, 10000);
     });
 </script>
 

--- a/static/madmin/templates/status.html
+++ b/static/madmin/templates/status.html
@@ -62,7 +62,18 @@
                     }
                 },
                 {
-                    "targets": [1, 8, 12],
+                    "targets": [1],
+                    "render": function (data, type, row) {
+                        if (type == "sort") { return data; }
+                        var dateToShow = moment.utc(data * 1000);
+                        if (dateToShow.isValid() && data != null && data != undefined) {
+                            return toHHMMSS(Math.abs(dateToShow.diff(moment.utc()) / 1000));
+                        }
+                        return "None";
+                    }
+                },
+                {
+                    "targets": [8, 12],
                     "render": function (data, type, row) {
                         if (type == "sort") { return data; }
                         var dateToShow = moment.utc(data * 1000);
@@ -91,6 +102,15 @@
                 return JSON.parse( localStorage.getItem( 'MAD_STATUS_' + settings.sInstance ) )
             }
         });
+    
+    var toHHMMSS_mark = (secs) => {
+        var sec_test = parseInt(secs, 10);
+        if (sec_test <  localStorage['MAD_MAXSECONDS_STATUS']) {
+                return "✔️";
+        }
+        return toHHMMSS(secs);
+    }
+    
     var toHHMMSS = (secs) => {
         var sec_num = parseInt(secs, 10)
         var hours   = Math.floor(sec_num / 3600)
@@ -105,8 +125,12 @@
     
     $(document).ready(function () {
         $("#navstatus").addClass("active");
+        $('input#maxSeconds').val(localStorage["MAD_MAXSECONDS_STATUS"]);
+        $('input#maxSeconds').on('input', function() {
+                localStorage['MAD_MAXSECONDS_STATUS'] = $(this).val();
+        });
         setInterval(function () {
-                dataTable.ajax.reload( null, false ); // user paging is not reset on reload
+                dataTable.ajax.reload(null, false); //user paging is not reset on reload
         }, 10000);
     });
 </script>
@@ -122,4 +146,10 @@
 </div>
 <br>
 <table id="show-data" class="table"></table>
+<div class="card border-secondary">
+  <div class="card-body py-2">
+    <p class="card-text">How many seconds for green tick? <input type="number" id="maxSeconds" /></p>
+  </div>
+</div>
+<br />
 {% endblock %}

--- a/static/madmin/templates/status.html
+++ b/static/madmin/templates/status.html
@@ -95,12 +95,6 @@
             "autoWidth": false,
             "stateSave": true,
             "stateDuration": 0,                                    
-            "stateSaveCallback": function(settings,data) {
-                localStorage.setItem( 'MAD_STATUS_' + settings.sInstance, JSON.stringify(data) )
-            },
-            "stateLoadCallback": function(settings) {
-                return JSON.parse( localStorage.getItem( 'MAD_STATUS_' + settings.sInstance ) )
-            }
         });
     
     var toHHMMSS_mark = (secs) => {

--- a/static/madmin/templates/status.html
+++ b/static/madmin/templates/status.html
@@ -67,7 +67,7 @@
                         if (type == "sort") { return data; }
                         var dateToShow = moment.utc(data * 1000);
                         if (dateToShow.isValid() && data != null && data != undefined) {
-                            return toHHMMSS(Math.abs(dateToShow.diff(moment.utc()) / 1000));
+                            return toHHMMSS_mark(Math.abs(dateToShow.diff(moment.utc()) / 1000));
                         }
                         return "None";
                     }


### PR DESCRIPTION
Columns with timestamps are now correctly sortable.

Moved ajax call to DataTable functions rather than some extra stuff we got there.

There is optional ✔️in Last Update column, set at the bottom of page, stored in Local Storage (so per browser) - this is just for people who just want to take a quick glance at status and see if it's working.
Fully optional, so if you don't put anything there it won't ever show up.
![image](https://user-images.githubusercontent.com/1145742/73996137-174d1280-495b-11ea-9914-6505564bcbe0.png)
