### PR TITLE
Silently ignore loading errors for few times in /status

### DIFF
--- a/static/madmin/templates/status.html
+++ b/static/madmin/templates/status.html
@@ -12,10 +12,23 @@
 </style>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.min.js"></script>
 <script>
+    var errorCount = 0;
     var dataTable = $("#show-data-status").DataTable({
             "ajax": {
                 "url": "get_status",
-                "dataSrc": ""
+                "dataSrc": function (data) {
+                        errorCount = 0;
+                        return data;
+                },
+                "error": function (xhr, error, code) {
+                        errorCount++;
+                        console.log(xhr);
+                        console.log(error);
+                        console.log(code);
+                        if (errorCount == 5) {
+                                alert("Could not get updates from MAD five times in a row. More logs in browser developer console. Is MAD running?");
+                        }
+                }
             },
             "columns": [
                 {


### PR DESCRIPTION
If we fail to get update 5 times in a row show alert with "Check browser console".
Could be anything - MAD restarting and request failing, connection issue, crappy 3G, anything.