### PR TITLE
Implement configurable stop highlighting

### DIFF
--- a/static/madmin/templates/map.html
+++ b/static/madmin/templates/map.html
@@ -52,6 +52,17 @@ var setlng = {{ setlng }};
               </div>
             </li>
             {% endraw %}
+            <li class="list-group-item layer-item d-flex">
+              <div class="flex-grow-1">Highlight</div>
+              <div class="form-group">
+                {% raw %}
+                <select class="form-control form-control-sm" v-model="settings.workerHighlight">
+                  <option :value="undefined">None (highlight quests)</option>
+                  <option v-for="worker in workers" v-bind:value="worker.name">Worker {{ worker.name }}</option>
+                </select>
+                {% endraw %}
+              </div>
+            </li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
* Implement highlighting of stops already visited by a worker. Previous mode (highlighting stops by quest) is used as default.
* Update stops already shown on map when new data is fetched. Already fetched stops were skipped prior this change, so a full reload had to be done to get new info.