### PR TITLE
Fix 774: Handle corrupted update_log.json file

### DIFF
--- a/mapadroid/utils/updater.py
+++ b/mapadroid/utils/updater.py
@@ -53,9 +53,14 @@ class deviceUpdater(object):
         self._current_job_id = []
         self._current_job_device = []
         self._returning = returning
-        if os.path.exists('update_log.json'):
-            with open('update_log.json') as logfile:
-                self._log = json.load(logfile)
+        try:
+            if os.path.exists('update_log.json'):
+                with open('update_log.json') as logfile:
+                    self._log = json.load(logfile)
+        except json.decoder.JSONDecodeError:
+            logger.error('Corrupted update_log.json file found. Deleting the '
+            'file. Please check remaining disk space or disk health.')
+            os.remove('update_log.json')
 
         self.init_jobs()
         self.kill_old_jobs()


### PR DESCRIPTION
fixes #774. 
In analogy to mitm_receiver/PlayerStats.py, the JSON exception will be handled by deleting the file and showing an error message. https://github.com/Map-A-Droid/MAD/blob/0ceaa68a01dd85b8bf778ae91327c504d824b3c6/mapadroid/mitm_receiver/PlayerStats.py#L82-L84

Confirmed working by manually creating a `update_log.json` file containing invalid json.