### PR TITLE
Quick-fix for missing workers in Inject Location

### DIFF
--- a/static/madmin/static/js/madmin.js
+++ b/static/madmin/static/js/madmin.js
@@ -393,9 +393,9 @@ new Vue({
             this.updateBounds(true);
         },
         map_fetch_workers() {
-            if (!this.layers.stat.workers) {
-                return;
-            }
+            //if (!this.layers.stat.workers) {
+            //    return;
+            //}
 
             this.mapGuardedFetch("workers", "get_workers", function (res) {
                 res.data.forEach(function (worker) {

--- a/static/madmin/static/js/madmin.js
+++ b/static/madmin/static/js/madmin.js
@@ -393,10 +393,6 @@ new Vue({
             this.updateBounds(true);
         },
         map_fetch_workers() {
-            //if (!this.layers.stat.workers) {
-            //    return;
-            //}
-
             this.mapGuardedFetch("workers", "get_workers", function (res) {
                 res.data.forEach(function (worker) {
                     const name = worker["name"];


### PR DESCRIPTION
After #959 . We need workers to use them in Inject Location (right bottom corner, satellite dish icon) https://github.com/Map-A-Droid/MAD/blob/41047464753eba5612874bc70fdab1799f1b1d39/static/madmin/templates/map.html#L213 - without enabled workers layer list was empty. I don't think enabling workers here should kill performance (one more GETs), but maybe we want it 'on-demand' before opening Inject Location modal? @MrJul you decide, kinda nuking all this nice job of not requesting 175781785871578178 of GETs every few seconds :D