### PR TITLE
Add evolution/mega support

### DIFF
--- a/mapadroid/db/DbPogoProtoSubmit.py
+++ b/mapadroid/db/DbPogoProtoSubmit.py
@@ -512,12 +512,12 @@ class DbPogoProtoSubmit:
 
         query_raid = (
             "INSERT INTO raid (gym_id, level, spawn, start, end, pokemon_id, cp, move_1, move_2, last_scanned, form, "
-            "is_exclusive, gender, costume) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
+            "is_exclusive, gender, costume, evolution) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
             "ON DUPLICATE KEY UPDATE level=VALUES(level), spawn=VALUES(spawn), start=VALUES(start), "
             "end=VALUES(end), pokemon_id=VALUES(pokemon_id), cp=VALUES(cp), move_1=VALUES(move_1), "
             "move_2=VALUES(move_2), last_scanned=VALUES(last_scanned), is_exclusive=VALUES(is_exclusive), "
-            "form=VALUES(form), gender=VALUES(gender), costume=VALUES(costume)"
+            "form=VALUES(form), gender=VALUES(gender), costume=VALUES(costume), evolution=VALUES(evolution)"
         )
 
         for cell in cells:
@@ -532,6 +532,7 @@ class DbPogoProtoSubmit:
                         form = gym["gym_details"]["raid_info"]["raid_pokemon"]["display"]["form_value"]
                         gender = gym["gym_details"]["raid_info"]["raid_pokemon"]["display"]["gender_value"]
                         costume = gym["gym_details"]["raid_info"]["raid_pokemon"]["display"]["costume_value"]
+                        evolution = gym["gym_details"]["raid_info"]["raid_pokemon"]["display"].get("evolution_value", 0)
                     else:
                         pokemon_id = None
                         cp = 0
@@ -540,6 +541,7 @@ class DbPogoProtoSubmit:
                         form = None
                         gender = None
                         costume = None
+                        evolution = 0
 
                     raid_end_sec = int(gym["gym_details"]["raid_info"]["raid_end"] / 1000)
                     raid_spawn_sec = int(gym["gym_details"]["raid_info"]["raid_spawn"] / 1000)
@@ -572,7 +574,8 @@ class DbPogoProtoSubmit:
                             form,
                             is_exclusive,
                             gender,
-                            costume
+                            costume,
+                            evolution
                         )
                     )
         self._db_exec.executemany(query_raid, raid_args, commit=True)

--- a/mapadroid/db/DbSchemaUpdater.py
+++ b/mapadroid/db/DbSchemaUpdater.py
@@ -191,6 +191,11 @@ class DbSchemaUpdater:
             "ctype": "tinyint(1) NULL"
         },
         {
+            "table": "raid",
+            "column": "evolution",
+            "ctype": "smallint(6) NULL"
+        },
+        {
             "table": "gym",
             "column": "is_ex_raid_eligible",
             "ctype": "tinyint(1) NOT NULL DEFAULT 0"

--- a/mapadroid/db/DbWebhookReader.py
+++ b/mapadroid/db/DbWebhookReader.py
@@ -20,7 +20,7 @@ class DbWebhookReader:
         query = (
             "SELECT raid.gym_id, raid.level, raid.spawn, raid.start, raid.end, raid.pokemon_id, "
             "raid.cp, raid.move_1, raid.move_2, raid.last_scanned, raid.form, raid.is_exclusive, raid.gender, "
-            "raid.costume, gymdetails.name, gymdetails.url, gym.latitude, gym.longitude, "
+            "raid.costume, raid.evolution, gymdetails.name, gymdetails.url, gym.latitude, gym.longitude, "
             "gym.team_id, weather_boosted_condition, gym.is_ex_raid_eligible "
             "FROM raid "
             "LEFT JOIN gymdetails ON gymdetails.gym_id = raid.gym_id "
@@ -33,7 +33,7 @@ class DbWebhookReader:
         ret = []
         for (gym_id, level, spawn, start, end, pokemon_id,
              cp, move_1, move_2, last_scanned, form, is_exclusive, gender,
-             costume, name, url, latitude, longitude, team_id,
+             costume, evolution, name, url, latitude, longitude, team_id,
              weather_boosted_condition, is_ex_raid_eligible) in res:
             ret.append({
                 "gym_id": gym_id,
@@ -56,7 +56,8 @@ class DbWebhookReader:
                 "is_exclusive": is_exclusive,
                 "gender": gender,
                 "is_ex_raid_eligible": is_ex_raid_eligible,
-                "costume": costume
+                "costume": costume,
+                "evolution": evolution
             })
         return ret
 

--- a/mapadroid/db/DbWrapper.py
+++ b/mapadroid/db/DbWrapper.py
@@ -506,7 +506,8 @@ class DbWrapper:
             "SELECT gym.gym_id, gym.latitude, gym.longitude, "
             "gymdetails.name, gymdetails.url, gym.team_id, "
             "gym.last_modified, raid.level, raid.spawn, raid.start, "
-            "raid.end, raid.pokemon_id, raid.form, gym.last_scanned "
+            "raid.end, raid.pokemon_id, raid.form, raid.costume, "
+            "raid.evolution, gym.last_scanned "
             "FROM gym "
             "INNER JOIN gymdetails ON gym.gym_id = gymdetails.gym_id "
             "LEFT JOIN raid ON raid.gym_id = gym.gym_id "
@@ -541,7 +542,7 @@ class DbWrapper:
         res = self.execute(query + query_where)
 
         for (gym_id, latitude, longitude, name, url, team_id, last_updated,
-             level, spawn, start, end, mon_id, form, last_scanned) in res:
+             level, spawn, start, end, mon_id, form, costume, evolution, last_scanned) in res:
 
             nowts = datetime.utcfromtimestamp(time.time()).timestamp()
 
@@ -555,7 +556,9 @@ class DbWrapper:
                     "end": int(end.replace(tzinfo=timezone.utc).timestamp()),
                     "mon": mon_id,
                     "form": form,
-                    "level": level
+                    "level": level,
+                    "costume": costume,
+                    "evolution": evolution
                 }
 
             gyms[gym_id] = {

--- a/scripts/SQL/rocketmap.sql
+++ b/scripts/SQL/rocketmap.sql
@@ -160,6 +160,7 @@ CREATE TABLE `raid` (
     `is_exclusive` tinyint(1) DEFAULT NULL,
     `gender` tinyint(1) DEFAULT NULL,
     `costume` tinyint(1) DEFAULT NULL,
+    `evolution` smallint(6) DEFAULT NULL,
     PRIMARY KEY (`gym_id`),
     KEY `raid_level` (`level`),
     KEY `raid_spawn` (`spawn`),


### PR DESCRIPTION
This will add a new `evolution` column to the `raid` table. Default value is always "0" but keep in mind, that old raids in the DB may still be set to NULL. This will update over time.

Webhook notifications for raids include the `evolution` property as well.