### PR TITLE
fix a mix-up of ScreenTypes FAILURE and RETRY

### DIFF
--- a/mapadroid/ocr/pogoWindows.py
+++ b/mapadroid/ocr/pogoWindows.py
@@ -35,10 +35,11 @@ class PogoWindows:
         self._ScreenType[2]: list = ['ZURUCKKEHRENDER', 'ZURÜCKKEHRENDER', 'GAME', 'FREAK', 'SPIELER']
         self._ScreenType[3]: list = ['Google', 'Facebook']
         self._ScreenType[4]: list = ['Benutzername', 'Passwort', 'Username', 'Password', 'DRESSEURS']
-        self._ScreenType[5]: list = ['TRY', 'DIFFERENT', 'ACCOUNT', 'Anmeldung', 'Konto', 'anderes',
-                                     'connexion.', 'connexion']
-        self._ScreenType[6]: list = ['Authentifizierung', 'fehlgeschlagen', 'Unable', 'authenticate',
+        self._ScreenType[5]: list = ['Authentifizierung', 'fehlgeschlagen', 'Unable', 'authenticate',
                                      'Authentification', 'Essaye']
+        self._ScreenType[6]: list = ['RETRY', 'TRY', 'DIFFERENT', 'ACCOUNT', 'Anmeldung',
+                                     'fehlgeschlagen', 'ANDERES', 'KONTO', 'VERSUCHEN',
+                                     'AUTRE', 'AUTORISER']
         self._ScreenType[7]: list = ['incorrect.', 'attempts', 'falsch.', 'gesperrt']
         self._ScreenType[8]: list = ['Spieldaten', 'abgerufen', 'lecture', 'depuis', 'server', 'data']
         self._ScreenType[12]: list = ['Events,', 'Benachrichtigungen', 'Einstellungen', 'events,', 'offers,',

--- a/mapadroid/ocr/pogoWindows.py
+++ b/mapadroid/ocr/pogoWindows.py
@@ -37,8 +37,8 @@ class PogoWindows:
         self._ScreenType[4]: list = ['Benutzername', 'Passwort', 'Username', 'Password', 'DRESSEURS']
         self._ScreenType[5]: list = ['Authentifizierung', 'fehlgeschlagen', 'Unable', 'authenticate',
                                      'Authentification', 'Essaye']
-        self._ScreenType[6]: list = ['RETRY', 'TRY', 'DIFFERENT', 'ACCOUNT', 'Anmeldung',
-                                     'fehlgeschlagen', 'ANDERES', 'KONTO', 'VERSUCHEN',
+        self._ScreenType[6]: list = ['RETRY', 'TRY', 'DIFFERENT', 'ACCOUNT',
+                                     'ANDERES', 'KONTO', 'VERSUCHEN',
                                      'AUTRE', 'AUTORISER']
         self._ScreenType[7]: list = ['incorrect.', 'attempts', 'falsch.', 'gesperrt']
         self._ScreenType[8]: list = ['Spieldaten', 'abgerufen', 'lecture', 'depuis', 'server', 'data']

--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -274,7 +274,7 @@ class WordToScreenMatching(object):
         elif screentype == ScreenType.PTC:
             return self.__handle_ptc_login()
         elif screentype == ScreenType.FAILURE:
-            self.__handle_failure_screen(diff, global_dict)
+            self.__handle_failure_screen()
         elif screentype == ScreenType.RETRY:
             self.__handle_retry_screen(diff, global_dict)
         elif screentype == ScreenType.WRONG:
@@ -433,7 +433,7 @@ class WordToScreenMatching(object):
         time.sleep(50)
         return ScreenType.PTC
 
-    def __handle_failure_screen(self, diff, global_dict) -> None:
+    def __handle_failure_screen(self) -> None:
         self.__handle_returning_player_or_wrong_credentials()
 
     def __handle_returning_player_or_wrong_credentials(self) -> None:

--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -274,7 +274,7 @@ class WordToScreenMatching(object):
         elif screentype == ScreenType.PTC:
             return self.__handle_ptc_login()
         elif screentype == ScreenType.FAILURE:
-            screentype = self.__handle_failure_screen(diff, global_dict)
+            self.__handle_failure_screen(diff, global_dict)
         elif screentype == ScreenType.RETRY:
             self.__handle_retry_screen(diff, global_dict)
         elif screentype == ScreenType.WRONG:
@@ -433,19 +433,8 @@ class WordToScreenMatching(object):
         time.sleep(50)
         return ScreenType.PTC
 
-    def __handle_failure_screen(self, diff, global_dict) -> ScreenType:
-        if self._logintype == LoginType.ptc:
-            click_text = 'DIFFERENT,AUTRE,AUTORISER,ANDERES,KONTO,ACCOUNT,VERSUCHEN'
-            n_boxes = len(global_dict['level'])
-            for i in range(n_boxes):
-                if any(elem.lower() in (global_dict['text'][i].lower()) for elem in click_text.split(",")):
-                    self._click_center_button(diff, global_dict, i)
-            time.sleep(5)
-            screentype = ScreenType.FAILURE
-        else:
-            self.__handle_returning_player_or_wrong_credentials()
-            screentype = ScreenType.ERROR
-        return screentype
+    def __handle_failure_screen(self, diff, global_dict) -> None:
+        self.__handle_returning_player_or_wrong_credentials()
 
     def __handle_returning_player_or_wrong_credentials(self) -> None:
         self._nextscreen = ScreenType.UNDEFINED

--- a/mapadroid/ocr/screen_type.py
+++ b/mapadroid/ocr/screen_type.py
@@ -7,8 +7,8 @@ class ScreenType(Enum):
     RETURNING = 2  # returning player screen
     LOGINSELECT = 3  # login selection regarding OAUTH
     PTC = 4  # PTC login
-    FAILURE = 5  # login failure
-    RETRY = 6  # auth failed, retry screen
+    FAILURE = 5  # Unable to authenticate. Please try again. One green button: OK
+    RETRY = 6  # Failed to log in. Green button on top: RETRY - no background button below: TRY A DIFFERENT ACCOUNT
     WRONG = 7  # incorrect credentials?
     GAMEDATA = 8  # game data could not be fetched from server
     GGL = 10  # Google account picker


### PR DESCRIPTION
See title. Also:

+ remove the handling procedure that was wrongly implemented because
of this mix-up.
+ describe the ScreenTypes more clearly.

This is ScreenType.FAILURE - one green button saying OK. Obviously we want to click the button here:
![grafik](https://user-images.githubusercontent.com/13463550/84776633-d89e2780-afe0-11ea-97c0-4e1522950739.png)

This is ScreenType.RETRY - green button on top saying RETRY, clickable "non-button text" below saying "TRY A DIFFERENT ACCOUNT". We want to click the "non-button text":
![grafik](https://user-images.githubusercontent.com/13463550/84776803-126f2e00-afe1-11ea-9a36-7816fcaac0af.png)


Edit: Due to the nature of the issue - dealing with an error condition that has to pop up first - this is untested beyond making sure that MAD still starts.

