### PR TITLE
add option to ignore backlog mitm data

### DIFF
--- a/mapadroid/mitm_receiver/MITMReceiver.py
+++ b/mapadroid/mitm_receiver/MITMReceiver.py
@@ -225,6 +225,8 @@ class MITMReceiver(Process):
                 data_processor.start()
                 self.worker_threads.append(data_processor)
 
+        self.__mitmreceiver_startup_time: float = time.time()
+
     def shutdown(self):
         logger.info("MITMReceiver stop called...")
         logger.info("Adding None to queue")
@@ -260,6 +262,7 @@ class MITMReceiver(Process):
         origin_logger = get_origin_logger(logger, origin=origin)
         origin_logger.debug2("Receiving proto")
         origin_logger.debug4("Proto data received {}", data)
+
         if isinstance(data, list):
             # list of protos... we hope so at least....
             origin_logger.debug2("Receiving list of protos")
@@ -284,10 +287,12 @@ class MITMReceiver(Process):
             return
 
         timestamp: float = data.get("timestamp", int(time.time()))
+        if self.__application_args.mitm_ignore_pre_boot is True and timestamp < self.__mitmreceiver_startup_time:
+            return
+
         location_of_data: Location = Location(data.get("lat", 0.0), data.get("lng", 0.0))
         if (location_of_data.lat > 90 or location_of_data.lat < -90 or
                 location_of_data.lng > 180 or location_of_data.lng < -180):
-            origin_logger.warning("Received invalid location in data: {}", location_of_data)
             location_of_data: Location = Location(0, 0)
         self.__mitm_mapper.update_latest(origin, timestamp_received_raw=timestamp,
                                          timestamp_received_receiver=time.time(), key=proto_type, values_dict=data,

--- a/mapadroid/utils/walkerArgs.py
+++ b/mapadroid/utils/walkerArgs.py
@@ -64,6 +64,8 @@ def parse_args():
                         help='Port to listen on for proto data (MITM data). Default: 8000.')
     parser.add_argument('-mrdw', '--mitmreceiver_data_workers', type=int, default=2,
                         help='Amount of workers to work off the data that queues up. Default: 2.')
+    parser.add_argument('-mipb', '--mitm_ignore_pre_boot', default=False, type=bool,
+                        help='Ignore MITM data having a timestamp pre MAD\'s startup time.')
 
     # WEBSOCKET
     parser.add_argument('-wsip', '--ws_ip', required=False, default="0.0.0.0", type=str,


### PR DESCRIPTION
If MAD is not available, PD will perform several retries to send mitm
data to MAD. Due to recent changes in 0.185.0, the amount of data coming
in from the game grew quite a lot. This can cause issue for dozens of
devices filling up the queue without it being processed fast enough.

Either start MAD with `--mitm_ignore_pre_boot` / `-mipb` or just add
`mitm_ignore_pre_boot` without any value to your config.ini.