### PR TITLE
PD APKs

### DIFF
--- a/mapadroid/mitm_receiver/MITMReceiver.py
+++ b/mapadroid/mitm_receiver/MITMReceiver.py
@@ -241,8 +241,9 @@ class MITMReceiver(Process):
             if 'filename' in apks:
                 versions = apks['version']
             else:
-                for apk_type, apk_info in apks.items():
-                    version[str(apk_type)] = apk_info['version']
+                return Response(status=404, response='Version not specified or invalid')
+        elif status_code == 404:
+            return Response(status=404, response='APK has not been downloaded')
         else:
-            return Response(status=404)
+            return Response(status=404, response='Please specify APK and Architecture')
         return versions

--- a/mapadroid/mitm_receiver/MITMReceiver.py
+++ b/mapadroid/mitm_receiver/MITMReceiver.py
@@ -13,6 +13,8 @@ from mapadroid.utils import MappingManager
 from mapadroid.utils.authHelper import check_auth
 from mapadroid.utils.logging import LogLevelChanger, logger
 from mapadroid.utils.apk_util import download_file, convert_to_backend, get_apk_list
+from threading import RLock
+import mapadroid.utils.data_manager
 
 app = Flask(__name__)
 
@@ -37,6 +39,14 @@ class EndpointAction(object):
                 abort = True
             else:
                 abort = False
+        elif request.url is not None and str(request.url_rule) == '/origin_generator':
+            auth = request.headers.get('Authorization', None)
+            if auth is None or not check_auth(auth, self.application_args,
+                                              self.mapping_manager.get_auths()):
+                logger.warning(
+                    "Unauthorized attempt to POST from {}", str(request.remote_addr))
+                self.response = Response(status=403, headers={})
+                abort = True
         else:
             if not origin:
                 logger.warning("Missing Origin header in request")
@@ -80,13 +90,15 @@ class EndpointAction(object):
 
 class MITMReceiver(Process):
     def __init__(self, listen_ip, listen_port, mitm_mapper, args_passed, mapping_manager: MappingManager,
-                 db_wrapper, name=None):
+                 db_wrapper, data_manager, name=None):
         Process.__init__(self, name=name)
         self.__application_args = args_passed
         self.__mapping_manager = mapping_manager
         self.__listen_ip = listen_ip
         self.__listen_port = listen_port
         self.__mitm_mapper: MitmMapper = mitm_mapper
+        self.__data_manager = data_manager
+        self.__hopper_mutex = RLock()
         self.app = Flask("MITMReceiver")
         self.add_endpoint(endpoint='/', endpoint_name='receive_protos', handler=self.proto_endpoint,
                           methods_passed=['POST'])
@@ -113,6 +125,10 @@ class MITMReceiver(Process):
         self.add_endpoint(endpoint='/mad_apk/<string:apk_type>/download',
                           endpoint_name='mad_apk/arch/download',
                           handler=self.mad_apk_download,
+                          methods_passed=['GET'])
+        self.add_endpoint(endpoint='/origin_generator',
+                          endpoint_name='origin_generator/',
+                          handler=self.origin_generator,
                           methods_passed=['GET'])
 
         self._data_queue: JoinableQueue = JoinableQueue()
@@ -248,9 +264,57 @@ class MITMReceiver(Process):
             if 'filename' in apks:
                 versions = apks['version']
             else:
-                return Response(status=404, response='Version not specified or invalid')
+                return Response(status=400, response='Version not specified or invalid')
         elif status_code == 404:
-            return Response(status=404, response='APK has not been downloaded')
+            return Response(status=400, response='APK has not been downloaded')
         else:
-            return Response(status=404, response='Please specify APK and Architecture')
+            return Response(status=400, response='Please specify APK and Architecture')
         return versions
