### PR TITLE
Change select style to multi+shift

### DIFF
--- a/static/madmin/templates/workerpicker.html
+++ b/static/madmin/templates/workerpicker.html
@@ -28,7 +28,7 @@
               }
             ],
             'select': {
-                'style': 'os'
+                'style': 'multi+shift'
             },
             "ordering": false,
             "responsive": {{ responsive }},


### PR DESCRIPTION
os is not mobile friendly to select anything. multi+shift is combo of shift+os, works on mobile, works almost the same as os without ctrl (shift still works). Win-win.