### PR TITLE
Resolution of #762

### DIFF
--- a/mapadroid/db/DbPogoProtoSubmit.py
+++ b/mapadroid/db/DbPogoProtoSubmit.py
@@ -93,7 +93,7 @@ class DbPogoProtoSubmit:
         Update/Insert a mon with IVs
         """
         wild_pokemon = encounter_proto.get("wild_pokemon", None)
-        if wild_pokemon is None or wild_pokemon.get("encounter_id", 0) == 0:
+        if wild_pokemon is None or wild_pokemon.get("encounter_id", 0) == 0 or not str(wild_pokemon["spawnpoint_id"]):
             return
 
         logger.debug("Updating IV sent by {} for encounter at {}".format(str(origin), str(timestamp)))


### PR DESCRIPTION
#762 reports that the assigning of `spawnid` on line 103 throws an error when `str(wild_pokemon["spawnpoint_id"])` returns an empty string, because you cannot cast an empty string to a base 16 integer. This adds checking for that problem in the existing if condition that would return before the assignment of `spawnid` ever occurs.

I'm not a Python programmer so please let me know if my syntax can be improved for future commits. Hope this helps. Cheers!