### PR TITLE
Optimized mon statistics page load

### DIFF
--- a/mapadroid/patcher/__init__.py
+++ b/mapadroid/patcher/__init__.py
@@ -40,6 +40,7 @@ MAD_UPDATES = OrderedDict([
     (33, 'routecalc_rename'),
     (34, 'trs_stats_detect_raw_split'),
     (35, 'madrom_autoconfig'),
+    (36, 'pokemon_iv_index')
 ])
 
 

--- a/mapadroid/patcher/pokemon_iv_index.py
+++ b/mapadroid/patcher/pokemon_iv_index.py
@@ -1,0 +1,24 @@
+from ._patch_base import PatchBase
+
+
+class Patch(PatchBase):
+    name = 'Add pokemon_iv index'
+
+    def _execute(self):
+        add_new_index = (
+            "ALTER TABLE pokemon "
+            "ADD INDEX pokemon_iv (individual_attack, individual_defense, individual_stamina)"
+        )
+        drop_old_index = (
+            "ALTER TABLE pokemon "
+            "DROP INDEX pokemon_individual_attack"
+        )
+
+        try:
+            if not self._schema_updater.check_index_exists('pokemon', 'pokemon_iv'):
+                self._db.execute(add_new_index, commit=True)
+            if self._schema_updater.check_index_exists('pokemon', 'pokemon_individual_attack'):
+                self._db.execute(drop_old_index, commit=True)
+        except Exception as e:
+            self._logger.exception("Unexpected error: {}", e)
+            self.issues = True

