### PR TITLE
Cause a timeout if data received is too far away from intended scan location

### DIFF
--- a/mapadroid/route/RouteManagerBase.py
+++ b/mapadroid/route/RouteManagerBase.py
@@ -135,6 +135,9 @@ class RouteManagerBase(ABC):
         else:
             return None
 
+    def get_max_radius(self):
+        return self._max_radius
+
     def _start_check_routepools(self):
         self._check_routepools_thread = Thread(name="_check_routepools_" + self.name,
                                                target=self._check_routepools)

--- a/mapadroid/utils/MappingManager.py
+++ b/mapadroid/utils/MappingManager.py
@@ -291,6 +291,10 @@ class MappingManager:
         routemanager = self.__fetch_routemanager(routemanager_name)
         return routemanager.get_position_type(worker_name) if routemanager is not None else None
 
+    def routemanager_get_max_radius(self, routemanager_name: str):
+        routemanager = self.__fetch_routemanager(routemanager_name)
+        return routemanager.get_max_radius() if routemanager is not None else None
+
     def routemanager_recalcualte(self, routemanager_name):
         successful = False
         try:

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -28,6 +28,7 @@ from mapadroid.utils.routeutil import check_walker_value_type
 from mapadroid.websocket.AbstractCommunicator import AbstractCommunicator
 from mapadroid.worker.AbstractWorker import AbstractWorker
 from mapadroid.utils.geo import get_distance_of_two_points_in_meters
+from mapadroid.utils.s2Helper import S2Helper
 
 
 class WorkerBase(AbstractWorker):
@@ -1205,11 +1206,24 @@ class WorkerBase(AbstractWorker):
         else:
             data_to_check = "forts"
         lat_sum, lng_sum, counter = 0, 0, 0
-        for cell in data:
-            for element in cell[data_to_check]:
-                counter += 1
-                lat_sum += element["latitude"]
-                lng_sum += element["longitude"]
+
+        if data_to_check == "forts":
+            for cell in data:
+                if cell[data_to_check]:
+                    cell_id = cell["id"]
+                    if cell_id < 0:
+                        cell_id = cell_id + 2 ** 64
+                    lat, lng, alt = S2Helper.get_position_from_cell(cell_id)
+                    counter += 1
+                    lat_sum += lat
+                    lng_sum += lng
+        else:
+            for cell in data:
+                for element in cell[data_to_check]:
+                    counter += 1
+                    lat_sum += element["latitude"]
+                    lng_sum += element["longitude"]
+
         if counter == 0:
             return None
         avg_lat = lat_sum / counter

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -1196,6 +1196,9 @@ class WorkerBase(AbstractWorker):
             self, self._screen_x, self._screen_y, x_offset, y_offset)
 
     def _check_data_distance(self, data):
+        max_radius = self._mapping_manager.routemanager_get_max_radius(self._routemanager_name)
+        if not max_radius:
+            return True
         mode = self._mapping_manager.routemanager_get_mode(self._routemanager_name)
         if mode in ["mon_mitm", "iv_mitm"]:
             data_to_check = "wild_pokemon"
@@ -1215,10 +1218,7 @@ class WorkerBase(AbstractWorker):
                                                         float(avg_lng),
                                                         float(self.current_location.lat),
                                                         float(self.current_location.lng))
-        max_radius = self._mapping_manager.routemanager_get_max_radius(self._routemanager_name)
-        if not max_radius:
-            return True
-        elif distance > max_radius:
+        if distance > max_radius:
             logger.debug2("Data is too far away!! avg location {}, {} from "
                 "data with self.current_location location {}, {} - that's a "
                 "{}m distance with max_radius {} for mode {}", avg_lat, avg_lng,

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -1216,7 +1216,9 @@ class WorkerBase(AbstractWorker):
                                                         float(self.current_location.lat),
                                                         float(self.current_location.lng))
         max_radius = self._mapping_manager.routemanager_get_max_radius(self._routemanager_name)
-        if distance > max_radius:
+        if not max_radius:
+            return True
+        elif distance > max_radius:
             logger.debug2("Data is too far away!! avg location {}, {} from "
                 "data with self.current_location location {}, {} - that's a "
                 "{}m distance with max_radius {} for mode {}", avg_lat, avg_lng,

--- a/mapadroid/worker/WorkerMITM.py
+++ b/mapadroid/worker/WorkerMITM.py
@@ -233,18 +233,20 @@ class WorkerMITM(MITMBase):
                     for data_extract in latest_data['payload']['cells']:
                         for WP in data_extract['wild_pokemon']:
                             # TODO: teach Prio Q / Clusterer to hold additional data such as mon/encounter IDs
-                            if WP['spawnpoint_id']:
+                            if WP['spawnpoint_id'] and self._check_data_distance(latest_data['payload']['cells']):
                                 data_requested = latest_data
                                 break
+                        if data_requested == latest_data: break
                     if data_requested is None or data_requested == LatestReceivedType.UNDEFINED:
                         logger.debug("No spawnpoints in data requested")
                         time.sleep(1)
                 elif mode in ["raids_mitm"]:
                     for data_extract in latest_data['payload']['cells']:
                         for forts in data_extract['forts']:
-                            if forts['id']:
+                            if forts['id'] and self._check_data_distance(latest_data['payload']['cells']):
                                 data_requested = latest_data
                                 break
+                        if data_requested == latest_data: break
                     if data_requested is None:
                         logger.debug("No forts in data received")
                         time.sleep(0.5)


### PR DESCRIPTION
... Thus a device will eventually restart pogo if it seems to be permanently stuck at a location. There have been reports from multiple users, me among them, of this happening.
MAD can't currently handle it because pogo doesn't freeze, so PogoDroid is still able to transmit related data, but from a wrong location.
Testing shows that a pogo restart seems to be enough to fix this.