### PR TITLE
Give more info about 'got the data requested'

### DIFF
--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -171,7 +171,8 @@ class MITMBase(WorkerBase):
             self.logger.warning("Mappings/Routemanagers have changed, stopping worker to be created again")
             raise InternalStopWorkerException
         if data_requested != LatestReceivedType.UNDEFINED:
-            self.logger.success('Got the data requested, type = {}', str(data_requested) if isinstance(data_requested, Enum) else '<data-block>' )
+            self.logger.success('Got the data requested, type = {}',
+                                str(data_requested) if isinstance(data_requested, Enum) else '<data-block>')
             self._reboot_count = 0
             self._restart_count = 0
             self._rec_data_time = datetime.now()

--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -171,7 +171,7 @@ class MITMBase(WorkerBase):
             self.logger.warning("Mappings/Routemanagers have changed, stopping worker to be created again")
             raise InternalStopWorkerException
         if data_requested != LatestReceivedType.UNDEFINED:
-            self.logger.success('Got the data requested')
+            self.logger.success('Got the data requested, type = ' + (str(data_requested) if isinstance(data_requested, Enum) else '<data-block>') )
             self._reboot_count = 0
             self._restart_count = 0
             self._rec_data_time = datetime.now()

--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -171,7 +171,7 @@ class MITMBase(WorkerBase):
             self.logger.warning("Mappings/Routemanagers have changed, stopping worker to be created again")
             raise InternalStopWorkerException
         if data_requested != LatestReceivedType.UNDEFINED:
-            self.logger.success('Got the data requested, type = ' + (str(data_requested) if isinstance(data_requested, Enum) else '<data-block>') )
+            self.logger.success('Got the data requested, type = {}', str(data_requested) if isinstance(data_requested, Enum) else '<data-block>' )
             self._reboot_count = 0
             self._restart_count = 0
             self._rec_data_time = datetime.now()


### PR DESCRIPTION
I recently had a problem with a client where the logs showed:
```
[08-23 15:03:19.69] [           atv107] [  MITMDataProcessor:71  ] [I] Processing GMO received. Received at 2020-08-23 15:03:20
[08-23 15:03:29.77] [           atv107] [  MITMDataProcessor:71  ] [I] Processing GMO received. Received at 2020-08-23 15:03:30
[08-23 15:03:35.85] [           atv107] [           MITMBase:188 ] [W] Timeout waiting for data
[08-23 15:03:38.87] [           atv107] [           MITMBase:131 ] [I] Waiting for data after 2020-08-23 15:03:35.290276
[08-23 15:03:39.51] [           atv107] [  MITMDataProcessor:71  ] [I] Processing GMO received. Received at 2020-08-23 15:03:40
[08-23 15:03:39.88] [           atv107] [           MITMBase:174 ] [S] Got the data requested
[08-23 15:03:39.88] [           atv107] [       WorkerQuests:721 ] [I] Spin Stop
[08-23 15:03:39.89] [           atv107] [           MITMBase:131 ] [I] Waiting for data after 2020-08-23 15:03:35.488163
[08-23 15:03:40.89] [           atv107] [           MITMBase:174 ] [S] Got the data requested
[08-23 15:03:41.90] [           atv107] [       WorkerQuests:782 ] [W] Softban - return to main screen and open again...
[08-23 15:03:45.94] [           atv107] [       WorkerQuests:613 ] [W] Can't spin stop - no map info in GMO!
[08-23 15:03:45.94] [           atv107] [           MITMBase:131 ] [I] Waiting for data after 2020-08-23 15:03:42.721225
[08-23 15:03:49.45] [           atv107] [  MITMDataProcessor:71  ] [I] Processing GMO received. Received at 2020-08-23 15:03:50
[08-23 15:04:00.41] [           atv107] [  MITMDataProcessor:71  ] [I] Processing GMO received. Received at 2020-08-23 15:04:00
```

I'm not sure how it 'got the data requested' if there was 'no map info in gmo'.  This will hopefully help me troubleshoot the next time it happens. 

A little more info.  I didn't notice the device had a problem for 12 hours, since the status page showed "last udpate" < a few seconds the whole time.  It happened during a quest route, I noticed there was a problem in the late afternoon.  When I looked at the device's screen it was still night time and it was sitting at a stop.  The device was responsive and still connected to MAD.  I never really figured out what went wrong.  I just manually rebooted the device and it started working normally then.  I'm hoping that if I can find the problem I can get MAD to just reboot the device so it isn't sitting around doing nothing.