--- a/scripts/SQL/rocketmap.sql
+++ b/scripts/SQL/rocketmap.sql
@@ -119,7 +119,7 @@ CREATE TABLE `pokemon` (
     KEY `pokemon_last_modified` (`last_modified`),
     KEY `pokemon_latitude_longitude` (`latitude`,`longitude`),
     KEY `pokemon_disappear_time_pokemon_id` (`disappear_time`,`pokemon_id`),
-    KEY `pokemon_individual_attack` (`individual_attack`)
+    KEY `pokemon_iv` (`individual_attack`, `individual_defense`, `individual_stamina`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `pokestop` (

--- a/static/madmin/templates/statistics/mon_statistics.html
+++ b/static/madmin/templates/statistics/mon_statistics.html
@@ -11,9 +11,9 @@
 <script type="text/javascript" src="static/js/jquery.flot.axislabels.js"></script>
 <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.6/js/dataTables.buttons.min.js"></script>
 <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.6/js/buttons.flash.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.2.0/jszip.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.68/pdfmake.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.68/vfs_fonts.js"></script>
 <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.6/js/buttons.html5.min.js"></script>
 <script>
     $(function () {
@@ -113,7 +113,7 @@
 
               setGrid('#show-data-good-pokemon', good_spawns, [
                   { data: 'id', title: 'Mon-ID' },
-                  { data: null, title: 'Mon' },
+                  { data: 'name', title: 'Mon' },
                   { data: 'lvl', title: 'Level' },
                   { data: 'cp', title: 'CP' },
                   { data: 'periode', title: 'Scantime' }
@@ -122,7 +122,9 @@
                 {
                   "targets": [1],
                   "render": function (data, type, row) {
-                    return `<div class="media"><img class="mr-3" src="${row.img}" width="50"><div class="media-body">${row.name}</div></div>`
+                      return type === "display"
+                          ? `<div class="media"><img class="mr-3" src="${row.img}" width="48" height="48"><div class="media-body">${row.name}</div></div>`
+                          : data;
                   }
                 }
               ]);
@@ -144,7 +146,7 @@
               $("#flot_spawn").UseTooltip();
             },
             complete: function () {
-                setTimeout($.unblockUI, 100);
+                $.unblockUI();
             }
 
         });
@@ -252,6 +254,7 @@
             "columns": columns,
             "ordering": true, "order": [],
             "columnDefs": defs,
+            "deferRender": true,
             "responsive": {{ responsive }},
             "lengthMenu": [ [10, 25, 50, 100, -1], [10, 25, 50, 100, "All"] ],
             dom: 'Blfrtip',
@@ -318,6 +321,8 @@
     }
     table.dataTable tr.odd { background-color: #F8F8F8; }
     table.dataTable tr.even { background-color: white; }
+    table.dataTable tr td { vertical-align: middle; }
+    table.dataTable tr td .media-body { margin: auto 0; }
 </style>
 {% endblock %}
 

--- a/static/madmin/templates/statistics/shiny_statistics.html
+++ b/static/madmin/templates/statistics/shiny_statistics.html
@@ -14,9 +14,9 @@
 <script type="text/javascript" src="static/js/jquery.flot.axislabels.js"></script>
 <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.6/js/dataTables.buttons.min.js"></script>
 <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.6/js/buttons.flash.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.2.0/jszip.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.68/pdfmake.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.68/vfs_fonts.js"></script>
 <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.6/js/buttons.html5.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.9.0/js/bootstrap-datepicker.min.js"></script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/timepicker@1.11.15/jquery.timepicker.min.js"></script>
@@ -343,6 +343,7 @@
             "columns": columns,
             "ordering": true, "order": [],
             "columnDefs": defs,
+            "deferRender": true,
             "responsive": {{ responsive }},
             "lengthMenu": [ [10, 25, 50, 100, -1], [10, 25, 50, 100, "All"] ],
             dom: 'Blfrtip',

--- a/static/madmin/templates/statistics/statistics.html
+++ b/static/madmin/templates/statistics/statistics.html
@@ -11,9 +11,9 @@
 <script type="text/javascript" src="static/js/jquery.flot.axislabels.js"></script>
 <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.6/js/dataTables.buttons.min.js"></script>
 <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.6/js/buttons.flash.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.2.0/jszip.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.68/pdfmake.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.68/vfs_fonts.js"></script>
 <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.6/js/buttons.html5.min.js"></script>
 <script>
 
@@ -338,6 +338,7 @@
             "columns": columns,
             "ordering": true, "order": [],
             "columnDefs": defs,
+            "deferRender": true,
             "responsive": {{ responsive }},
             "lengthMenu": [ [10, 25, 50, 100, -1], [10, 25, 50, 100, "All"] ],
             dom: 'Blfrtip',

--- a/static/madmin/templates/statistics/stop_quest_statistics.html
+++ b/static/madmin/templates/statistics/stop_quest_statistics.html
@@ -11,9 +11,9 @@
 <script type="text/javascript" src="static/js/jquery.flot.axislabels.js"></script>
 <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.6/js/dataTables.buttons.min.js"></script>
 <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.6/js/buttons.flash.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.2.0/jszip.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.68/pdfmake.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.68/vfs_fonts.js"></script>
 <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.6/js/buttons.html5.min.js"></script>
 <script>
     function setGrid(tableGridHtmlId, gridData, columns, defs) {
@@ -24,6 +24,7 @@
             "columns": columns,
             "ordering": true, "order": [],
             "columnDefs": defs,
+            "deferRender": true,
             "responsive": {{ responsive }},
             "lengthMenu": [ [10, 25, 50, 100, -1], [10, 25, 50, 100, "All"] ],
             dom: 'Blfrtip',


### PR DESCRIPTION
The mon statistics page took almost 8 seconds to load for me with 780k encounter rows in the db.

Here are the changes:

1. The recent 100% mons query was the main culprit. No indexes were used for this query: the one on `individual_attack` apparently wasn't sufficient. After adding on index on the 3 IV stats, the query is almost instant. I've also deleted the attack index since it's covered by the new one.

2. `pdfmake` has been updated; for some reason the older version was slow (hundreds of ms) to load.

3. Defered rendering has been enabled on DataTables: it avoid loading hundreds of mon images when only 10 rows are visible by default.

4. Images have a height to prevent row size from changing after the image is loaded.

TL;DR: 1s < 8s