### PR TITLE
cleanup of get_raid_boss_cp

### DIFF
--- a/mapadroid/webhook/webhookworker.py
+++ b/mapadroid/webhook/webhookworker.py
@@ -7,7 +7,7 @@ import requests
 from mapadroid.db.DbWebhookReader import DbWebhookReader
 from mapadroid.geofence.geofenceHelper import GeofenceHelper
 from mapadroid.utils import MappingManager
-from mapadroid.utils.gamemechanicutil import calculate_mon_level, get_raid_boss_cp
+from mapadroid.utils.gamemechanicutil import calculate_mon_level
 from mapadroid.utils.logging import logger
 from mapadroid.utils.madGlobals import terminate_mad
 from mapadroid.utils.questGen import generate_quest
@@ -332,9 +332,6 @@ class WebhookWorker:
 
             if raid["move_2"] is not None:
                 raid_payload["move_2"] = raid["move_2"]
-
-            if raid["cp"] is None:
-                raid_payload["cp"] = get_raid_boss_cp(raid["pokemon_id"])
 
             if raid["pokemon_id"] is None:
                 raid_payload["pokemon_id"] = 0


### PR DESCRIPTION
raid_payload already have cp in default payload, it's set to 0 in DbPogoProtoSubmit (or value if boss hatched already).

Seems totally useless here.

EDIT: We should be happy that this never worked, the `get_raid_boss_cp` does not return CP, it returns a dictionary :D