### PR TITLE
Fixed double clicking on map preventing fence creation/editing

### DIFF
--- a/static/madmin/static/js/leaflet-event-forwarder.js
+++ b/static/madmin/static/js/leaflet-event-forwarder.js
@@ -46,7 +46,9 @@ const EventForwarder = L.Class.extend({
     },
 
     _onClick: function (event) {
-        this._propagateEvent(event);
+        if (this.isEnabled) {
+            this._propagateEvent(event);
+        }
     },
 
     _onMouseOut: function (event) {

--- a/static/madmin/templates/map.html
+++ b/static/madmin/templates/map.html
@@ -4,7 +4,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.6.0/leaflet.css" integrity="sha256-SHMGCYmST46SoyGgo4YR/9AlK1vf3ff84Aq9yK4hdqM=" crossorigin="anonymous" />
 <link rel="stylesheet" href="static/style/leaflet-easybutton.min.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.EasyButton/2.4.0/easy-button.min.css">
-<link rel="stylesheet" href="https://unpkg.com/@geoman-io/leaflet-geoman-free@2.6.0/dist/leaflet-geoman.css" />
+<link rel="stylesheet" href="https://unpkg.com/@geoman-io/leaflet-geoman-free@2.7.0/dist/leaflet-geoman.css" />
 <link rel="stylesheet" href="static/style/madmin.css?1596807250" />
 {% endblock %}
 
@@ -19,8 +19,8 @@ var setlng = {{ setlng }};
 <script src="static/js/leaflet-sidebar.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.EasyButton/2.4.0/easy-button.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.min.js"></script>
-<script src="https://unpkg.com/@geoman-io/leaflet-geoman-free@2.6.0/dist/leaflet-geoman.min.js"></script>
-<script src="static/js/leaflet-event-forwarder.js"></script>
+<script src="https://unpkg.com/@geoman-io/leaflet-geoman-free@2.7.0/dist/leaflet-geoman.min.js"></script>
+<script src="static/js/leaflet-event-forwarder.js?1599172474"></script>
 <script src="static/js/s2geometry.min.js"></script>
 <script src="static/js/madmin.js?1597161106"></script>
 {% endblock %}


### PR DESCRIPTION
Double clicking on the map while creating or editing a fence was adding two markers at the same location: the polygon became self-intersected, preventing further editing. It's fixed in leaflet-geoman 2.7.0, but the event forwarder was also messing with the fix.