### PR TITLE
Dropdown filter for Spawnpoint Statistics

### DIFF
--- a/mapadroid/madmin/routes/statistics.py
+++ b/mapadroid/madmin/routes/statistics.py
@@ -522,7 +522,12 @@ class statistics(object):
     @auth_required
     @logger.catch()
     def get_spawnpoints_stats(self):
-
+        
+        geofence_type = request.args.get('type', 'mon_mitm')
+        if geofence_type not in ['idle', 'iv_mitm', 'mon_mitm', 'pokestops', 'raids_mitm']:
+            stats = {'spawnpoints': []}
+            return jsonify(stats)
+        
         coords = []
         known = {}
         unknown = {}
@@ -531,7 +536,7 @@ class statistics(object):
         eventidhelper = {}
 
 
-        possible_fences = get_geofences(self._mapping_manager, self._data_manager)
+        possible_fences = get_geofences(self._mapping_manager, self._data_manager, fence_type=geofence_type)
         for possible_fence in possible_fences:
             mode = possible_fences[possible_fence]['mode']
             area_id = possible_fences[possible_fence]['area_id']

--- a/static/madmin/templates/statistics/spawn_statistics.html
+++ b/static/madmin/templates/statistics/spawn_statistics.html
@@ -305,7 +305,7 @@
 {% endblock %}
 
 {% block content %}
-<h2>Spawnpoint Statistics(for <select name="geofence_type_selector" id="geofence_type_selector">
+<h2>Spawnpoint Stats (for <select name="geofence_type_selector" id="geofence_type_selector">
     <option value="mon_mitm" selected="selected">Mons [mon_mitm]</option>
     <option value="iv_mitm">IVs [iv_mitm]</option>
     <option value="pokestops">Quests [pokestops]</option>

--- a/static/madmin/templates/statistics/spawn_statistics.html
+++ b/static/madmin/templates/statistics/spawn_statistics.html
@@ -74,17 +74,17 @@
 	}
 
 	function loadData() {
-	    $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif').lstrip('/') }}" width="100px" /><br /><h2>Load...</h2>' });
-        $('body').Aplus();
-        $("#navgyms").addClass("active");
-        $.ajax({
-            type: "GET",
-            url: "get_spawnpoints_stats",
-            success: function (result) {
-                setTimeout($.unblockUI, 100);
-                setGrid('#show-spawnpoints-stats', result.spawnpoints);
-            }
-        });
+	    $.blockUI({ message: '<img src="{{ url_for('static', filename='loading.gif').lstrip('/') }}" width="100px" /><br /><h2>Loading...</h2>' });
+            $('body').Aplus();
+            $("#navgyms").addClass("active");
+            $.ajax({
+                type: "GET",
+                url: "get_spawnpoints_stats" + "?type=" + $("#geofence_type_selector").val(),
+                success: function (result) {
+                    setTimeout($.unblockUI, 100);
+                    setGrid('#show-spawnpoints-stats', result.spawnpoints);
+                }
+            });
 	}
 
 
@@ -93,6 +93,10 @@
 
     $(document).ready(function () {
         loadData();
+        $("#geofence_type_selector").change(function() {
+            $("#show-spawnpoints-stats").DataTable().destroy();
+            loadData();
+        });
     });
 
 
@@ -301,7 +305,14 @@
 {% endblock %}
 
 {% block content %}
-<h2>Spawnpoint Statistics</h2>
+<h2>Spawnpoint Statistics(for <select name="geofence_type_selector" id="geofence_type_selector">
+    <option value="mon_mitm" selected="selected">Mons [mon_mitm]</option>
+    <option value="iv_mitm">IVs [iv_mitm]</option>
+    <option value="pokestops">Quests [pokestops]</option>
+    <option value="raids_mitm">Raids [raids_mitm]</option>
+    <option value="idle">Idle [idle]</option>
+</select>
+)</h2>
 <div class="dropdown">
   <button type="button" class="btn btn-secondary dropdown-toggle float-right btn-sm" data-toggle="dropdown">Legend</button>
   <ul class="dropdown-menu dropdown-menu-right">


### PR DESCRIPTION
Loading mon_mitm by default, if you need anything else then just select from dropdown and wait again.

With a lot of areas and a lot of events this thing can takes aaaaaaaaaages to load. This way we can at least restrict it to one type of "geofence" and make it faster, a little.