### PR TITLE
AutoConfig UX Improvements

### DIFF
--- a/mapadroid/data_manager/modules/pogoauth.py
+++ b/mapadroid/data_manager/modules/pogoauth.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 from .resource import Resource
 
 
@@ -33,6 +33,18 @@ class PogoAuth(Resource):
                     "description": "Password",
                     "expected": str
                 }
+            },
+            "device_id": {
+                "settings": {
+                    "type": "deviceselect",
+                    "require": False,
+                    "empty": None,
+                    "description": "Device assigned to the auth",
+                    "expected": int,
+                    "uri": True,
+                    "data_source": "device",
+                    "uri_source": "api_device"
+                }
             }
         }
     }
@@ -43,3 +55,50 @@ class PogoAuth(Resource):
         for ind, device_id in enumerate(dependencies[:]):
             dependencies[ind] = ('device', device_id)
         return dependencies
+
+    def _load(self) -> None:
+        super()._load()
+        sql = "SELECT `device_id`\n" \
+              "FROM `settings_device`\n" \
+              "WHERE `account_id` = %s"
+        self._data['fields']['device_id'] = self._dbc.autofetch_value(sql, args=(self.identifier))
+
+    def save(self, force_insert: Optional[bool] = False, ignore_issues: Optional[List[str]] = []) -> int:
+        self.presave_validation(ignore_issues=ignore_issues)
+        device_id = self._data['fields']['device_id']
+        core_data = {
+            'login_type': self._data['fields']['login_type'],
+            'username': self._data['fields']['username'],
+            'password': self._data['fields']['password'],
+        }
+        super().save(core_data=core_data, force_insert=force_insert, ignore_issues=ignore_issues)
+        if device_id is not None:
+            device = self._data_manager.get_resource('device', device_id)
+            device['account_id'] = self.identifier
+            device.save()
+        else:
+            devices = self._data_manager.search('device', params={'account_id': self.identifier})
+            if devices:
+                device = devices[next(iter(devices))]
+                device['account_id'] = None
+                device.save()
+        return self.identifier
+
+    def validate_custom(self):
+        issues = {}
+        # One google account per device (for now)
+        login_type = None
+        try:
+            login_type = self._data['fields']['login_type']
+        except KeyError:
+            return issues
+        if login_type == 'google' and \
+                ('device_id' in self._data['fields'] and self._data['fields']['device_id']):
+            sql = "SELECT `account_id`\n"\
+                  "FROM `settings_device`\n"\
+                  "WHERE `device_id` = %s"
+            aligned = self._dbc.autofetch_column(sql, (self._data['fields']['device_id']))
+            if len(aligned) == 1 and any(aligned):
+                if aligned[0] != self.identifier:
+                    issues['invalid'] = [('device_id', 'Device already has a Google login')]
+        return issues

