### PR TITLE
Performance optimizations on trs_spawn & weather

### DIFF
--- a/mapadroid/patcher/__init__.py
+++ b/mapadroid/patcher/__init__.py
@@ -28,6 +28,7 @@ MAD_UPDATES = OrderedDict([
     (24, 'patch_24'),
     (25, 'patch_25'),
     (26, 'patch_26'),
+    (27, 'patch_27'),
 ])
 
 

--- a/mapadroid/patcher/patch_27.py
+++ b/mapadroid/patcher/patch_27.py
@@ -1,0 +1,33 @@
+from ._patch_base import PatchBase
+
+
+class Patch(PatchBase):
+    name = 'Patch 27 - trs_spawn performance improvement'
+
+    def _execute(self):
+        # Previous versions of this table have an unneeded second index on the spawnpoint field
+        sql = "ALTER TABLE `trs_spawn` "\
+              "DROP KEY `spawnpoint`, "\
+              "DROP KEY `spawnpoint_2`, "\
+              "ADD PRIMARY KEY (`spawnpoint`)"
+        try:
+            self._db.execute(sql, commit=True, suppress_log=True)
+        except Exception:
+            self._logger.warning("Can't drop and re-create trs_spawn.spawnpoint primary key")
+
+        # trs_spawn.spawnpoint has a different type than pokemon.spawnpoint_id. This
+        # spoils the join performance.
+        sql = "ALTER TABLE `trs_spawn` "\
+              "CHANGE `spawnpoint` `spawnpoint` bigint(20) unsigned NOT NULL"
+        try:
+            self._db.execute(sql, commit=True, suppress_log=True)
+        except Exception:
+            pass
+
+        # This index will improve performance on route calculations and map queries
+        sql = "ALTER TABLE `trs_spawn` "\
+              "ADD KEY `event_lat_long` (`eventid`, `latitude`, `longitude`)"
+        try:
+            self._db.execute(sql, commit=True, suppress_log=True)
+        except Exception:
+            self._logger.warning("Can't add additional indices")

--- a/mapadroid/patcher/patch_27.py
+++ b/mapadroid/patcher/patch_27.py
@@ -2,7 +2,7 @@ from ._patch_base import PatchBase
 
 
 class Patch(PatchBase):
-    name = 'Patch 27 - trs_spawn performance improvement'
+    name = 'Patch 27 - trs_spawn & weather table performance improvement'
 
     def _execute(self):
         # Previous versions of this table have an unneeded second index on the spawnpoint field
@@ -31,3 +31,20 @@ class Patch(PatchBase):
             self._db.execute(sql, commit=True, suppress_log=True)
         except Exception:
             self._logger.warning("Can't add additional indices")
+
+        # There are unneeded indexes on the weather table
+        sql = "ALTER TABLE `weather` "\
+              "DROP INDEX `weather_cloud_level`, "\
+              "DROP INDEX `weather_rain_level`, "\
+              "DROP INDEX `weather_wind_level`, "\
+              "DROP INDEX `weather_snow_level`, "\
+              "DROP INDEX `weather_fog_level`, "\
+              "DROP INDEX `weather_wind_direction`, "\
+              "DROP INDEX `weather_gameplay_weather`, "\
+              "DROP INDEX `weather_severity`, "\
+              "DROP INDEX `weather_warn_weather`, "\
+              "DROP INDEX `weather_world_time`"
+        try:
+            self._db.execute(sql, commit=True, suppress_log=True)
+        except Exception:
+            self._logger.warning("Can't drop unneeded indices on the weather table")

--- a/scripts/SQL/rocketmap.sql
+++ b/scripts/SQL/rocketmap.sql
@@ -569,7 +569,7 @@ CREATE TABLE `trs_s2cells` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `trs_spawn` (
-    `spawnpoint` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,
+    `spawnpoint` bigint(20) unsigned NOT NULL,
     `latitude` double NOT NULL,
     `longitude` double NOT NULL,
     `spawndef` int(11) NOT NULL DEFAULT '240',
@@ -579,8 +579,8 @@ CREATE TABLE `trs_spawn` (
     `last_non_scanned` datetime DEFAULT NULL,
     `calc_endminsec` varchar(5) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
     `eventid` int NOT NULL DEFAULT 1,
-    UNIQUE KEY `spawnpoint_2` (`spawnpoint`),
-    KEY `spawnpoint` (`spawnpoint`)
+    PRIMARY KEY (`spawnpoint`),
+    KEY `event_lat_long` (`eventid`, latitude`, `longitude`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `trs_spawnsightings` (

--- a/scripts/SQL/rocketmap.sql
+++ b/scripts/SQL/rocketmap.sql
@@ -719,16 +719,6 @@ CREATE TABLE `weather` (
     `world_time` smallint(6) DEFAULT NULL,
     `last_updated` datetime DEFAULT NULL,
     PRIMARY KEY (`s2_cell_id`),
-    KEY `weather_cloud_level` (`cloud_level`),
-    KEY `weather_rain_level` (`rain_level`),
-    KEY `weather_wind_level` (`wind_level`),
-    KEY `weather_snow_level` (`snow_level`),
-    KEY `weather_fog_level` (`fog_level`),
-    KEY `weather_wind_direction` (`wind_direction`),
-    KEY `weather_gameplay_weather` (`gameplay_weather`),
-    KEY `weather_severity` (`severity`),
-    KEY `weather_warn_weather` (`warn_weather`),
-    KEY `weather_world_time` (`world_time`),
     KEY `weather_last_updated` (`last_updated`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 


### PR DESCRIPTION
3 optimizations on `trs_spawn`:

* The two keys on `spawnpoint` are dropped and replaced with a single primary key.
* The column type of `spawnpoint` is aligned with `pokemon.spawnpoint_id` to increase join performance.
* Two additional keys are added to speed up some route and map related queries.

Changing a column type might affect 3rd party software, though it's not very likely. Rocketmap/Rocketmad seems to deal fine with those changes.