### PR TITLE
Quest fixes

### DIFF
--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -209,6 +209,7 @@ class MITMBase(WorkerBase):
                 logger.warning("Could not find any trashcan on a valid screen"
                     "shot {} time(s) in a row!", self._clear_quests_failcount)
             else:
+                self._clear_quests_failcount = 0
                 logger.error("Unable to clear quests 3 times in a row. Restart "
                         "pogo ...")
                 if not self._restart_pogo(mitm_mapper=self._mitm_mapper):

--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -45,6 +45,7 @@ class MITMBase(WorkerBase):
         self._encounter_ids = {}
         self._current_sleep_time = 0
         self._db_wrapper.save_idle_status(dev_id, False)
+        self._clear_quests_failcount = 0
         self._mitm_mapper.collect_location_stats(self._origin, self.current_location, 1, time.time(), 2, 0,
                                                  self._mapping_manager.routemanager_get_mode(
                                                      self._routemanager_name),
@@ -105,6 +106,7 @@ class MITMBase(WorkerBase):
                                                      position_type, time.time(),
                                                      self._mapping_manager.routemanager_get_mode(
                                                          self._routemanager_name), self._transporttype)
+
         else:
             # TODO: timeout also happens if there is no useful data such as mons nearby in mon_mitm mode, we need to
             # TODO: be more precise (timeout vs empty data)
@@ -201,12 +203,27 @@ class MITMBase(WorkerBase):
         if trashcancheck is None:
             logger.error('Could not find any trashcan - abort')
             return
-        logger.info("Found {} trashcan(s) on screen", len(trashcancheck))
+        if len(trashcancheck) == 0:
+            self._clear_quests_failcount += 1
+            if self._clear_quests_failcount < 3:
+                logger.warning("Could not find any trashcan on a valid screen"
+                    "shot {} time(s) in a row!", self._clear_quests_failcount)
+            else:
+                logger.error("Unable to clear quests 3 times in a row. Restart "
+                        "pogo ...")
+                if not self._restart_pogo(mitm_mapper=self._mitm_mapper):
+                    # TODO: put in loop, count up for a reboot ;)
+                    raise InternalStopWorkerException
+                return
+        else:
+            logger.info("Found {} trashcan(s) on screen", len(trashcancheck))
         # get confirm box coords
         x, y = self._resocalc.get_confirm_delete_quest_coords(self)[0], \
                self._resocalc.get_confirm_delete_quest_coords(self)[1]
 
         for trash in range(len(trashcancheck)):
+            self._clear_quests_failcount = 0
+            self.set_devicesettings_value('last_questclear_time', time.time())
             logger.info("Delete old quest {}", int(trash) + 1)
             self._communicator.click(int(trashcancheck[0].x), int(trashcancheck[0].y))
             time.sleep(1 + int(delayadd))

--- a/mapadroid/worker/WorkerQuests.py
+++ b/mapadroid/worker/WorkerQuests.py
@@ -528,6 +528,7 @@ class WorkerQuests(MITMBase):
                     for text in not_allow:
                         if self.similar(text, item_text) > 0.6:
                             match_one_item = True
+                            break
                     if match_one_item:
                         logger.info('Could not delete this item - check next one')
                         trash += 1

--- a/mapadroid/worker/WorkerQuests.py
+++ b/mapadroid/worker/WorkerQuests.py
@@ -650,9 +650,7 @@ class WorkerQuests(MITMBase):
                 fort_type: int = fort.get("type", 0)
                 if fort_type == 0:
                     self._db_wrapper.delete_stop(latitude, longitude)
-                    # TODO: if you know what fort_type 0 means, please edit
-                    # this logline accordingly :)
-                    logger.warning("Can't spin the stop because of fort_type 0")
+                    logger.warning("Tried to open a stop but found a gym instead!")
                     return False, True
 
                 rocket_incident_diff_ms = 0

--- a/mapadroid/worker/WorkerQuests.py
+++ b/mapadroid/worker/WorkerQuests.py
@@ -526,7 +526,7 @@ class WorkerQuests(MITMBase):
                     logger.info("Found item {}", str(item_text))
                     match_one_item: bool = False
                     for text in not_allow:
-                        if self.similar(text, item_text) > 0.5:
+                        if self.similar(text, item_text) > 0.6:
                             match_one_item = True
                     if match_one_item:
                         logger.info('Could not delete this item - check next one')


### PR DESCRIPTION
Update 2020-02-17:

Completely reworked and tested this. Should now handle the following, as described in the commit notes:

* fix #746: restart PoGo if clear tasks constantly fail
* fix #749: handle all WebsocketWorker* exceptions
* TODO: less magic numbers
* a little more logging for more info
* detect full quest log (FortSearchResultTypes.FULL)
* avoid softban deadlock by closing the stop after every spin attempt
* fix stops being silently skipped, handle timedelta issue better
* add GMO / 106 handling to _wait_data_worker (needed for spinnable check)

The goal is to increase efficiency and consistency of the quest scan mode by fixing a couple of issues and improving the overall working logic here and there.

Over a weekend of testing, I achieved more consistent scanning which translates into more quests being scanned in a given time frame.