### PR TITLE
Handle KO error from RGC correctly, properly handle login failure on PTC

### DIFF
--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -248,8 +248,7 @@ class WordToScreenMatching(object):
         elif screentype == ScreenType.PTC:
             return self.__handle_ptc_login()
         elif screentype == ScreenType.FAILURE:
-            self.__handle_returning_player_or_wrong_credentials()
-            screentype = ScreenType.ERROR
+            screentype = self.__handle_failure_screen(diff, global_dict)
         elif screentype == ScreenType.RETRY:
             self.__handle_retry_screen(diff, global_dict)
         elif screentype == ScreenType.WRONG:
@@ -405,6 +404,20 @@ class WordToScreenMatching(object):
         logger.info("Sleeping 50 seconds - please wait!")
         time.sleep(50)
         return ScreenType.PTC
+
+    def __handle_failure_screen(self, diff, global_dict) -> None:
+        if self._logintype == LoginType.ptc:
+            click_text = 'DIFFERENT,AUTRE,AUTORISER,ANDERES,KONTO,ACCOUNT,VERSUCHEN'
+            n_boxes = len(global_dict['level'])
+            for i in range(n_boxes):
+                if any(elem.lower() in (global_dict['text'][i].lower()) for elem in click_text.split(",")):
+                    self._click_center_button(diff, global_dict, i)
+            time.sleep(5)
+            screentype = ScreenType.FAILURE
+        else:
+            self.__handle_returning_player_or_wrong_credentials()
+            screentype = ScreenType.ERROR
+        return screentype
 
     def __handle_returning_player_or_wrong_credentials(self) -> None:
         self._nextscreen = ScreenType.UNDEFINED

--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -402,7 +402,7 @@ class WordToScreenMatching(object):
         time.sleep(50)
         return ScreenType.PTC
 
-    def __handle_failure_screen(self, diff, global_dict) -> None:
+    def __handle_failure_screen(self, diff, global_dict) -> ScreenType:
         if self._logintype == LoginType.ptc:
             click_text = 'DIFFERENT,AUTRE,AUTORISER,ANDERES,KONTO,ACCOUNT,VERSUCHEN'
             n_boxes = len(global_dict['level'])

--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -129,10 +129,7 @@ class WordToScreenMatching(object):
         returntype: ScreenType = ScreenType.UNDEFINED
         global_dict: dict = {}
         diff = 1
-        if "KO: Could not read topmost app. Is screen off?" in topmost_app:
-            logger.error("RGC could not read topmost app. Is screen off?")
-            return ScreenType.ERROR, global_dict, diff
-        elif "AccountPickerActivity" in topmost_app or 'SignInActivity' in topmost_app:
+        if "AccountPickerActivity" in topmost_app or 'SignInActivity' in topmost_app:
             return ScreenType.GGL, global_dict, diff
         elif "GrantPermissionsActivity" in topmost_app:
             return ScreenType.PERMISSION, global_dict, diff

--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -129,7 +129,10 @@ class WordToScreenMatching(object):
         returntype: ScreenType = ScreenType.UNDEFINED
         global_dict: dict = {}
         diff = 1
-        if "AccountPickerActivity" in topmost_app or 'SignInActivity' in topmost_app:
+        if "KO: Could not read topmost app. Is screen off?" in topmost_app:
+            logger.error("RGC could not read topmost app. Is screen off?")
+            return ScreenType.ERROR, global_dict, diff
+        elif "AccountPickerActivity" in topmost_app or 'SignInActivity' in topmost_app:
             return ScreenType.GGL, global_dict, diff
         elif "GrantPermissionsActivity" in topmost_app:
             return ScreenType.PERMISSION, global_dict, diff

--- a/mapadroid/websocket/communicator.py
+++ b/mapadroid/websocket/communicator.py
@@ -171,7 +171,7 @@ class Communicator(AbstractCommunicator):
 
     def topmost_app(self) -> Optional[MessageTyping]:
         topmost = self.__run_get_gesponse("more topmost app\r\n")
-        if "KO:" in topmost:
+        if topmost and "KO:" in topmost:
             return None
         return topmost
 

--- a/mapadroid/websocket/communicator.py
+++ b/mapadroid/websocket/communicator.py
@@ -170,7 +170,10 @@ class Communicator(AbstractCommunicator):
         return "com.nianticlabs.pokemongo" in topmost
 
     def topmost_app(self) -> Optional[MessageTyping]:
-        return self.__run_get_gesponse("more topmost app\r\n")
+        topmost = self.__run_get_gesponse("more topmost app\r\n")
+        if "KO:" in topmost:
+            return None
+        return topmost
 
     def set_location(self, location: Location, altitude: float) -> Optional[MessageTyping]:
         return self.__run_get_gesponse("geo fix {} {} {}\r\n".format(location.lat, location.lng, altitude))


### PR DESCRIPTION
1) Identify the KO error from RGC as screentype.ERROR instead of getting wrongly caught as screentype.CLOSE in ``` elif "com.nianticlabs.pokemongo" not in topmost_app:```

2) fix #485 - on PTC the text below the green button on the failure screen needs to be clicked to be able to log in again. Independently found this issue and implemented the same fix @cecpk proposed in #485 .

I tested these for a couple of days, but cleaned them up today for the PR, so one or two tests or a couple more days in my setup would be good to 100% confirm them working.