### PR TITLE
Force fa(s) icons to dark on leaflet popup

### DIFF
--- a/static/madmin/static/style/MAD.css
+++ b/static/madmin/static/style/MAD.css
@@ -191,6 +191,8 @@
     border: 1px solid #bbb !important;
 }
 
+[data-theme="dark"] .leaflet-popup-content i.fas, .leaflet-popup-content i.fa { color: #333 !important; }
+
 .leaflet-draw-toolbar a {
     background-image: url(/static/leaflet.draw.png) !important;
     background-repeat: no-repeat;


### PR DESCRIPTION
Darkmode only, it was white on white, they were gone!

However not sure if mon/gym/spawn popup wasn't black earlier in darkmode and something changed?