--- a/mapadroid/mad_apk/utils.py
+++ b/mapadroid/mad_apk/utils.py
@@ -204,7 +204,11 @@ def lookup_package_info(storage_obj: AbstractAPKStorage, package: APKType,
     Returns:
         Tuple containing (Package or Packages info, status code)
     """
-    package_info: MADPackages = storage_obj.get_current_package_info(package)
+    package_info: MADPackages = None
+    try:
+        package_info = storage_obj.get_current_package_info(package)
+    except AttributeError:
+        pass
     if package_info is None:
         return (None, 404)
     if architecture is None:

--- a/mapadroid/madmin/api/autoconf/autoconfHandler.py
+++ b/mapadroid/madmin/api/autoconf/autoconfHandler.py
@@ -18,10 +18,10 @@ class AutoConfHandler(apiHandler.APIHandler):
                         methods=['GET', 'POST', 'DELETE'],
                         endpoint='api_autoconf_status')(self.entrypoint)
         self._app.route('/api/autoconf/rgc',
-                        methods=['POST'],
+                        methods=['POST', 'DELETE'],
                         endpoint='api_autoconf_rgc')(self.entrypoint)
         self._app.route('/api/autoconf/pd',
-                        methods=['POST'],
+                        methods=['POST', 'DELETE'],
                         endpoint='api_autoconf_pd')(self.entrypoint)
 
     # =====================================
@@ -48,8 +48,12 @@ class AutoConfHandler(apiHandler.APIHandler):
         elif self.api_req._request.endpoint == 'api_autoconf_rgc':
             if self.api_req._request.method == 'POST':
                 return self.autoconf_config_rgc()
+            elif self.api_req._request.method == 'DELETE':
+                return self.autoconf_delete_rgc()
         elif self.api_req._request.endpoint == 'api_autoconf_pd':
             if self.api_req._request.method == 'POST':
                 return self.autoconf_config_pd()
+            elif self.api_req._request.method == 'DELETE':
+                return self.autoconf_delete_pd()
         else:
             return Response(status=404)

--- a/mapadroid/madmin/api/autoconf/ftr_autoconf.py
+++ b/mapadroid/madmin/api/autoconf/ftr_autoconf.py
@@ -14,7 +14,7 @@ class APIAutoConf(AutoConfHandler):
         try:
             conf.save_config(self.api_req.data)
         except AutoConfIssue as err:
-            return (None, 400, {"headers": {'X-Issues': err.issues}})
+            return (err.issues, 400)
         return (None, 200)
 
     def autoconf_config_rgc(self):
@@ -22,7 +22,7 @@ class APIAutoConf(AutoConfHandler):
         try:
             conf.save_config(self.api_req.data)
         except AutoConfIssue as err:
-            return (None, 400, {"headers": {'X-Issues': err.issues}})
+            return (err.issues, 400)
         return (None, 200)
 
     def autoconf_delete_pd(self):

--- a/mapadroid/madmin/api/autoconf/ftr_autoconf.py
+++ b/mapadroid/madmin/api/autoconf/ftr_autoconf.py
@@ -25,6 +25,14 @@ class APIAutoConf(AutoConfHandler):
             return (None, 400, {"headers": {'X-Issues': err.issues}})
         return (None, 200)
 
+    def autoconf_delete_pd(self):
+        PDConfig(self.dbc, self._args, self._data_manager).delete()
+        return (None, 200)
+
+    def autoconf_delete_rgc(self):
+        RGCConfig(self.dbc, self._args, self._data_manager).delete()
+        return (None, 200)
+
     def autoconf_delete_session(self, session_id: int):
         del_info = {
             'session_id': session_id,

--- a/mapadroid/madmin/api/autoconf/ftr_autoconf.py
+++ b/mapadroid/madmin/api/autoconf/ftr_autoconf.py
@@ -60,7 +60,7 @@ class APIAutoConf(AutoConfHandler):
         }
         device = None
         if status == 1:
-            autoconf_issues = generate_autoconf_issues(self.dbc, self._data_manager, self._args)
+            autoconf_issues = generate_autoconf_issues(self.dbc, self._data_manager, self._args, self.storage_obj)
             if autoconf_issues[1]:
                 return (autoconf_issues, 406)
             # Set the device id.  If it was not requested use the origin hopper to create one

--- a/mapadroid/madmin/api/resources/resourceHandler.py
+++ b/mapadroid/madmin/api/resources/resourceHandler.py
@@ -335,7 +335,7 @@ class ResourceHandler(apiHandler.APIHandler):
             converted = self.translate_data_for_response(resource)
             return (converted, 201, {'headers': headers})
         else:
-            raise (flask.request.method, 405)
+            return (flask.request.method, 405)
 
     def put(self, identifier, data, resource_def, resource_info, *args, **kwargs):
         """ API call to replace an object """

--- a/mapadroid/madmin/madmin.py
+++ b/mapadroid/madmin/madmin.py
@@ -77,7 +77,8 @@ class MADmin(object):
                                       self._storage_obj)
         self.event = MADminEvent(self._db_wrapper, self._args, logger, self._app, self._mapping_manager,
                                  self._data_manager)
-        self.autoconf = AutoConfigManager(self._db_wrapper, self._app, self._data_manager, self._args)
+        self.autoconf = AutoConfigManager(self._db_wrapper, self._app, self._data_manager, self._args,
+                                          self._storage_obj)
 
     @logger.catch()
     def madmin_start(self):

--- a/mapadroid/madmin/routes/autoconf.py
+++ b/mapadroid/madmin/routes/autoconf.py
@@ -4,11 +4,12 @@ from mapadroid.utils.autoconfig import generate_autoconf_issues, RGCConfig, PDCo
 
 
 class AutoConfigManager(object):
-    def __init__(self, db, app, data_manager, args):
+    def __init__(self, db, app, data_manager, args, storage_obj):
         self._db = db
         self._app = app
         self._args = args
         self._data_manager = data_manager
+        self._storage_obj = storage_obj
 
     def add_route(self):
         routes = [
@@ -79,7 +80,8 @@ class AutoConfigManager(object):
               "FROM `settings_pogoauth` ag\n"\
               "LEFT JOIN `settings_device` sd ON sd.`account_id` = ag.`account_id`\n"\
               "WHERE ag.`instance_id` = %s AND sd.`device_id` IS NULL"
-        (issues_warning, issues_critical) = generate_autoconf_issues(self._db, self._data_manager, self._args)
+        (issues_warning, issues_critical) = generate_autoconf_issues(self._db, self._data_manager, self._args,
+                                                                     self._storage_obj)
         pending = {}
         sql = "SELECT ar.`session_id`, ar.`ip`, sd.`device_id`, sd.`name` AS 'origin', ar.`status`"\
               "FROM `autoconfig_registration` ar\n"\
@@ -117,7 +119,7 @@ class AutoConfigManager(object):
               "FROM `settings_pogoauth` ag\n"\
               "LEFT JOIN `settings_device` sd ON sd.`account_id` = ag.`account_id`\n"\
               "WHERE ag.`instance_id` = %s AND (sd.`device_id` IS NULL OR sd.`device_id` = %s)"
-        (_, issues_critical) = generate_autoconf_issues(self._db, self._data_manager, self._args)
+        (_, issues_critical) = generate_autoconf_issues(self._db, self._data_manager, self._args, self._storage_obj)
         if issues_critical:
             redirect(url_for('autoconfig_pending'), code=302)
         google_addresses = self._db.autofetch_all(sql, (self._db.instance_id, session['device_id']))

--- a/mapadroid/madmin/routes/autoconf.py
+++ b/mapadroid/madmin/routes/autoconf.py
@@ -1,4 +1,4 @@
-from flask import jsonify, render_template, redirect, url_for
+from flask import jsonify, render_template, redirect, url_for, Response
 from mapadroid.madmin.functions import auth_required
 from mapadroid.utils.autoconfig import generate_autoconf_issues, RGCConfig, PDConfig
 
@@ -53,7 +53,7 @@ class AutoConfigManager(object):
               "WHERE `session_id` = %s AND `instance_id` = %s"
         session = self._db.autofetch_row(sql, (session_id, self._db.instance_id))
         if not session:
-            return redirect(url_for('autoconfig_pending'), code=302)
+            return Response('', status=302)
         sql = "SELECT UNIX_TIMESTAMP(`log_time`) as 'log_time', `level`, `msg`\n"\
               "FROM `autoconfig_logs`\n"\
               "WHERE `instance_id` = %s AND `session_id` = %s\n"\

--- a/mapadroid/madmin/routes/autoconf.py
+++ b/mapadroid/madmin/routes/autoconf.py
@@ -1,4 +1,5 @@
-from flask import jsonify, render_template, redirect, url_for, Response
+from io import BytesIO
+from flask import jsonify, render_template, redirect, url_for, Response, send_file
 from mapadroid.madmin.functions import auth_required
 from mapadroid.utils.autoconfig import generate_autoconf_issues, RGCConfig, PDConfig
 
@@ -20,6 +21,7 @@ class AutoConfigManager(object):
             ("/autoconfig/logs/<int:session_id>/update", self.autoconf_logs_get),
             ("/autoconfig/rgc", self.autoconf_rgc),
             ("/autoconfig/pd", self.autoconf_pd),
+            ("/autoconfig/download", self.autoconfig_download_file)
         ]
         for route_def in routes:
             if len(route_def) == 2:
@@ -31,6 +33,26 @@ class AutoConfigManager(object):
 
     def start_modul(self):
         self.add_route()
+
+    @auth_required
+    def autoconfig_download_file(self):
+        (_, issues_critical) = generate_autoconf_issues(self._db, self._data_manager, self._args, self._storage_obj)
+        if issues_critical:
+            return Response('Basic requirements not met', status=406)
+        rgc_conf = RGCConfig(self._db, self._args, self._data_manager)
+        config_file = BytesIO()
+        info = [rgc_conf.contents['websocket_uri']]
+        try:
+            if rgc_conf.contents['mad_auth'] is not None:
+                auth = self._data_manager.get_resource('auth', rgc_conf.contents['mad_auth'])
+                info.append(f"{auth['username']}:{auth['password']}")
+        except KeyError:
+            # No auth defined for RGC so theres probably no auth for the system
+            pass
+        config_file.write('\r\n'.join(info).encode('utf-8'))
+        config_file.seek(0, 0)
+        return send_file(config_file, as_attachment=True, attachment_filename='mad_autoconf.txt',
+                         mimetype='text/plain')
 
     @auth_required
     def autoconf_logs(self, session_id):

--- a/mapadroid/madmin/routes/autoconf.py
+++ b/mapadroid/madmin/routes/autoconf.py
@@ -39,12 +39,12 @@ class AutoConfigManager(object):
         (_, issues_critical) = generate_autoconf_issues(self._db, self._data_manager, self._args, self._storage_obj)
         if issues_critical:
             return Response('Basic requirements not met', status=406)
-        rgc_conf = RGCConfig(self._db, self._args, self._data_manager)
+        pd_conf = PDConfig(self._db, self._args, self._data_manager)
         config_file = BytesIO()
-        info = [rgc_conf.contents['websocket_uri']]
+        info = [pd_conf.contents['post_destination']]
         try:
-            if rgc_conf.contents['mad_auth'] is not None:
-                auth = self._data_manager.get_resource('auth', rgc_conf.contents['mad_auth'])
+            if pd_conf.contents['mad_auth'] is not None:
+                auth = self._data_manager.get_resource('auth', pd_conf.contents['mad_auth'])
                 info.append(f"{auth['username']}:{auth['password']}")
         except KeyError:
             # No auth defined for RGC so theres probably no auth for the system

--- a/mapadroid/madmin/routes/config.py
+++ b/mapadroid/madmin/routes/config.py
@@ -320,9 +320,17 @@ class MADminConfig(object):
     @auth_required
     def settings_pogoauth(self):
         device_links = {}
+        available_devices = {}
         for device_id, device in self._data_manager.get_root_resource('device').items():
             if device['account_id'] is None:
+                available_devices[device_id] = device
                 continue
+            try:
+                current_id = request.args.get('id', None)
+                if current_id is not None and int(current_id) == device['account_id']:
+                    available_devices[device_id] = device
+            except ValueError:
+                pass
             device_links[device['account_id']] = device
         required_data = {
             'identifier': 'id',
@@ -333,6 +341,7 @@ class MADminConfig(object):
             'html_all': 'settings_pogoauth.html',
             'subtab': 'pogoauth',
             'passthrough': {
+                'devices': available_devices,
                 'device_links': device_links
             },
         }

--- a/mapadroid/madmin/routes/config.py
+++ b/mapadroid/madmin/routes/config.py
@@ -265,7 +265,8 @@ class MADminConfig(object):
                 'pools': 'devicepool'
             },
             'passthrough': {
-                'accounts': accounts
+                'accounts': accounts,
+                'requires_auth': not self._args.autoconfig_no_auth
             }
         }
         return self.process_element(**required_data)

--- a/mapadroid/tests/api/test_pogoauth.py
+++ b/mapadroid/tests/api/test_pogoauth.py
@@ -73,3 +73,32 @@ class APIPogoAuth(api_base.APITestBase):
         response = self.api.delete(pogoauth_obj['uri'])
         self.assertEqual(response.status_code, 412)
         self.remove_resources()
+
+    def test_duplicate_assignment_from_auth(self):
+        pogoauth_1 = super().create_valid_resource('pogoauth')
+        dev_payload = copy.copy(global_variables.DEFAULT_OBJECTS['device']['payload'])
+        dev_payload['account_id'] = pogoauth_1['uri']
+        dev_info_1 = super().create_valid_resource('device', payload=dev_payload)
+        pogoauth_2 = super().create_valid_resource('pogoauth')
+        dev_payload = copy.copy(global_variables.DEFAULT_OBJECTS['device']['payload'])
+        dev_payload['account_id'] = pogoauth_2['uri']
+        super().create_valid_resource('device', payload=dev_payload)
+        data = {
+            'device_id': dev_info_1['uri']
+        }
+        res = self.api.patch(pogoauth_2['uri'], json=data)
+        self.assertTrue(res.status_code == 422)
+
+    def test_duplicate_assignment_from_device(self):
+        pogoauth_1 = super().create_valid_resource('pogoauth')
+        dev_payload = copy.copy(global_variables.DEFAULT_OBJECTS['device']['payload'])
+        dev_payload['account_id'] = pogoauth_1['uri']
+        super().create_valid_resource('device', payload=dev_payload)
+        dev_payload = copy.copy(global_variables.DEFAULT_OBJECTS['device']['payload'])
+        dev_payload['account_id'] = pogoauth_1['uri']
+        dev_info = super().create_valid_resource('device',)
+        data = {
+            'account_id': pogoauth_1['uri']
+        }
+        res = self.api.patch(dev_info['uri'], json=data)
+        self.assertTrue(res.status_code == 422)

--- a/mapadroid/tests/mad_apk/base_storage.py
+++ b/mapadroid/tests/mad_apk/base_storage.py
@@ -3,7 +3,7 @@ import io
 import os
 from unittest import TestCase
 from mapadroid.db.DbFactory import DbFactory
-from mapadroid.tests.test_utils import upload_rgc, mimetype, filepath_rgc
+from mapadroid.tests.test_utils import upload_package, mimetype, filepath_rgc
 from mapadroid.utils.logging import init_logging
 from mapadroid.mad_apk import get_storage_obj, APKArch, APKType, MADPackage, MADPackages, MADapks, get_apk_status,\
     file_generator
@@ -67,7 +67,7 @@ class StorageBase(TestCase):
 
     def upload_check(self):
         self.assertIsNone(self.storage_elem.get_current_package_info(APKType.rgc))
-        upload_rgc(self.storage_elem)
+        upload_package(self.storage_elem)
         packages_data: MADPackages = self.storage_elem.get_current_package_info(APKType.rgc)
         self.assertIsInstance(packages_data, MADPackages)
         self.assertTrue(APKArch.noarch in packages_data)
@@ -85,7 +85,7 @@ class StorageBase(TestCase):
         self.assertIsInstance(package_data['usage_disp'], str)
 
     def download_check(self):
-        upload_rgc(self.storage_elem)
+        upload_package(self.storage_elem)
         gen = file_generator(self.db_wrapper, self.storage_elem, APKType.rgc, APKArch.noarch)
         data = io.BytesIO()
         for chunk in gen:
@@ -93,17 +93,17 @@ class StorageBase(TestCase):
         self.assertTrue(data.getbuffer().nbytes == os.stat(filepath_rgc).st_size)
 
     def delete_check(self):
-        upload_rgc(self.storage_elem)
+        upload_package(self.storage_elem)
         self.assertTrue(self.storage_elem.delete_file(APKType.rgc, APKArch.noarch))
         self.assertIsNone(self.storage_elem.get_current_package_info(APKType.rgc))
 
     def package_upgrade_check(self, version: str):
-        upload_rgc(self.storage_elem, version=version)
-        upload_rgc(self.storage_elem)
+        upload_package(self.storage_elem, version=version)
+        upload_package(self.storage_elem)
 
     def version_check(self):
         version = '0.1'
-        upload_rgc(self.storage_elem, version=version)
+        upload_package(self.storage_elem, version=version)
         self.assertTrue(self.storage_elem.get_current_version(APKType.rgc, APKArch.noarch) == version)
 
     def test_check_invalid(self):

--- a/mapadroid/tests/mad_apk/test_wizard.py
+++ b/mapadroid/tests/mad_apk/test_wizard.py
@@ -1,8 +1,8 @@
 from mapadroid.mad_apk import APKType, WizardError
-from mapadroid.tests.mad_apk.base_storage import StorageBase, upload_rgc
+from mapadroid.tests.mad_apk.base_storage import StorageBase, upload_package
 
 
 class WizardTests(StorageBase):
     def test_mistmatched_type(self):
         with self.assertRaises(WizardError):
-            upload_rgc(self.storage_elem, apk_type=APKType.pd)
+            upload_package(self.storage_elem, apk_type=APKType.pd)

--- a/mapadroid/tests/test_autoconfig.py
+++ b/mapadroid/tests/test_autoconfig.py
@@ -240,8 +240,7 @@ class MITMAutoConf(TestCase):
                 storage.upload_all()
                 res = self.api.get('/autoconfig/download')
                 self.assertTrue(res.status_code == 200)
-                host = f"ws://{args.ws_ip}:{args.ws_port}"
-                expected = f"{host}"
+                expected = f"http://{args.mitmreceiver_ip}:{args.mitmreceiver_port}"
                 self.assertTrue((expected == res.content.decode('utf-8')))
                 # Create auth and test
                 payload = {
@@ -258,7 +257,7 @@ class MITMAutoConf(TestCase):
                 self.assertTrue(res.status_code == 200)
                 res = self.api.get('/autoconfig/download')
                 self.assertTrue(res.status_code == 200)
-                host = f"ws://{args.ws_ip}:{args.ws_port}"
+                host = f"http://{args.mitmreceiver_ip}:{args.mitmreceiver_port}"
                 auth = f"{email_base}:{pwd_base}"
                 expected = f"{host}\r\n{auth}"
                 self.assertTrue((expected == res.content.decode('utf-8')))

--- a/mapadroid/tests/test_autoconfig.py
+++ b/mapadroid/tests/test_autoconfig.py
@@ -109,7 +109,9 @@ class MITMAutoConf(TestCase):
                 expected_issues = [
                     [
                         'No available Google logins for auto creation of devices.  Configure through Settings -> '
-                        '<a href="/settings/pogoauth">PogoAuth</a>'
+                        '<a href="/settings/pogoauth">PogoAuth</a>',
+                        'No auth configured which is a potential security risk.  Configure through Settings -> '
+                        '<a href="/settings/auth">Auth</a>'
                     ],
                     [
                         'PogoDroid is not configured.  Configure through Auto-Config -> '
@@ -142,7 +144,9 @@ class MITMAutoConf(TestCase):
                 expected_issues = [
                     [
                         'No available Google logins for auto creation of devices.  Configure through Settings -> '
-                        '<a href="/settings/pogoauth">PogoAuth</a>'
+                        '<a href="/settings/pogoauth">PogoAuth</a>',
+                        'No auth configured which is a potential security risk.  Configure through Settings -> '
+                        '<a href="/settings/auth">Auth</a>'
                     ],
                     [
                         'PogoDroid is not configured.  Configure through Auto-Config -> '
@@ -160,7 +164,9 @@ class MITMAutoConf(TestCase):
                 expected_issues = [
                     [
                         'No available Google logins for auto creation of devices.  Configure through Settings -> '
-                        '<a href="/settings/pogoauth">PogoAuth</a>'
+                        '<a href="/settings/pogoauth">PogoAuth</a>',
+                        'No auth configured which is a potential security risk.  Configure through Settings -> '
+                        '<a href="/settings/auth">Auth</a>'
                     ],
                     [
                         'PogoDroid is not configured.  Configure through Auto-Config -> '
@@ -178,7 +184,9 @@ class MITMAutoConf(TestCase):
                 expected_issues = [
                     [
                         'No available Google logins for auto creation of devices.  Configure through Settings -> '
-                        '<a href="/settings/pogoauth">PogoAuth</a>'
+                        '<a href="/settings/pogoauth">PogoAuth</a>',
+                        'No auth configured which is a potential security risk.  Configure through Settings -> '
+                        '<a href="/settings/auth">Auth</a>'
                     ],
                     [
                         'PogoDroid is not configured.  Configure through Auto-Config -> '
@@ -196,7 +204,9 @@ class MITMAutoConf(TestCase):
                 expected_issues = [
                     [
                         'No available Google logins for auto creation of devices.  Configure through Settings -> '
-                        '<a href="/settings/pogoauth">PogoAuth</a>'
+                        '<a href="/settings/pogoauth">PogoAuth</a>',
+                        'No auth configured which is a potential security risk.  Configure through Settings -> '
+                        '<a href="/settings/auth">Auth</a>'
                     ],
                     [
                         'PogoDroid is not configured.  Configure through Auto-Config -> '

--- a/mapadroid/tests/test_autoconfig.py
+++ b/mapadroid/tests/test_autoconfig.py
@@ -3,7 +3,7 @@ from functools import wraps
 from typing import Any
 from unittest import TestCase
 import mapadroid.tests.test_variables as global_variables
-from mapadroid.tests.test_utils import get_connection_api, get_connection_mitm, ResourceCreator
+from mapadroid.tests.test_utils import get_connection_api, get_connection_mitm, ResourceCreator, GetStorage
 
 
 email_base: str = "UnitTest@UnitTest.com"
@@ -16,53 +16,55 @@ def basic_autoconf(func) -> Any:
         api_creator = ResourceCreator(self.api)
         gacct = None
         session_id = None
-        try:
-            res = self.mitm.post('/autoconfig/register')
-            self.assertTrue(res.status_code == 201)
-            session_id = res.content.decode('utf-8')
-            # Setup basic PD Auth
-            payload = {
-                'username': email_base,
-                'password': pwd_base
-            }
-            (auth_shared, _) = api_creator.create_valid_resource('auth', payload=payload)
-            auth = {
-                'mad_auth': auth_shared['uri'].split('/')[-1]
-            }
-            res = self.api.post('/api/autoconf/pd', json=auth)
-            self.assertTrue(res.status_code == 200)
-            res = self.api.post('/api/autoconf/rgc', json=auth)
-            self.assertTrue(res.status_code == 200)
-            # Create Google Account
-            gacc = {
-                "login_type": "google",
-                "username": "Unit",
-                "password": "Test"
-            }
-            res = self.api.post('/api/pogoauth', json=gacc)
-            gacct = res.headers['X-URI']
-            self.assertTrue(res.status_code == 201)
-            dev_payload = copy.copy(global_variables.DEFAULT_OBJECTS['device']['payload'])
-            dev_payload['account_id'] = gacct
-            (dev_info, _) = api_creator.create_valid_resource('device', payload=dev_payload)
-            accept_info = {
-                'status': 1,
-                'device_id': dev_info['uri']
-            }
-            res = self.api.post('/api/autoconf/{}'.format(session_id), json=accept_info)
-            self.assertTrue(res.status_code == 200)
-            res = self.mitm.get('/autoconfig/{}/status'.format(session_id))
-            self.assertTrue(res.status_code == 200)
-            (ss_info, _) = api_creator.create_valid_resource('devicesetting')
-            func(self, session_id, dev_info, ss_info, api_creator, *args, **kwargs)
-        except Exception:
-            raise
-        finally:
-            api_creator.remove_resources()
-            if session_id is not None:
-                self.mitm.delete('/autoconfig/{}/complete'.format(session_id))
-            if gacct is not None:
-                self.api.delete(gacct)
+        with GetStorage(self.api) as storage:
+            try:
+                storage.upload_all()
+                res = self.mitm.post('/autoconfig/register')
+                self.assertTrue(res.status_code == 201)
+                session_id = res.content.decode('utf-8')
+                # Setup basic PD Auth
+                payload = {
+                    'username': email_base,
+                    'password': pwd_base
+                }
+                (auth_shared, _) = api_creator.create_valid_resource('auth', payload=payload)
+                auth = {
+                    'mad_auth': auth_shared['uri'].split('/')[-1]
+                }
+                res = self.api.post('/api/autoconf/pd', json=auth)
+                self.assertTrue(res.status_code == 200)
+                res = self.api.post('/api/autoconf/rgc', json=auth)
+                self.assertTrue(res.status_code == 200)
+                # Create Google Account
+                gacc = {
+                    "login_type": "google",
+                    "username": "Unit",
+                    "password": "Test"
+                }
+                res = self.api.post('/api/pogoauth', json=gacc)
+                gacct = res.headers['X-URI']
+                self.assertTrue(res.status_code == 201)
+                dev_payload = copy.copy(global_variables.DEFAULT_OBJECTS['device']['payload'])
+                dev_payload['account_id'] = gacct
+                (dev_info, _) = api_creator.create_valid_resource('device', payload=dev_payload)
+                accept_info = {
+                    'status': 1,
+                    'device_id': dev_info['uri']
+                }
+                res = self.api.post('/api/autoconf/{}'.format(session_id), json=accept_info)
+                self.assertTrue(res.status_code == 200)
+                res = self.mitm.get('/autoconfig/{}/status'.format(session_id))
+                self.assertTrue(res.status_code == 200)
+                (ss_info, _) = api_creator.create_valid_resource('devicesetting')
+                func(self, session_id, dev_info, ss_info, api_creator, *args, **kwargs)
+            except Exception:
+                raise
+            finally:
+                api_creator.remove_resources()
+                if session_id is not None:
+                    self.mitm.delete('/autoconfig/{}/complete'.format(session_id))
+                if gacct is not None:
+                    self.api.delete(gacct)
     return decorated
 
 
@@ -100,21 +102,110 @@ class MITMAutoConf(TestCase):
                 'status': 1,
                 'device_id': dev_info['uri']
             }
-            res = self.api.post('/api/autoconf/{}'.format(session_id), json=accept_info)
-            self.assertTrue(res.status_code == 406)
-            expected_issues = [
-                [
-                    'No available Google logins for auto creation of devices.  Configure through Settings -> '
-                    '<a href="/settings/pogoauth">PogoAuth</a>'
-                ],
-                [
-                    'PogoDroid is not configured.  Configure through Auto-Config -> '
-                    '<a href="/autoconfig/pd">PogoDroid Configuration</a>',
-                    'RGC is not configured.  Configure through Auto-Config -> '
-                    '<a href="/autoconfig/rgc">RemoteGPSController Configuration</a>'
+            with GetStorage(self.api) as storage:
+                storage.upload_all()
+                res = self.api.post('/api/autoconf/{}'.format(session_id), json=accept_info)
+                self.assertTrue(res.status_code == 406)
+                expected_issues = [
+                    [
+                        'No available Google logins for auto creation of devices.  Configure through Settings -> '
+                        '<a href="/settings/pogoauth">PogoAuth</a>'
+                    ],
+                    [
+                        'PogoDroid is not configured.  Configure through Auto-Config -> '
+                        '<a href="/autoconfig/pd">PogoDroid Configuration</a>',
+                        'RGC is not configured.  Configure through Auto-Config -> '
+                        '<a href="/autoconfig/rgc">RemoteGPSController Configuration</a>',
+                    ]
                 ]
-            ]
-            self.assertListEqual(expected_issues, res.json())
+                self.assertListEqual(expected_issues, res.json())
+        finally:
+            api_creator.remove_resources()
+            if session_id is not None:
+                self.mitm.delete('/autoconfig/{}/complete'.format(session_id))
+
+    def test_missing_apks(self):
+        api_creator = ResourceCreator(self.api)
+        session_id = None
+        try:
+            res = self.mitm.post('/autoconfig/register')
+            self.assertTrue(res.status_code == 201)
+            session_id = res.content.decode('utf-8')
+            (dev_info, _) = api_creator.create_valid_resource('device')
+            accept_info = {
+                'status': 1,
+                'device_id': dev_info['uri']
+            }
+            with GetStorage(self.api) as storage:
+                res = self.api.post('/api/autoconf/{}'.format(session_id), json=accept_info)
+                self.assertTrue(res.status_code == 406)
+                expected_issues = [
+                    [
+                        'No available Google logins for auto creation of devices.  Configure through Settings -> '
+                        '<a href="/settings/pogoauth">PogoAuth</a>'
+                    ],
+                    [
+                        'PogoDroid is not configured.  Configure through Auto-Config -> '
+                        '<a href="/autoconfig/pd">PogoDroid Configuration</a>',
+                        'RGC is not configured.  Configure through Auto-Config -> '
+                        '<a href="/autoconfig/rgc">RemoteGPSController Configuration</a>',
+                        'Missing one or more required packages.  Configure through System -> '
+                        '<a href="/apk">MADmin Packages</a>'
+                    ]
+                ]
+                self.assertListEqual(expected_issues, res.json())
+                storage.upload_rgc()
+                res = self.api.post('/api/autoconf/{}'.format(session_id), json=accept_info)
+                self.assertTrue(res.status_code == 406)
+                expected_issues = [
+                    [
+                        'No available Google logins for auto creation of devices.  Configure through Settings -> '
+                        '<a href="/settings/pogoauth">PogoAuth</a>'
+                    ],
+                    [
+                        'PogoDroid is not configured.  Configure through Auto-Config -> '
+                        '<a href="/autoconfig/pd">PogoDroid Configuration</a>',
+                        'RGC is not configured.  Configure through Auto-Config -> '
+                        '<a href="/autoconfig/rgc">RemoteGPSController Configuration</a>',
+                        'Missing one or more required packages.  Configure through System -> '
+                        '<a href="/apk">MADmin Packages</a>'
+                    ]
+                ]
+                self.assertListEqual(expected_issues, res.json())
+                storage.upload_pd()
+                res = self.api.post('/api/autoconf/{}'.format(session_id), json=accept_info)
+                self.assertTrue(res.status_code == 406)
+                expected_issues = [
+                    [
+                        'No available Google logins for auto creation of devices.  Configure through Settings -> '
+                        '<a href="/settings/pogoauth">PogoAuth</a>'
+                    ],
+                    [
+                        'PogoDroid is not configured.  Configure through Auto-Config -> '
+                        '<a href="/autoconfig/pd">PogoDroid Configuration</a>',
+                        'RGC is not configured.  Configure through Auto-Config -> '
+                        '<a href="/autoconfig/rgc">RemoteGPSController Configuration</a>',
+                        'Missing one or more required packages.  Configure through System -> '
+                        '<a href="/apk">MADmin Packages</a>'
+                    ]
+                ]
+                self.assertListEqual(expected_issues, res.json())
+                storage.upload_pogo()
+                res = self.api.post('/api/autoconf/{}'.format(session_id), json=accept_info)
+                self.assertTrue(res.status_code == 406)
+                expected_issues = [
+                    [
+                        'No available Google logins for auto creation of devices.  Configure through Settings -> '
+                        '<a href="/settings/pogoauth">PogoAuth</a>'
+                    ],
+                    [
+                        'PogoDroid is not configured.  Configure through Auto-Config -> '
+                        '<a href="/autoconfig/pd">PogoDroid Configuration</a>',
+                        'RGC is not configured.  Configure through Auto-Config -> '
+                        '<a href="/autoconfig/rgc">RemoteGPSController Configuration</a>'
+                    ]
+                ]
+                self.assertListEqual(expected_issues, res.json())
         finally:
             api_creator.remove_resources()
             if session_id is not None:

--- a/mapadroid/utils/autoconfig.py
+++ b/mapadroid/utils/autoconfig.py
@@ -120,6 +120,13 @@ class AutoConfigCreator:
         self.configured: bool = False
         self.load_config()
 
+    def delete(self):
+        del_info = {
+            "name": self.source,
+            "instance_id": self._db.instance_id
+        }
+        self._db.autoexec_delete('autoconfig_file', del_info)
+
     def generate_config(self, origin: str) -> str:
         origin_config = self.get_config()
         origin_config[self.origin_field] = origin

--- a/mapadroid/utils/autoconfig.py
+++ b/mapadroid/utils/autoconfig.py
@@ -307,7 +307,7 @@ class RGCConfig(AutoConfigCreator):
                 "title": "Override OOM value",
                 "type": "bool",
                 "expected": bool,
-                "default": False,
+                "default": True,
                 "summary": "Overrides the oom_adj value to reduce the possibility of the process being killed when "
                            "the system runs out of memory.",
                 "required": False
@@ -334,7 +334,7 @@ class RGCConfig(AutoConfigCreator):
                 "title": "Use Android Mock location",
                 "type": "bool",
                 "expected": bool,
-                "default": False,
+                "default": True,
                 "summary": "Requires RGC to be set as Mocking app in developer options",
                 "required": False
             },
@@ -351,7 +351,7 @@ class RGCConfig(AutoConfigCreator):
                 "type": "option",
                 "values": ["Minimal", "Common", "Indirect"],
                 "expected": str,
-                "default": "",
+                "default": "Minimal",
                 "summary": "Defines how many providers are overwritten (also known as indirect mocking). Minimal "
                            "(only GPS), Common (GPS, Network, Passive)",
                 "required": False
@@ -370,7 +370,7 @@ class RGCConfig(AutoConfigCreator):
                 "title": "Start on boot",
                 "type": "bool",
                 "expected": bool,
-                "default": False,
+                "default": True,
                 "summary": "Start app on boot",
                 "required": False
             },
@@ -386,7 +386,7 @@ class RGCConfig(AutoConfigCreator):
                 "title": "Start services on appstart",
                 "type": "bool",
                 "expected": bool,
-                "default": False,
+                "default": True,
                 "summary": "Automatically start the services when the app is opened",
                 "required": False
             }
@@ -530,7 +530,7 @@ class PDConfig(AutoConfigCreator):
                 "title": "GZIP the raw data that is to be posted.",
                 "type": "bool",
                 "expected": bool,
-                "default": False,
+                "default": True,
                 "summary": "",
                 "required": False
             },
@@ -547,7 +547,7 @@ class PDConfig(AutoConfigCreator):
                 "type": "bool",
                 "expected": bool,
                 "default": False,
-                "summary": "Disable display of notifcations of the last timestamp data was sent at. Attempts are also "
+                "summary": "Disable display of notifications of the last timestamp data was sent at. Attempts are also "
                            " logged for debugging of connectivity issues.",
                 "required": False
             },
@@ -627,7 +627,7 @@ class PDConfig(AutoConfigCreator):
                 "title": "Default to mapping mode",
                 "type": "bool",
                 "expected": bool,
-                "default": False,
+                "default": True,
                 "summary": "",
                 "required": False
             },
@@ -635,7 +635,7 @@ class PDConfig(AutoConfigCreator):
                 "title": "Patch SELinux",
                 "type": "bool",
                 "expected": bool,
-                "default": True,
+                "default": False,
                 "summary": "Patches very few SELinux rules, require for Samsung Stock ROMs for example (generally "
                            "enforcing kernels)",
                 "required": False
@@ -644,7 +644,7 @@ class PDConfig(AutoConfigCreator):
                 "title": "Full daemon mode",
                 "type": "bool",
                 "expected": bool,
-                "default": False,
+                "default": True,
                 "summary": "Automatically start app on boot (and watchdog if enabled)",
                 "required": False
             },
@@ -652,7 +652,7 @@ class PDConfig(AutoConfigCreator):
                 "title": "Start Pogodroid with a delay (seconds)",
                 "type": int,
                 "expected": int,
-                "default": 100,
+                "default": 30,
                 "summary": "",
                 "required": False
             },
@@ -660,7 +660,7 @@ class PDConfig(AutoConfigCreator):
                 "title": "Override OOM value",
                 "type": "bool",
                 "expected": bool,
-                "default": False,
+                "default": True,
                 "summary": "Enables OOM adjustments to reduce the 'risk' of Android killing the app.",
                 "required": False
             },

--- a/mapadroid/utils/autoconfig.py
+++ b/mapadroid/utils/autoconfig.py
@@ -23,6 +23,10 @@ def generate_autoconf_issues(db, data_manager, args, storage_obj) -> Tuple[List[
         link = url_for('settings_walkers')
         anchor = f"Settings -> <a href=\"{link}\">Walker</a>"
         issues_critical.append(f"No walkers configured.  Configure through {anchor}")
+    if not data_manager.get_root_resource('auth'):
+        link = url_for('settings_auth')
+        anchor = f"Settings -> <a href=\"{link}\">Auth</a>"
+        issues_warning.append(f"No auth configured which is a potential security risk.  Configure through {anchor}")
     if not PDConfig(db, args, data_manager).configured:
         link = url_for('autoconf_pd')
         anchor = f"Auto-Config -> <a href=\"{link}\">PogoDroid Configuration</a>"

--- a/mapadroid/utils/autoconfig.py
+++ b/mapadroid/utils/autoconfig.py
@@ -7,6 +7,7 @@ from xml.sax.saxutils import escape
 from mapadroid.data_manager.modules import MAPPINGS
 from mapadroid.mad_apk import get_apk_status
 
+
 def generate_autoconf_issues(db, data_manager, args, storage_obj) -> Tuple[List[str], List[str]]:
     issues_warning = []
     issues_critical = []
@@ -30,14 +31,13 @@ def generate_autoconf_issues(db, data_manager, args, storage_obj) -> Tuple[List[
         link = url_for('autoconf_rgc')
         anchor = f"Auto-Config -> <a href=\"{link}\">RemoteGPSController Configuration</a>"
         issues_critical.append(f"RGC is not configured.  Configure through {anchor}")
-    packages = get_apk_status(storage_obj)
     missing_packages = []
     for _, apkpackages in get_apk_status(storage_obj).items():
         for _, package in apkpackages.items():
             if package.version is None:
                 missing_packages.append(package)
     if missing_packages:
-        link = url_for('autoconfig_root')
+        link = url_for('mad_apks')
         anchor = f"System -> <a href=\"{link}\">MADmin Packages</a>"
         issues_critical.append(f"Missing one or more required packages.  Configure through {anchor}")
     return (issues_warning, issues_critical)

--- a/mapadroid/utils/autoconfig.py
+++ b/mapadroid/utils/autoconfig.py
@@ -5,9 +5,9 @@ from io import BytesIO
 from typing import Any, List, NoReturn, Tuple
 from xml.sax.saxutils import escape
 from mapadroid.data_manager.modules import MAPPINGS
+from mapadroid.mad_apk import get_apk_status
 
-
-def generate_autoconf_issues(db, data_manager, args) -> Tuple[List[str], List[str]]:
+def generate_autoconf_issues(db, data_manager, args, storage_obj) -> Tuple[List[str], List[str]]:
     issues_warning = []
     issues_critical = []
     sql = "SELECT count(*)\n" \
@@ -30,6 +30,16 @@ def generate_autoconf_issues(db, data_manager, args) -> Tuple[List[str], List[st
         link = url_for('autoconf_rgc')
         anchor = f"Auto-Config -> <a href=\"{link}\">RemoteGPSController Configuration</a>"
         issues_critical.append(f"RGC is not configured.  Configure through {anchor}")
+    packages = get_apk_status(storage_obj)
+    missing_packages = []
+    for _, apkpackages in get_apk_status(storage_obj).items():
+        for _, package in apkpackages.items():
+            if package.version is None:
+                missing_packages.append(package)
+    if missing_packages:
+        link = url_for('autoconfig_root')
+        anchor = f"System -> <a href=\"{link}\">MADmin Packages</a>"
+        issues_critical.append(f"Missing one or more required packages.  Configure through {anchor}")
     return (issues_warning, issues_critical)
 
 

--- a/static/madmin/templates/autoconfig_logs.html
+++ b/static/madmin/templates/autoconfig_logs.html
@@ -22,13 +22,17 @@
                         return data;
                 },
                 "error": function (xhr, error, code) {
-                        errorCount++;
-                        console.log(xhr);
-                        console.log(error);
-                        console.log(code);
-                        if (errorCount == 5) {
-                                alert("Could not get updates from MAD five times in a row. More logs in browser developer console. Is MAD running?");
-                        }
+                    if(xhr.status == 302) {
+                        alert('Session has completed or has been deleted.  Returning to pending page');
+                        location.href = '{{ url_for('autoconfig_root') }}';
+                    }
+                    console.log(xhr);
+                    console.log(error);
+                    console.log(code);
+                    errorCount++;
+                    if (errorCount == 5) {
+                            alert("Could not get updates from MAD five times in a row. More logs in browser developer console. Is MAD running?");
+                    }
                 }
             },
             "columns": [

--- a/static/madmin/templates/autoconfig_pending.html
+++ b/static/madmin/templates/autoconfig_pending.html
@@ -137,13 +137,6 @@ $(document).ready(function () {
 </div>
 <div class="row mt-3">
   <div class="col">
-    <div class="btn-group-vertical float-right">
-        {% if issues_critical %}
-        Clear all blocking issues to get USB Configuration file
-        {% else %}
-        <button class="btn btn-info btn-sm nav-link text-uppercase font-weight-bold download_config align-items-center mb-1"><i class="fas fa-3x fa-cog align-middle"></i>Download Configuration</button>
-        {% endif %}
-    </div>
     <table class="table table-striped table-hover table-sm">
       <thead>
         <tr>
@@ -191,8 +184,8 @@ $(document).ready(function () {
     </table>
   </div>
 </div>
-<div>
-  <div class="col">
+<div class="row">
+  <div class="col-sm">
     Bulk Actions
     <select class='bulk_update'>
       <option value="None">None</option>
@@ -203,5 +196,13 @@ $(document).ready(function () {
       <!-- <option value='Reject'>Delete</option> -->
     </select>
   </div>
+  <div class="col-sm">
+        <div class="btn-group-vertical float-right">
+        {% if issues_critical %}
+        Clear all blocking issues to get USB Configuration file
+        {% else %}
+        <button class="btn btn-info btn-sm nav-link text-uppercase font-weight-bold download_config align-items-center mb-1"><i class="fas fa-3x fa-cog align-middle"></i> Download Configuration</button>
+        {% endif %}
+    </div>
 </div>
 {% endblock %}

--- a/static/madmin/templates/autoconfig_pending.html
+++ b/static/madmin/templates/autoconfig_pending.html
@@ -57,6 +57,10 @@ $(document).ready(function () {
         }
     });
 
+    $(".download_config").click(function() {
+        window.location.href = "{{ url_for('autoconfig_download_file') }}";
+    });
+
     $(".sess_logs").click(function() {
         var session_id = $(this).data('identifier');
         window.location.replace('{{ url_for('autoconfig_root') }}/logs/'+ session_id);
@@ -133,6 +137,13 @@ $(document).ready(function () {
 </div>
 <div class="row mt-3">
   <div class="col">
+    <div class="btn-group-vertical float-right">
+        {% if issues_critical %}
+        Clear all blocking issues to get USB Configuration file
+        {% else %}
+        <button class="btn btn-info btn-sm nav-link text-uppercase font-weight-bold download_config align-items-center mb-1"><i class="fas fa-3x fa-cog align-middle"></i>Download Configuration</button>
+        {% endif %}
+    </div>
     <table class="table table-striped table-hover table-sm">
       <thead>
         <tr>

--- a/static/madmin/templates/base.html
+++ b/static/madmin/templates/base.html
@@ -88,7 +88,7 @@
                     </a>
                       <div class="dropdown-menu"i aria-labelledby="navbarDropdown">
                         <a href="{{ url_for('autoconfig_root') }}" class="dropdown-item">Auto-Config</a>
-                        <a href="{{ url_for('mad_apks') }}" class="dropdown-item">MADmin APKs</a>
+                        <a href="{{ url_for('mad_apks') }}" class="dropdown-item">MADmin Packages</a>
                         <a href="{{ url_for('events') }}" class="dropdown-item">MAD Events</a>
                         <a href="{{ url_for('plugins') }}" class="dropdown-item">MAD Plugins</a>
                         <div class="darkmode_check">

--- a/static/madmin/templates/settings_singledevice.html
+++ b/static/madmin/templates/settings_singledevice.html
@@ -68,6 +68,9 @@ $(document).ready(function () {
 
 {% block content %}
 {{ super() }}
+{% if requires_auth and element.origin and (not element.ptc_login and not element.account_id) %}
+    <div class="alert alert-warning">No Pogo Auth (Google or PTC) selected for the device.  During auto-configuration the device will not be able to automatically sign-in.</div>
+{% endif %}
 
 <h1 class="display-4">{{ element.origin }}</h1>
 

--- a/static/madmin/templates/settings_singlepogoauth.html
+++ b/static/madmin/templates/settings_singlepogoauth.html
@@ -31,7 +31,7 @@ $(document).ready(function () {
 <div class="row">
   <div class="col-sm">
     <div class="form-group">
-      <select class="form-control login_type" name="login_type" data-default="{{ element.login_type[key] if 'login_type' in element else 'None' }}">
+      <select class="form-control login_type" name="login_type" data-default="{{ element.login_type if 'login_type' in element else 'None' }}">
         <option value="google" {% if 'login_type' in element and element.login_type == 'google' %}{{ 'selected="selected"' }}{% endif %}>google</option>
         <option value="ptc" {% if 'login_type' in element and element.login_type == 'ptc' %}{{ 'selected="selected"' }}{% endif %}>ptc</option>
       </select>
@@ -46,8 +46,19 @@ $(document).ready(function () {
       <input type="input" class="form-control" id="password" name="password" value="{{ element.password }}" data-default="{{ element.password }}">
       <small class="form-text text-muted">Password</small>
     </div>
+    <div class="form-group">
+      <label for="device_id">Assigned Device</label>
+      <select class="form-control" name="device_id" data-default="{{ url_for('api_device') + '/'+ element.device_id|string if element.device_id else 'None' }}">
+        <option value='None'>None</option>
+        {% if devices is not none %}
+        {% for device_id, device in devices.items() %}
+         <option value="{{ url_for('api_device') + '/'+ device_id|string }}" {{ 'selected=selected' if element.device_id == device_id else "" }}>{{ device.origin }}</option>
+        {% endfor %}
+        {% endif %}
+      </select>
+      <small class="form-text text-muted">Aligned Device</small>
+    </div>
     <button type="button" id="submit" class="btn btn-success btn-lg btn-block">Save</button>
   </div>
 </div>
 {% endblock %}
-


### PR DESCRIPTION
UX Improvements for Auto-Config

* Viewing the log page for a session when completed or deleted now prompts an redirects to the pending page
* Add a warning message if no auth is configured
* Require MAD Packages to be up-to-date before a session can be accepted
* MADmin Packages must be available or a blocking issue will prevent auto-config from executing
* Allow a device to be added through the PogoAuth Page
* Only allow a Google PogoAuth account to be assigned to a single device
* Display a warning message on a device if autoconfig is required to have an assigned Pogo Auth and none is present