### PR TITLE
Fix SQL statement to use index instead of table scan

### DIFF
--- a/mapadroid/db/DbWrapper.py
+++ b/mapadroid/db/DbWrapper.py
@@ -225,7 +225,7 @@ class DbWrapper:
             "latitude <= %s AND longitude <= %s AND "
             "cp IS NOT NULL AND "
             "disappear_time > UTC_TIMESTAMP() - INTERVAL 1 HOUR AND "
-            "UNIX_TIMESTAMP(last_modified) > %s "
+            "last_modified > FROM_UNIXTIME(%s) "
         )
 
         params = rectangle


### PR DESCRIPTION
Doing any kind of calculation on an indexed column prevents MySQL
from using the index for queries.

So instead of

```
WHERE function(indexedcolumn) = expression
```

doing

```
WHERE indexedcolumn = inversefunction(expression)
```

can improve query performance in order of magnitudes.