### PR TITLE
Display spawn point first detection correctly.

### DIFF
--- a/mapadroid/db/DbWrapper.py
+++ b/mapadroid/db/DbWrapper.py
@@ -931,7 +931,7 @@ class DbWrapper:
                 'spawndef': spawndef,
                 'lastscan': str(last_scanned),
                 'lastnonscan': str(last_non_scanned),
-                'first_detection': str(first_detection),
+                'first_detection': int(first_detection.timestamp()),
                 'event': eventname,
                 'eventid': eventid
             }

--- a/static/madmin/static/js/madmin.js
+++ b/static/madmin/static/js/madmin.js
@@ -1384,7 +1384,7 @@ new Vue({
          </div>
          <br>
           <div cla ss="spawnContent">
-            <div class="spawnFirstDetection"><i class="fas fa-baby"></i> First seen: <strong>${spawn["first_detection"]}</strong></div>
+            <div class="spawnFirstDetection"><i class="fas fa-baby"></i> First seen: <strong>${moment(spawn["first_detection"] * 1000).format("YYYY-MM-DD HH:mm:ss")}</strong></div>
             <div class="timestamp"><i class="fas fa-eye"></i> <abbr title="This is the time a mon has been seen on this spawnpoint.">Last mon seen</abbr>: <strong>${lastMon}</strong></div>
             <div class="timestamp"><i class="fa fa-clock"></i> <abbr title="The timestamp of the last time this spawnpoint's despawn time has been confirmed.">Last confirmation</abbr>: <strong>${spawn["lastscan"]}</strong></div>
             <div class="spawnType"><i class="fa fa-wrench"></i> Type: <strong>${type || "Unknown despawn time"}</strong></div>


### PR DESCRIPTION
`first_detection` is UTC, but MADmin showed it as if it's local time.