### PR TITLE
Improve login type selection

### DIFF
--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -189,41 +189,67 @@ class WordToScreenMatching(object):
             # french ...
             if 'DRESSEURS' in (global_dict['text'][i]):
                 temp_dict['CLUB'] = global_dict['top'][i] / diff
+            if 'Google' in (global_dict['text'][i]):
+                temp_dict['Google'] = global_dict['top'][i] / diff
 
             if self.get_devicesettings_value('logintype', 'google') == 'ptc':
                 self._nextscreen = ScreenType.PTC
                 if 'CLUB' in (global_dict['text'][i]):
                     self._click_center_button(diff, global_dict, i)
                     time.sleep(5)
+                    return
+
+                # alternative select - calculate down from Facebook button
+                elif 'Facebook' in temp_dict:
+                    click_x = self._width / 2
+                    click_y = (temp_dict['Facebook'] + 2 * self._height / 10.11)
+                    logger.debug('Click ' + str(click_x) + ' / ' + str(click_y))
+                    self._communicator.click(click_x, click_y)
+                    time.sleep(5)
+                    return
+
+                # alternative select - calculate down from Google button
+                elif 'Google' in temp_dict:
+                    click_x = self._width / 2
+                    click_y = (temp_dict['Google'] + self._height / 10.11)
+                    logger.debug('Click ' + str(click_x) + ' / ' + str(click_y))
+                    self._communicator.click(click_x, click_y)
+                    time.sleep(5)
+                    return
+
             else:
                 self._nextscreen = ScreenType.UNDEFINED
                 if 'Google' in (global_dict['text'][i]):
                     self._click_center_button(diff, global_dict, i)
                     time.sleep(5)
+                    return
 
                 # alternative select
-                if 'Facebook' in temp_dict and 'TRAINER' in temp_dict:
+                elif 'Facebook' in temp_dict and 'CLUB' in temp_dict:
                     click_x = self._width / 2
-                    click_y = (temp_dict['Facebook'] + ((temp_dict['TRAINER'] - temp_dict['Facebook']) / 2))
+                    click_y = (temp_dict['Facebook'] + ((temp_dict['CLUB'] - temp_dict['Facebook']) / 2))
                     logger.debug('Click ' + str(click_x) + ' / ' + str(click_y))
                     self._communicator.click(click_x, click_y)
                     time.sleep(5)
+                    return
 
                 # alternative select
-                if 'Facebook' in temp_dict:
+                elif 'Facebook' in temp_dict:
                     click_x = self._width / 2
                     click_y = (temp_dict['Facebook'] + self._height / 10.11)
                     logger.debug('Click ' + str(click_x) + ' / ' + str(click_y))
                     self._communicator.click(click_x, click_y)
                     time.sleep(5)
+                    return
 
                 # alternative select
-                if 'CLUB' in temp_dict:
+                elif 'CLUB' in temp_dict:
                     click_x = self._width / 2
                     click_y = (temp_dict['CLUB'] - self._height / 10.11)
                     logger.debug('Click ' + str(click_x) + ' / ' + str(click_y))
                     self._communicator.click(click_x, click_y)
                     time.sleep(5)
+                    return
 
     def _click_center_button(self, diff, global_dict, i) -> None:
         (x, y, w, h) = (global_dict['left'][i], global_dict['top'][i],

--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -319,7 +319,7 @@ class WordToScreenMatching(object):
         elif screentype == ScreenType.BLACK:
             logger.warning("Screen is black, sleeping a couple seconds for another check...")
         elif screentype == ScreenType.CLOSE:
-            logger.warning("Detected pogo not open")
+            logger.debug("Detected pogo not open")
         elif screentype == ScreenType.DISABLED:
             logger.warning("Screendetection disabled")
         elif screentype == ScreenType.ERROR:

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -663,7 +663,7 @@ class WorkerBase(AbstractWorker):
                 logger.info("Found Black Loading Screen - waiting ...")
                 time.sleep(20)
             elif screen_type == ScreenType.CLOSE:
-                logger.warning("screendetection found pogo closed, start it...")
+                logger.debug("screendetection found pogo closed, start it...")
                 self._start_pogo()
                 self._loginerrorcounter += 1
             elif screen_type in [ScreenType.GAMEDATA, ScreenType.CONSENT]:


### PR DESCRIPTION
As discussed with @cecpk -

this will do the following:

1. prevent a (seemingly rare?) loop on `screentype.LOGINSELECT` with PTC login by implementing more ways to find the PTC button - as it is done for the Google button already - by calculating the coordinates from other buttons.

2. significantly reduce the run time of `__handle_login_screen` using `elif` and `break` so the function exits after clicking one button instead of looping through all available boxes

3. using the opportunity to reduce the three warnings to one when pogo is not opened