### PR TITLE
Fix for issue 756

### DIFF
--- a/mapadroid/patcher/__init__.py
+++ b/mapadroid/patcher/__init__.py
@@ -32,6 +32,7 @@ MAD_UPDATES = OrderedDict([
     (28, 'patch_28'),
     (29, 'patch_29'),
     (30, 'patch_30'),
+    (31, 'trs_status_lastProtoDateTime_fix'),
 ])
 
 

--- a/mapadroid/patcher/trs_status_lastProtoDateTime_fix.py
+++ b/mapadroid/patcher/trs_status_lastProtoDateTime_fix.py
@@ -1,0 +1,21 @@
+from ._patch_base import PatchBase
+
+
+class Patch(PatchBase):
+    name = 'Fix trs_status.lastProtoDateTime auto-update'
+
+    def _execute(self):
+        sql = "SELECT `EXTRA`\n"\
+              "FROM `INFORMATION_SCHEMA`.`COLUMNS`\n"\
+              "WHERE TABLE_SCHEMA = %s AND `TABLE_NAME` = 'trs_status'\n"\
+              "AND `COLUMN_NAME` = 'lastProtoDateTime'"
+        try:
+            extra = self._db.autofetch_value(sql, (self._application_args.dbname))
+            if extra:
+                update = "ALTER TABLE `%s`.`trs_status`\n"\
+                         "CHANGE `lastProtoDateTime`\n"\
+                         "lastProtoDateTime TIMESTAMP NULL" % (self._application_args.dbname,)
+                self._db.execute(update, args=(), commit=True, raise_exc=True)
+        except Exception as e:
+            self._logger.exception("Unexpected error: {}", e)
+            self.issues = True


### PR DESCRIPTION
This update to the DB schema checks to see if the column lastProtoDateTime is updates each time the row is updated.  This field should only be updated when specified by the worker