### PR TITLE
Prevent rare loop with ScreenType.ERROR/FAILURE

### DIFF
--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -609,7 +609,7 @@ class WorkerBase(AbstractWorker):
             if screen_type in [ScreenType.GAMEDATA, ScreenType.CONSENT, ScreenType.CLOSE]:
                 logger.warning('Error getting Gamedata or strange ggl message appears')
                 self._loginerrorcounter += 1
-                if self._loginerrorcounter < 3:
+                if self._loginerrorcounter < 2:
                     self._restart_pogo(True)
             elif screen_type == ScreenType.DISABLED:
                 # Screendetection is disabled

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -637,13 +637,14 @@ class WorkerBase(AbstractWorker):
                 self._reboot()
                 break
 
-            if self._loginerrorcounter == 2:
+            if self._loginerrorcounter > 1:
                 logger.error('Could not login again - (clearing game data + restarting device')
                 self._stop_pogo()
                 self._communicator.clear_app_cache("com.nianticlabs.pokemongo")
                 if self.get_devicesettings_value('clear_game_data', False):
                     logger.info('Clearing game data')
                     self._communicator.reset_app_data("com.nianticlabs.pokemongo")
+                self._loginerrorcounter = 0
                 self._reboot()
                 break
 


### PR DESCRIPTION
Had a device endlessly loop with ScreenType.ERROR/ScreenType.FAILURE,
logging only: `[ WARNING] Something wrong with screendetection or pogo failure screen`.

It has to be assumed that `self._loginerrorcounter` somehow was incremented over 2, thus MAD was
unable to enter the appropriate routine because it only checked `self._loginerrorcounter == 2`.
I changed this to check `self._loginerrorcounter > 1` and to reset the loginerrorcounter to 0 once the routine ran to prevent this rare condition.