### PR TITLE
Add RGC APK to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# Files and directories not required in a docker build
+APK/RemoteGpsController.apk


### PR DESCRIPTION
Adds a `.dockerignore` file including the RGC APK which is part of the repository but not being used during build. 

This reduces the size of docker context during the build process, and it prevents that the APK eventually ends up in the final docker image.