### PR TITLE
Screendetection improvements

### DIFF
--- a/mapadroid/ocr/pogoWindows.py
+++ b/mapadroid/ocr/pogoWindows.py
@@ -55,7 +55,7 @@ class PogoWindows:
         self._ScreenType[17]: list = ['Suspension', 'suspended', 'violating', 'days', ]
         self._ScreenType[18]: list = ['Termination', 'terminated', 'permanently']
         self._ScreenType[21]: list = ['GPS', 'signal', 'GPS-Signal', '(11)', 'introuvable.',
-                                      'found.', 'gefunden.', 'Signal']
+                                      'found.', 'gefunden.', 'Signal', 'geortet', 'detect', '(12)']
 
     def __most_present_colour(self, filename, max_colours) -> Optional[List[int]]:
         if filename is None or max_colours is None:
@@ -911,7 +911,8 @@ class PogoWindows:
                             break
                         if len(globaldict['text'][i]) > 3:
                             for z in self._ScreenType:
-                                if globaldict['top'][i] > height / 4 and globaldict['text'][i] in \
+                                heightlimit = 0 if z == 21 else height / 4
+                                if globaldict['top'][i] > heightlimit and globaldict['text'][i] in \
                                         self._ScreenType[z]:
                                     returntype = ScreenType(z)
                     if returntype != ScreenType.UNDEFINED:

--- a/mapadroid/ocr/pogoWindows.py
+++ b/mapadroid/ocr/pogoWindows.py
@@ -33,7 +33,7 @@ class PogoWindows:
         self._ScreenType: dict = {}
         self._ScreenType[1]: list = ['Geburtdatum', 'birth.', 'naissance.', 'date']
         self._ScreenType[2]: list = ['ZURUCKKEHRENDER', 'ZURÜCKKEHRENDER', 'GAME', 'FREAK', 'SPIELER']
-        self._ScreenType[3]: list = ['KIDS', 'Google', 'Facebook']
+        self._ScreenType[3]: list = ['Google', 'Facebook']
         self._ScreenType[4]: list = ['Benutzername', 'Passwort', 'Username', 'Password', 'DRESSEURS']
         self._ScreenType[5]: list = ['TRY', 'DIFFERENT', 'ACCOUNT', 'Anmeldung', 'Konto', 'anderes',
                                      'connexion.', 'connexion']
@@ -56,6 +56,7 @@ class PogoWindows:
         self._ScreenType[18]: list = ['Termination', 'terminated', 'permanently']
         self._ScreenType[21]: list = ['GPS', 'signal', 'GPS-Signal', '(11)', 'introuvable.',
                                       'found.', 'gefunden.', 'Signal', 'geortet', 'detect', '(12)']
+        self._ScreenType[23]: list = ['CLUB', 'KIDS']
 
     def __most_present_colour(self, filename, max_colours) -> Optional[List[int]]:
         if filename is None or max_colours is None:

--- a/mapadroid/ocr/pogoWindows.py
+++ b/mapadroid/ocr/pogoWindows.py
@@ -892,8 +892,11 @@ class PogoWindows:
                     frame_org = frame_org.resize([int(2 * s) for s in frame_org.size], Image.ANTIALIAS)
                     diff: int = 2
 
