### PR TITLE
Workaround: Repeatedly click trash during quest deletion

### DIFF
--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -321,6 +321,11 @@ class MITMBase(WorkerBase):
             self._clear_quests_failcount = 0
             self.set_devicesettings_value('last_questclear_time', time.time())
             logger.info("Delete old quest {}", int(trash) + 1)
+            for i in range(3):
+                logger.debug("repeated trash click #{}", i + 1)
+                self._communicator.click(int(trashcancheck[0].x), int(trashcancheck[0].y))
+                time.sleep(0.3 + int(delayadd))
+            logger.debug("final trash click ...")
             self._communicator.click(int(trashcancheck[0].x), int(trashcancheck[0].y))
             time.sleep(2.5 + int(delayadd))
             self._communicator.click(int(x), int(y))


### PR DESCRIPTION
There seems to be a recent issue with clicks on the trash quest icon not
registering. This leads to the procedure not properly emptying the quest
bag, which in turn reduces efficiency of the quest scan mode because
stops will be spun when the quest bag is already completely filled. This
causes the need to re-visit the stop later.

It can be identified by this log line appearing in huge numbers:
`[ WARNING] Failed getting quest but got items - quest box is probably full. Start cleanup.`

This change significantly reduces occurence of the problem (90%+
reduction during my testing) at the cost of some more delay for these clicks.

It's more of a brute-force workaround than a pretty fix though. More
research into the exact problem should yield a more efficient solution.