### PR TITLE
Removed map duplicate computed properties

### DIFF
--- a/static/madmin/static/js/madmin.js
+++ b/static/madmin/static/js/madmin.js
@@ -255,13 +255,6 @@ new Vue({
             });
         }
     },
-    computed: {
-        sortedGeofences() {
-            return Object.values(this.layers.dyn.geofences).sort(function (x, y) {
-                return x.name.localeCompare(y.name, "en", {sensitivity: "base"});
-            });
-        }
-    },
     watch: {
         "layers.stat.gyms": function (newVal, oldVal) {
             if (newVal && !init) {


### PR DESCRIPTION
`computed` properties were duplicated in `madmin.js` (probably by a recent merge)