-                frame = frame_org.convert('LA')
-                texts = [frame, frame_org]
+                texts = [frame_org]
+                for thresh in [200, 175, 150]:
+                    fn = lambda x : 255 if x > thresh else 0
+                    frame = frame_org.convert('L').point(fn, mode='1')
+                    texts.append(frame)
                 for text in texts:
                     try:
                         globaldict = pytesseract.image_to_data(text, output_type=Output.DICT, timeout=40,

--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -268,6 +268,8 @@ class WordToScreenMatching(object):
             self._nextscreen = ScreenType.UNDEFINED
         elif screentype == ScreenType.UPDATE:
             self._nextscreen = ScreenType.UNDEFINED
+        elif screentype == ScreenType.NOGGL:
+            self._nextscreen = ScreenType.UNDEFINED
         elif screentype == ScreenType.STRIKE:
             self.__handle_strike_screen(diff, global_dict)
         elif screentype == ScreenType.SUSPENDED:

--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -138,6 +138,7 @@ class WordToScreenMatching(object):
         elif "ConsentActivity" in topmost_app:
             return ScreenType.CONSENT, global_dict, diff
         elif "com.nianticlabs.pokemongo" not in topmost_app:
+            logger.warning("PoGo ist not opened! Current topmost app: {}", topmost_app)
             return ScreenType.CLOSE, global_dict, diff
         elif self._nextscreen != ScreenType.UNDEFINED:
             # TODO: how can the nextscreen be known in the current? o.O
@@ -429,6 +430,7 @@ class WordToScreenMatching(object):
     def detect_screentype(self) -> ScreenType:
         topmostapp = self._communicator.topmost_app()
         if not topmostapp:
+            logger.warning("Failed getting the topmost app!")
             return ScreenType.ERROR
 
         screentype, global_dict, diff = self.__evaluate_topmost_app(topmost_app=topmostapp)

--- a/mapadroid/ocr/screen_type.py
+++ b/mapadroid/ocr/screen_type.py
@@ -23,6 +23,7 @@ class ScreenType(Enum):
     QUEST = 20  # research menu / quest listing (pogo)
     GPS = 21  # GPS signal not found error message (pogo)
     CREDENTIALS = 22  # new GrantCredentials dialog
+    NOGGL = 23 # loginselect, but without the google button (probably failed to set a correct birthdate)
     POGO = 99  # uhm, whatever... At least pogo is topmost, no idea where we are yet tho (in the process of switching)
     ERROR = 100  # some issue occurred while handling screentypes or not able to determine screen
     BLACK = 110  # screen is black, likely loading up game

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -673,6 +673,10 @@ class WorkerBase(AbstractWorker):
             elif screen_type in [ScreenType.ERROR, ScreenType.FAILURE]:
                 logger.warning('Something wrong with screendetection or pogo failure screen')
                 self._loginerrorcounter += 1
+            elif screen_type == ScreenType.NOGGL:
+                logger.warning('Detected login select screen missing the Google'
+                    ' button - likely entered an invalid birthdate previously')
+                self._loginerrorcounter += 1
             elif screen_type == ScreenType.GPS:
                 logger.error("Detected GPS error - reboot device")
                 self._reboot()

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -661,8 +661,11 @@ class WorkerBase(AbstractWorker):
             if screen_type == ScreenType.BLACK:
                 logger.info("Found Black Loading Screen - waiting ...")
                 time.sleep(20)
-
-            if screen_type in [ScreenType.GAMEDATA, ScreenType.CONSENT, ScreenType.CLOSE]:
+            elif screen_type == ScreenType.CLOSE:
+                logger.warning("screendetection found pogo closed, start it...")
+                self._start_pogo()
+                self._loginerrorcounter += 1
+            elif screen_type in [ScreenType.GAMEDATA, ScreenType.CONSENT]:
                 logger.warning('Error getting Gamedata or strange ggl message appears')
                 self._loginerrorcounter += 1
                 if self._loginerrorcounter < 2:

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -640,14 +640,19 @@ class WorkerBase(AbstractWorker):
                 self._last_screen_type = screen_type
                 logger.debug2("Found pogo or questlog to be open")
                 break
-            elif screen_type != ScreenType.ERROR and self._last_screen_type == screen_type:
-                logger.info("Found screen multiple times in a row")
-                if self._same_screen_count < 3:
-                    self._same_screen_count += 1
-                else:
-                    logger.warning('Game froze - restarting device')
-                    self._reboot()
+
+            if screen_type != ScreenType.ERROR and self._last_screen_type == screen_type:
+                self._same_screen_count += 1
+                logger.warning("Found {} multiple times in a row ({})",
+                        screen_type, self._same_screen_count)
+                if self._same_screen_count > 3:
+                    logger.warning("Screen is frozen!")
+                    if self._same_screen_count > 4 or not self._restart_pogo():
+                        logger.error("Restarting PoGo failed - reboot device")
+                        self._reboot()
                     break
+            elif self._last_screen_type != screen_type:
+                self._same_screen_count = 0
 
             # now handle all screens that may not have been handled by detect_screentype since that only clicks around
             # so any clearing data whatsoever happens here (for now)

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -638,6 +638,7 @@ class WorkerBase(AbstractWorker):
             screen_type: ScreenType = self._WordToScreenMatching.detect_screentype()
             if screen_type in [ScreenType.POGO, ScreenType.QUEST]:
                 self._last_screen_type = screen_type
+                self._loginerrorcounter = 0
                 logger.debug2("Found pogo or questlog to be open")
                 break
 
@@ -658,7 +659,7 @@ class WorkerBase(AbstractWorker):
             # so any clearing data whatsoever happens here (for now)
             if screen_type == ScreenType.UNDEFINED:
                 logger.error("Undefined screentype!")
-            if screen_type == ScreenType.BLACK:
+            elif screen_type == ScreenType.BLACK:
                 logger.info("Found Black Loading Screen - waiting ...")
                 time.sleep(20)
             elif screen_type == ScreenType.CLOSE:

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -674,8 +674,9 @@ class WorkerBase(AbstractWorker):
                 logger.warning('Something wrong with screendetection or pogo failure screen')
                 self._loginerrorcounter += 1
             elif screen_type == ScreenType.GPS:
-                logger.warning("Detected GPS error 11 - rebooting device")
+                logger.error("Detected GPS error - reboot device")
                 self._reboot()
+                break
             elif screen_type == ScreenType.SN:
                 logger.warning('Getting SN Screen - restart PoGo and later PD')
                 self._restart_pogo_safe()


### PR DESCRIPTION
Propsing a few improvements to screendetection and related procedures. I tried to split the independent changes into separate commits so they could be used individually by the maintainers if they see it fit. I'll cite my commit notes as a summary here:

1. Detect GPS errors again
Due to false positives from heads up notifications, we ignored the upper
25% of the screen. Thus we also ignored red GPS errors in the game.
With this change, the upper 25% won't be ignored exclusively when checking
against the strings indicating GPS errors. This avoids the known false
positives from PogoDroid notifications while still being able to act on the
errors.
A slim chance for false positives remains, which could be handled by
disabling heads up notifications. They should be unnecessary on scanner
devices anyway.

2. Handle login screen after entering an invalid birthdate
when due to some sort of glitch a invalid birthdate is intered during
the login procedures (too young), we end up on a screen only showing PTC
and KIDS login buttons. It was wrongly identified as screentype.POGO which
resulted in an infinite loop. This commit properly identifies and
handles that situation.

3. Use binarized pictures with different thresholds
On some screens, the new screentype.NOGGL being my test subject, the
text on some buttons couldn't be read by tesseract. By preprocessing the
screenshots, namely binarizing them with different thresholds, we can
improve results for text on different backgrounds.

4. Try a PoGo restart before rebooting due to a frozen screen
As reboots are a potential cause for issues on ATV boxes and cause
additional wait time, it should be attempted to restart PoGo before
rebooting when the screen/game seems to be frozen.

5. Try to start PoGo when we find it closed
Should be self-explaining

6. minor screentype handling logic improvements
Reset a counter at the appropriate place + replace `if` with `elif`