### PR TITLE
Integrate routefree levelmode in current master

### DIFF
--- a/mapadroid/data_manager/modules/area_pokestops.py
+++ b/mapadroid/data_manager/modules/area_pokestops.py
@@ -70,7 +70,7 @@ class AreaPokestops(Area):
             "route_calc_algorithm": {
                 "settings": {
                     "type": "option",
-                    "values": ['optimized', 'quick'],
+                    "values": ['optimized', 'quick', 'routefree'],
                     "require": False,
                     "description": "Method of calculation for routes. (Default optimized)",
                     "expected": str

--- a/mapadroid/geofence/geofenceHelper.py
+++ b/mapadroid/geofence/geofenceHelper.py
@@ -187,3 +187,15 @@ class GeofenceHelper:
             lat1, lon1 = lat2, lon2
 
         return inside
+
+    def get_middle_from_fence(self):
+        maxLat, minLat, maxLon, minLon = -90, 90, -180, 180
+        if self.geofenced_areas:
+            for va in self.geofenced_areas:
+                for fence in va['polygon']:
+                    maxLat = max(fence['lat'], maxLat)
+                    minLat = min(fence['lat'], minLat)
+                    maxLon = max(fence['lon'], maxLon)
+                    minLon = min(fence['lon'], minLon)
+
+        return minLat + ((maxLat - minLat) / 2), minLon + ((maxLon - minLon) / 2)

--- a/mapadroid/patcher/__init__.py
+++ b/mapadroid/patcher/__init__.py
@@ -30,6 +30,7 @@ MAD_UPDATES = OrderedDict([
     (26, 'patch_26'),
     (27, 'patch_27'),
     (28, 'patch_28'),
+    (29, 'patch_29'),
 ])
 
 

--- a/mapadroid/patcher/patch_29.py
+++ b/mapadroid/patcher/patch_29.py
@@ -7,7 +7,7 @@ class Patch(PatchBase):
 
     def _execute(self):
         origin_sql = """
-            ALTER TABLE `aibling`.`settings_area_pokestops` 
+            ALTER TABLE `settings_area_pokestops` 
             CHANGE COLUMN `route_calc_algorithm` 
             `route_calc_algorithm` ENUM('optimized', 'quick', 'routefree') 
             CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_unicode_ci' NULL DEFAULT NULL ;

--- a/mapadroid/patcher/patch_29.py
+++ b/mapadroid/patcher/patch_29.py
@@ -1,0 +1,19 @@
+from ._patch_base import PatchBase
+
+
+class Patch(PatchBase):
+    name = 'Routefree algo for quest/level mode'
+    descr = 'Adds routefree algo mode'
+
+    def _execute(self):
+        origin_sql = """
+            ALTER TABLE `aibling`.`settings_area_pokestops` 
+            CHANGE COLUMN `route_calc_algorithm` 
+            `route_calc_algorithm` ENUM('optimized', 'quick', 'routefree') 
+            CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_unicode_ci' NULL DEFAULT NULL ;
+        """
+        try:
+            self._db.execute(origin_sql, commit=True, raise_exec=True)
+        except Exception as e:
+            self._logger.exception("Unexpected error: {}", e)
+            self.issues = True

--- a/mapadroid/route/RouteManagerBase.py
+++ b/mapadroid/route/RouteManagerBase.py
@@ -82,6 +82,7 @@ class RouteManagerBase(ABC):
         self._routepool: Dict[str, RoutePoolEntry] = {}
         self._roundcount: int = 0
         self._joinqueue = joinqueue
+        self._worker_start_position: Dict[str] = {}
 
         # we want to store the workers using the routemanager
         self._workers_registered: List[str] = []
@@ -578,6 +579,8 @@ class RouteManagerBase(ABC):
                 logger.debug("No subroute/routepool entry of {} present, creating it", origin)
                 self._routepool[origin] = RoutePoolEntry(time.time(), collections.deque(), [],
                                                          time_added=time.time())
+                if origin in self._worker_start_position:
+                    self._routepool[origin].current_pos = self._worker_start_position[origin]
                 if not self.worker_changed_update_routepools():
                     logger.info("Failed updating routepools after adding a worker to it")
                     return None
@@ -1142,3 +1145,10 @@ class RouteManagerBase(ABC):
 
         logger.debug('Open Coords from workers: {}'.format(str(coordlist)))
         return coordlist
+
+    def set_worker_startposition(self, worker, lat, lon):
+        logger.info("Getting startposition for walker {} ({} / {}".format(str(worker), str(lat), str(lon)))
+        if worker not in self._worker_start_position:
+            self._worker_start_position[worker] = Location(0.0, 0.0)
+
+        self._worker_start_position[worker] = Location(lat, lon)

--- a/mapadroid/route/RouteManagerBase.py
+++ b/mapadroid/route/RouteManagerBase.py
@@ -1123,6 +1123,9 @@ class RouteManagerBase(ABC):
     def get_level_mode(self):
         return self._level
 
+    def get_calc_type(self):
+        return self._calctype
+
     def redo_stop(self, worker, lat, lon):
         logger.info('Worker {} redo a unprocessed Stop ({}, {})'.format(str(worker), str(lat), str(lon)))
         if worker in self._routepool:

--- a/mapadroid/route/RouteManagerFactory.py
+++ b/mapadroid/route/RouteManagerFactory.py
@@ -3,6 +3,7 @@ from typing import Optional
 from mapadroid.route.RouteManagerMon import RouteManagerMon
 from mapadroid.route.RouteManagerIV import RouteManagerIV
 from mapadroid.route.RouteManagerLeveling import RouteManagerLeveling
+from mapadroid.route.RouteManagerLevelingRoutefree import RouteManagerLevelingRoutefree
 from mapadroid.route.RouteManagerQuests import RouteManagerQuests
 from mapadroid.route.RouteManagerRaids import RouteManagerRaids
 from mapadroid.worker.WorkerType import WorkerType
@@ -49,7 +50,7 @@ class RouteManagerFactory:
                                               joinqueue=joinqueue
                                               )
         elif mode == WorkerType.STOPS.value:
-            if level:
+            if level and calctype in ('optimized', 'quick'):
                 route_manager = RouteManagerLeveling(db_wrapper, dbm, area_id, coords, max_radius,
                                                      max_coords_within_radius,
                                                      path_to_include_geofence, path_to_exclude_geofence,
@@ -58,6 +59,15 @@ class RouteManagerFactory:
                                                      level=True,
                                                      calctype=calctype, joinqueue=joinqueue
                                                      )
+            elif level and calctype == 'routefree':
+                route_manager = RouteManagerLevelingRoutefree(db_wrapper, dbm, area_id, coords, max_radius,
+                                                              max_coords_within_radius,
+                                                              path_to_include_geofence, path_to_exclude_geofence,
+                                                              routefile,
+                                                              mode=mode, settings=settings, init=init, name=name,
+                                                              level=True,
+                                                              calctype=calctype, joinqueue=joinqueue
+                                                              )
             else:
                 route_manager = RouteManagerQuests(db_wrapper, dbm, area_id, coords, max_radius,
                                                    max_coords_within_radius,

--- a/mapadroid/route/RouteManagerLevelingRoutefree.py
+++ b/mapadroid/route/RouteManagerLevelingRoutefree.py
@@ -1,0 +1,192 @@
+import time
+from typing import List
+
+import numpy as np
+
+from mapadroid.db.DbWrapper import DbWrapper
+from mapadroid.route.RouteManagerBase import RoutePoolEntry
+from mapadroid.route.RouteManagerQuests import RouteManagerQuests
+from mapadroid.utils.collections import Location
+from mapadroid.utils.logging import logger
+
+
+class RouteManagerLevelingRoutefree(RouteManagerQuests):
+    def __init__(self, db_wrapper: DbWrapper, dbm, area_id, coords: List[Location], max_radius: float,
+                 max_coords_within_radius: int, path_to_include_geofence: str, path_to_exclude_geofence: str,
+                 routefile: str, mode=None, init: bool = False, name: str = "unknown", settings: dict = None,
+                 level: bool = False, calctype: str = "quick", joinqueue=None):
+        RouteManagerQuests.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id, coords=coords,
+                                    max_radius=max_radius, max_coords_within_radius=max_coords_within_radius,
+                                    path_to_include_geofence=path_to_include_geofence,
+                                    path_to_exclude_geofence=path_to_exclude_geofence,
+                                    routefile=routefile, init=init,
+                                    name=name, settings=settings, mode=mode, level=level, calctype=calctype,
+                                    joinqueue=joinqueue
+                                    )
+
+    def worker_changed_update_routepools(self):
+        with self._manager_mutex and self._workers_registered_mutex:
+            logger.info("Updating all routepools in levelmode for {} origins", len(self._routepool))
+            if len(self._workers_registered) == 0:
+                logger.info("No registered workers, aborting __worker_changed_update_routepools...")
+                return False
+
+            any_at_all = False
+            for origin in self._routepool:
+                origin_local_list = []
+                entry: RoutePoolEntry = self._routepool[origin]
+
+                if len(entry.queue) > 0:
+                    logger.debug("origin {} already has a queue, do not touch...", origin)
+                    continue
+                current_worker_pos = entry.current_pos
+                unvisited_stops = self.db_wrapper.get_nearest_stops_from_position(geofence_helper=self.geofence_helper,
+                                                                                  origin=origin,
+                                                                                  lat=current_worker_pos.lat,
+                                                                                  lon=current_worker_pos.lng,
+                                                                                  limit=30,
+                                                                                  ignore_spinned=self.settings.get("ignore_spinned_stops", True),
+                                                                                  maxdistance=5)
+                if len(unvisited_stops) == 0:
+                    logger.info("There are no unvisited stops left in DB for {} - nothing more to do!",
+                                origin)
+                    continue
+
+                for coord in unvisited_stops:
+                    coord_location = Location(coord.lat, coord.lng)
+                    if coord_location in self._coords_to_be_ignored:
+                        logger.info('Already tried this Stop but it failed spinnable test, skip it')
+                        continue
+                    origin_local_list.append(coord_location)
+
+                if len(unvisited_stops) > 0:
+                    logger.info("Recalc a route")
+                    new_route = self._local_recalc_subroute(unvisited_stops)
+                    origin_local_list.clear()
+                    for coord in new_route:
+                        origin_local_list.append(Location(coord["lat"], coord["lng"]))
+
+                # subroute is all stops unvisited
+                logger.info("Origin {} has {} unvisited stops for this route", origin, len(origin_local_list))
+                entry.subroute = origin_local_list
+                # let's clean the queue just to make sure
+                entry.queue.clear()
+                [entry.queue.append(i) for i in origin_local_list]
+                any_at_all = len(origin_local_list) > 0 or any_at_all
+                # saving new startposition of walker in db
+                newstartposition: Location = entry.queue[0]
+                self.db_wrapper.save_last_walker_position(origin=origin,
+                                                          lat=newstartposition.lat,
+                                                          lng=newstartposition.lng)
+            return True
+
+    def _local_recalc_subroute(self, unvisited_stops):
+        to_be_route = np.zeros(shape=(len(unvisited_stops), 2))
+        for i in range(len(unvisited_stops)):
+            to_be_route[i][0] = float(unvisited_stops[i].lat)
+            to_be_route[i][1] = float(unvisited_stops[i].lng)
+        new_route = self.calculate_new_route(to_be_route, self._max_radius, self._max_coords_within_radius,
+                                             False, 1,
+                                             True)
+
+        return new_route
+
+    def _retrieve_latest_priority_queue(self):
+        return None
+
+    def _get_coords_post_init(self):
+        return self.db_wrapper.stops_from_db(self.geofence_helper)
+
+    def _cluster_priority_queue_criteria(self):
+        pass
+
+    def _priority_queue_update_interval(self):
+        return 0
+
+    def _recalc_route_workertype(self):
+        self.recalc_route(self._max_radius, self._max_coords_within_radius, 1, delete_old_route=False,
+                          in_memory=True)
+        self._init_route_queue()
+
+    def _get_coords_after_finish_route(self) -> bool:
+        self._manager_mutex.acquire()
+        try:
+
+            if self._shutdown_route:
+                logger.info('Other worker shutdown route {} - leaving it', str(self.name))
+                return False
+
+            self.worker_changed_update_routepools()
+            self._start_calc = False
+            return True
+        finally:
+            self._manager_mutex.release()
+
+    def _check_unprocessed_stops(self):
+        self._manager_mutex.acquire()
+
+        try:
+            # We finish routes on a per walker/origin level, so the route itself is always the same as long as at
+            # least one origin is connected to it.
+            return self._stoplist
+        finally:
+            self._manager_mutex.release()
+
+    def _start_routemanager(self):
+        self._manager_mutex.acquire()
+        try:
+            if not self._is_started:
+                self._is_started = True
+                logger.info("Starting routemanager {}", str(self.name))
+
+                if self._shutdown_route:
+                    logger.info('Other worker shutdown route {} - leaving it', str(self.name))
+                    return False
+
+                self._prio_queue = None
+                self.delay_after_timestamp_prio = None
+                self.starve_route = False
+                self._first_round_finished = False
+                self._start_check_routepools()
+
+                return True
+
+        finally:
+            self._manager_mutex.release()
+
+        return True
+
+    def _recalc_stop_route(self, stops):
+        self._clear_coords()
+        self.add_coords_list(stops)
+        self._overwrite_calculation = True
+        self._recalc_route_workertype()
+        self._init_route_queue()
+
+    def _delete_coord_after_fetch(self) -> bool:
+        return False
+
+    def _quit_route(self):
+        logger.info('Shutdown Route {}', str(self.name))
+        if self._is_started:
+            self._is_started = False
+            self._round_started_time = None
+            if self.init: self._first_started = False
+            self._shutdown_route = False
+
+        # clear not processed stops
+        self._stops_not_processed.clear()
+        self._coords_to_be_ignored.clear()
+        self._stoplist.clear()
+
+    def _check_coords_before_returning(self, lat, lng, origin):
+        if self.init:
+            logger.debug('Init Mode - coord is valid')
+            return True
+        stop = Location(lat, lng)
+        logger.info('Checking Stop with ID {}', str(stop))
+        if stop in self._coords_to_be_ignored:
+            logger.info('Already tried this Stop and failed it')
+            return False
+        logger.info('DB knows nothing of this stop for {} lets try and go there', origin)
+        return True

--- a/mapadroid/route/RouteManagerLevelingRoutefree.py
+++ b/mapadroid/route/RouteManagerLevelingRoutefree.py
@@ -24,7 +24,7 @@ class RouteManagerLevelingRoutefree(RouteManagerQuests):
                                     joinqueue=joinqueue
                                     )
 
-    def worker_changed_update_routepools(self):
+    def _worker_changed_update_routepools(self):
         with self._manager_mutex and self._workers_registered_mutex:
             logger.info("Updating all routepools in levelmode for {} origins", len(self._routepool))
             if len(self._workers_registered) == 0:
@@ -116,7 +116,7 @@ class RouteManagerLevelingRoutefree(RouteManagerQuests):
                 logger.info('Other worker shutdown route {} - leaving it', str(self.name))
                 return False
 
-            self.worker_changed_update_routepools()
+            self._worker_changed_update_routepools()
             self._start_calc = False
             return True
         finally:

--- a/mapadroid/utils/MappingManager.py
+++ b/mapadroid/utils/MappingManager.py
@@ -254,6 +254,10 @@ class MappingManager:
         routemanager = self.__fetch_routemanager(routemanager_name)
         return routemanager.get_level_mode() if routemanager is not None else None
 
+    def routemanager_get_calc_type(self, routemanager_name: str) -> bool:
+        routemanager = self.__fetch_routemanager(routemanager_name)
+        return routemanager.get_calc_type() if routemanager is not None else None
+
     def routemanager_get_mode(self, routemanager_name: str) -> WorkerType:
         routemanager = self.__fetch_routemanager(routemanager_name)
         return routemanager.get_mode() if routemanager is not None else WorkerType.UNDEFINED.value
@@ -286,6 +290,11 @@ class MappingManager:
                                          sleep_duration: float):
         routemanager = self.__fetch_routemanager(routemanager_name)
         routemanager.set_worker_sleeping(worker_name, sleep_duration)
+
+    def set_worker_startposition(self, routemanager_name: str, worker_name: str,
+                                 lat: float, lon: float):
+        routemanager = self.__fetch_routemanager(routemanager_name)
+        routemanager.set_worker_startposition(worker_name, lat, lon)
 
     def routemanager_get_position_type(self, routemanager_name: str, worker_name: str) -> Optional[str]:
         routemanager = self.__fetch_routemanager(routemanager_name)
@@ -415,8 +424,8 @@ class MappingManager:
                                                                  include_event_id=
                                                                  area.get("settings", {}).get("include_event_id", None)
                                                                  )
-
-            if mode not in ("iv_mitm", "idle"):
+            logger.info("Initializing area {}", area["name"])
+            if mode not in ("iv_mitm", "idle") and area.get("route_calc_algorithm", "optimized") not in "routefree":
                 coords = self.__fetch_coords(mode, geofence_helper,
                                              coords_spawns_known=area.get("coords_spawns_known", False),
                                              init=area.get("init", False),
@@ -429,7 +438,7 @@ class MappingManager:
                 max_radius = mode_mapping[area_true.area_type]["range"]
                 max_count_in_radius = mode_mapping[area_true.area_type]["max_count"]
                 if not area.get("init", False):
-                    logger.info("Initializing area {}", area["name"])
+
                     proc = thread_pool.apply_async(route_manager.initial_calculation,
                                                    args=(max_radius, max_count_in_radius,
                                                          0, False))

--- a/mapadroid/worker/WorkerQuests.py
+++ b/mapadroid/worker/WorkerQuests.py
@@ -120,6 +120,9 @@ class WorkerQuests(MITMBase):
 
         if self._level_mode:
             logger.info("Starting Level Mode")
+            if self._mapping_manager.routemanager_get_calc_type == "routefree":
+                logger.info("Sleeping one minute for getting data")
+                time.sleep(60)
         else:
             # initial cleanup old quests
             if not self._init:
@@ -445,6 +448,7 @@ class WorkerQuests(MITMBase):
         stop_inventory_clear = Event()
         stop_screen_clear = Event()
         logger.info('Cleanup Box')
+        self._mapping_manager.routemanager_set_worker_sleeping(self._routemanager_name, self._origin, 300)
         not_allow = ('Gift', 'Geschenk', 'Glücksei', 'Glucks-Ei', 'Glücks-Ei', 'Lucky Egg', 'CEuf Chance',
                      'Cadeau', 'Appareil photo', 'Wunderbox', 'Mystery Box', 'Boîte Mystère', 'Premium',
                      'Raid', 'Teil',

--- a/scripts/SQL/rocketmap.sql
+++ b/scripts/SQL/rocketmap.sql
@@ -282,7 +282,7 @@ CREATE TABLE `settings_area_pokestops` (
     `routecalc` int(10) unsigned NOT NULL,
     `init` tinyint(1) NOT NULL,
     `level` tinyint(1) DEFAULT NULL,
-    `route_calc_algorithm` enum('optimized','quick') COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+    `route_calc_algorithm` enum('optimized','quick', 'routefree') COLLATE utf8mb4_unicode_ci DEFAULT NULL,
     `speed` float DEFAULT NULL,
     `max_distance` float DEFAULT NULL,
     `ignore_spinned_stops` tinyint(1) DEFAULT NULL,


### PR DESCRIPTION
Routefree Levelmode using near stops from db instand of generate a fix route.

**Usage**
Create big fence (Paris / Tokyo)
Create Area Pokestop with level:true
Setting Device Start position within this fence (Devicesettings) <-- not longer needed. MAD sets middle of fence as startposition
Let the magic beginn. 

**Activate routefree mode**
Create normal quest area with level = true and select route_calc_algorithm = routefree

<img width="475" alt="Bildschirmfoto 2020-04-23 um 22 37 55" src="https://user-images.githubusercontent.com/36961143/80151063-b6c48d80-85b9-11ea-99a8-b3982693cf98.png">
