### PR TITLE
Pausing device enables ConfigMode for the worker

### DIFF
--- a/mapadroid/data_manager/__init__.py
+++ b/mapadroid/data_manager/__init__.py
@@ -22,7 +22,7 @@ class DataManager(object):
     def __init__(self, dbc: DbWrapper, instance_id: int):
         self.dbc = dbc
         self.instance_id = instance_id
-        self.__paused_devices = []
+        self.__paused_devices: List[int] = []
 
     def clear_on_boot(self) -> None:
         # This function should handle any on-boot clearing.  It is not initiated by __init__ on the off-chance that
@@ -149,15 +149,15 @@ class DataManager(object):
             valid_modes = sorted(modules.AREA_MAPPINGS.keys())
         return valid_modes
 
-    def set_device_state(self, dev_name: str, active: int) -> None:
+    def set_device_state(self, device_id: int, active: int) -> None:
         if active == 1:
             try:
-                self.__paused_devices.remove(dev_name)
+                self.__paused_devices.remove(device_id)
             except ValueError:
                 pass
         else:
-            if dev_name not in self.__paused_devices:
-                self.__paused_devices.append(dev_name)
+            if device_id not in self.__paused_devices:
+                self.__paused_devices.append(device_id)
 
-    def is_device_active(self, dev_name: str) -> bool:
-        return dev_name not in self.__paused_devices
+    def is_device_active(self, device_id: int) -> bool:
+        return device_id not in self.__paused_devices

--- a/mapadroid/data_manager/modules/device.py
+++ b/mapadroid/data_manager/modules/device.py
@@ -407,5 +407,5 @@ class Device(Resource):
     def _load(self) -> None:
         super()._load()
         self.state = 0
-        if self._data_manager.is_device_active(self['origin']):
+        if self._data_manager.is_device_active(self.identifier):
             self.state = 1

--- a/mapadroid/madmin/api/resources/ftr_device.py
+++ b/mapadroid/madmin/api/resources/ftr_device.py
@@ -15,11 +15,9 @@ class APIDevice(ResourceHandler):
                 args = self.api_req.data.get('args', {})
                 if call == 'device_state':
                     active = args.get('active', 1)
-                    origin = resource['origin']
-                    self._data_manager.set_device_state(origin, active)
-                    if active == 0:
-                        self._mapping_manager.device_set_disabled(origin)
-                        self._ws_server.force_disconnect(origin)
+                    self._data_manager.set_device_state(int(identifier), active)
+                    self._mapping_manager.device_set_disabled(resource['origin'])
+                    self._ws_server.force_disconnect(resource['origin'])
                     return (None, 200)
                 elif call == 'flush_level':
                     resource.flush_level()

--- a/mapadroid/utils/MappingManager.py
+++ b/mapadroid/utils/MappingManager.py
@@ -323,6 +323,9 @@ class MappingManager:
             logger.opt(exception=True).error('Unable to start recalculation')
         return successful
 
+    def data_manager_is_device_active(self, device_id: int):
+        return self.__data_manager.is_device_active(device_id)
+
     def __inherit_device_settings(self, devicesettings, poolsettings):
         inheritsettings = {}
         for pool_setting in poolsettings:

--- a/mapadroid/websocket/WebsocketServer.py
+++ b/mapadroid/websocket/WebsocketServer.py
@@ -246,7 +246,6 @@ class WebsocketServer(object):
         origin_logger.info("Done with connection ({})", websocket_client_connection.remote_address)
 
     async def __add_worker_and_thread_to_entry(self, entry, origin, use_configmode: bool = None) -> bool:
-        origin_logger = get_origin_logger(logger, origin=origin)
         communicator: AbstractCommunicator = Communicator(
             entry, origin, None, self.__args.websocket_command_timeout)
         use_configmode: bool = use_configmode if use_configmode is not None else self.__enable_configmode

--- a/mapadroid/worker/WorkerConfigmode.py
+++ b/mapadroid/worker/WorkerConfigmode.py
@@ -55,17 +55,7 @@ class WorkerConfigmode(AbstractWorker):
         self._db_wrapper.save_idle_status(self._dev_id, True)
         self.logger.debug("Device set to idle for routemanager")
         while self.check_walker() and not self._stop_worker_event.is_set():
-            if self._args.config_mode:
-                time.sleep(10)
-            else:
-                position_type = self._mapping_manager.routemanager_get_position_type(self._routemanager_name,
-                                                                                     self._origin)
-                if position_type is None:
-                    self.logger.warning("Mappings/Routemanagers have changed, stopping worker to be created again")
-                    self._stop_worker_event.set()
-                    time.sleep(1)
-                else:
-                    time.sleep(10)
+            time.sleep(10)
         self.set_devicesettings_value('finished', True)
         self._mapping_manager.unregister_worker_from_routemanager(self._routemanager_name, self._origin)
         try:


### PR DESCRIPTION
A paused device will now run under ConfigMode worker which allows it to stay connected to MAD. This replaced the old functionality of not allowing the device to reconnect.

Implementation for #923 