+
+    def origin_generator(self, *args, **kwargs):
+        origin = request.headers.get('OriginBase', None)
+        walker_id = request.headers.get('walker', None)
+        pool_id = request.headers.get('pool', None)
+        device = mapadroid.data_manager.modules.MAPPINGS['device'](self.__data_manager)
+        if origin is None:
+            return Response(status=400, response='Please specify an Origin Prefix')
+        with self.__hopper_mutex:
+            last_id_sql = "SELECT `last_id` FROM `origin_hopper` WHERE `origin` = %s"
+            last_id = self._db_wrapper.autofetch_value(last_id_sql, (origin,))
+            if last_id is None:
+                last_id = 0
+            walkers = self.__data_manager.get_root_resource('walker')
+            if len(walkers) == 0:
+                    return Response(status=400, response='No walkers configured')
+            if walker_id is not None:
+                try:
+                    walker_id = int(walker_id)
+                    walkers[walker_id]
+                except KeyError:
+                    return Response(404, response='Walker ID not found')
+                except ValueError:
+                    return Response(status=404, response='Walker must be an integer')
+            else:
+                walker_id = next(iter(walkers))
+            device['walker'] = walker_id
+            if pool_id is not None:
+                pools = self.__data_manager.get_root_resource('devicepool')
+                try:
+                    pool_id = int(pool_id)
+                    pools[pool_id]
+                except KeyError:
+                    return Response(404, response='Walker ID not found')
+                except ValueError:
+                    return Response(status=404, response='Walker must be an integer')
+                device['pool'] = pool_id
+            next_id = last_id + 1
+            data = {
+                'origin': origin,
+                'last_id': next_id,
+            }
+            origin = '%s%s' % (origin, next_id,)
+            self._db_wrapper.autoexec_insert('origin_hopper', data, optype="ON DUPLICATE")
+            device['walker'] = walker_id
+            device['origin'] = origin
+            device.save()
+            return origin

--- a/mapadroid/mitm_receiver/MITMReceiver.py
+++ b/mapadroid/mitm_receiver/MITMReceiver.py
@@ -243,4 +243,6 @@ class MITMReceiver(Process):
             else:
                 for apk_type, apk_info in apks.items():
                     version[str(apk_type)] = apk_info['version']
+        else:
+            return Response(status=404)
         return versions

--- a/mapadroid/mitm_receiver/MITMReceiver.py
+++ b/mapadroid/mitm_receiver/MITMReceiver.py
@@ -14,7 +14,7 @@ from mapadroid.utils.authHelper import check_auth
 from mapadroid.utils.logging import LogLevelChanger, logger
 from mapadroid.utils.apk_util import download_file, convert_to_backend, get_apk_list
 from threading import RLock
-import mapadroid.utils.data_manager
+import mapadroid.data_manager
 
 app = Flask(__name__)
 

--- a/mapadroid/patcher/__init__.py
+++ b/mapadroid/patcher/__init__.py
@@ -29,6 +29,7 @@ MAD_UPDATES = OrderedDict([
     (25, 'patch_25'),
     (26, 'patch_26'),
     (27, 'patch_27'),
+    (28, 'patch_28'),
 ])
 
 

--- a/mapadroid/patcher/patch_28.py
+++ b/mapadroid/patcher/patch_28.py
@@ -1,0 +1,20 @@
+from ._patch_base import PatchBase
+
+
+class Patch(PatchBase):
+    name = 'Origin Hopper'
+    descr = 'Allows a device with the correct authentication to generate a new origin record'
+
+    def _execute(self):
+        origin_sql = """
+            CREATE TABLE `origin_hopper` (
+                `origin` VARCHAR(128) NOT NULL,
+                `last_id` int UNSIGNED NOT NULL,
+                PRIMARY KEY (`origin`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        """
+        try:
+            self._db.execute(origin_sql, commit=True, raise_exec=True)
+        except Exception as e:
+            self._logger.exception("Unexpected error: {}", e)
+            self.issues = True

--- a/start.py
+++ b/start.py
@@ -219,7 +219,8 @@ if __name__ == "__main__":
         pogoWindowManager = PogoWindows(args.temp_path, args.ocr_thread_count)
 
         mitm_receiver_process = MITMReceiver(args.mitmreceiver_ip, int(args.mitmreceiver_port),
-                                             mitm_mapper, args, mapping_manager, db_wrapper)
+                                             mitm_mapper, args, mapping_manager, db_wrapper,
+                                             data_manager)
         mitm_receiver_process.start()
 
         logger.info('Starting websocket server on port {}'.format(str(args.ws_port)))


### PR DESCRIPTION
Allow PogoDroid and MAD API to serve APKs.  Allow for quick-configuration via Origin Hopper when mass deploying new devices.