### PR TITLE
Give more info about 'got the data requested'

### DIFF
--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -173,8 +173,8 @@ class MITMBase(WorkerBase):
         if data_requested != LatestReceivedType.UNDEFINED:
             self.logger.success('Got the data requested, type = {}',
                                 str(data_requested) if isinstance(data_requested, Enum)
-                                else (str(type(data_requested)) + ' size = ' +
-                                str(len(str(data_requested))) + ' bytes'))
+                                                    else (str(type(data_requested)) + ' size = ' +
+                                                          str(len(str(data_requested))) + ' bytes'))
             self._reboot_count = 0
             self._restart_count = 0
             self._rec_data_time = datetime.now()

--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -173,8 +173,8 @@ class MITMBase(WorkerBase):
         if data_requested != LatestReceivedType.UNDEFINED:
             self.logger.success('Got the data requested, type = {}',
                                 str(data_requested) if isinstance(data_requested, Enum)
-                                                    else (str(type(data_requested)) + ' size = ' +
-                                                          str(len(str(data_requested))) + ' bytes'))
+                                 else (str(type(data_requested)) + ' size = ' +
+                                       str(len(str(data_requested))) + ' bytes'))
             self._reboot_count = 0
             self._restart_count = 0
             self._rec_data_time = datetime.now()

--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -171,7 +171,8 @@ class MITMBase(WorkerBase):
             self.logger.warning("Mappings/Routemanagers have changed, stopping worker to be created again")
             raise InternalStopWorkerException
         if data_requested != LatestReceivedType.UNDEFINED:
-            self.logger.success('Got the data requested, type = {}', str(data_requested) if isinstance(data_requested, Enum) else '<data-block>' )
+            self.logger.success('Got the data requested, type = {}',
+                                str(data_requested) if isinstance(data_requested, Enum) else '<data-block>')
             self._reboot_count = 0
             self._restart_count = 0
             self._rec_data_time = datetime.now()

--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -172,7 +172,9 @@ class MITMBase(WorkerBase):
             raise InternalStopWorkerException
         if data_requested != LatestReceivedType.UNDEFINED:
             self.logger.success('Got the data requested, type = {}',
-                                str(data_requested) if isinstance(data_requested, Enum) else '<data-block>')
+                                str(data_requested) if isinstance(data_requested, Enum)
+                                else (str(type(data_requested)) + ' size = ' +
+                                str(len(str(data_requested))) + ' bytes'))
             self._reboot_count = 0
             self._restart_count = 0
             self._rec_data_time = datetime.now()

--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -171,7 +171,7 @@ class MITMBase(WorkerBase):
             self.logger.warning("Mappings/Routemanagers have changed, stopping worker to be created again")
             raise InternalStopWorkerException
         if data_requested != LatestReceivedType.UNDEFINED:
-            self.logger.success('Got the data requested')
+            self.logger.success('Got the data requested, type = ' + (str(data_requested) if isinstance(data_requested, Enum) else '<data-block>') )
             self._reboot_count = 0
             self._restart_count = 0
             self._rec_data_time = datetime.now()

--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -171,7 +171,7 @@ class MITMBase(WorkerBase):
             self.logger.warning("Mappings/Routemanagers have changed, stopping worker to be created again")
             raise InternalStopWorkerException
         if data_requested != LatestReceivedType.UNDEFINED:
-            self.logger.success('Got the data requested, type = ' + (str(data_requested) if isinstance(data_requested, Enum) else '<data-block>') )
+            self.logger.success('Got the data requested, type = {}', str(data_requested) if isinstance(data_requested, Enum) else '<data-block>' )
             self._reboot_count = 0
             self._restart_count = 0
             self._rec_data_time = datetime.now()


### PR DESCRIPTION
I couldn't see a way to re-open PR968 ( https://github.com/Map-A-Droid/MAD/pull/968 ), so I've opened this new PR.

Please see last question on this PR.

With this update you will be able to see more information in the 'Got the data requested' log line.
Originally all you would see is a bunch of:
```
[           MITMBase:177 ] [S] Got the data requested
```
With 968 you would have seen:
```
[           MITMBase:177 ] [S] Got the data requested, type = LatestReceivedType.GMO
[           MITMBase:177 ] [S] Got the data requested, type = LatestReceivedType.MON
[           MITMBase:177 ] [S] Got the data requested, type = LatestReceivedType.STOP
[           MITMBase:177 ] [S] Got the data requested, type = FortSearchResultTypes.QUEST
[           MITMBase:177 ] [S] Got the data requested, type = <data-block>
```
But with this new expanded logging you will see lines like:
```
[           MITMBase:177 ] [S] Got the data requested, type = LatestReceivedType.GMO
[           MITMBase:177 ] [S] Got the data requested, type = LatestReceivedType.MON
[           MITMBase:177 ] [S] Got the data requested, type = LatestReceivedType.STOP
[           MITMBase:177 ] [S] Got the data requested, type = FortSearchResultTypes.QUEST
[           MITMBase:177 ] [S] Got the data requested, type = <class 'dict'> size = 7816 bytes
[           MITMBase:177 ] [S] Got the data requested, type = <class 'dict'> size = 61347 bytes
[           MITMBase:177 ] [S] Got the data requested, type = <class 'dict'> size = 351232 bytes
```

To expand on my earlier issue, originally I found a worker had been "sitting idle" at a pokestop for 12 hours.  The only thing in the MAD log was a constant repetition of:
```
[08-23 15:03:19.69] [           atv107] [  MITMDataProcessor:71  ] [I] Processing GMO received. Received at 2020-08-23 15:03:20
[08-23 15:03:29.77] [           atv107] [  MITMDataProcessor:71  ] [I] Processing GMO received. Received at 2020-08-23 15:03:30
[08-23 15:03:35.85] [           atv107] [           MITMBase:188 ] [W] Timeout waiting for data
[08-23 15:03:38.87] [           atv107] [           MITMBase:131 ] [I] Waiting for data after 2020-08-23 15:03:35.290276
[08-23 15:03:39.51] [           atv107] [  MITMDataProcessor:71  ] [I] Processing GMO received. Received at 2020-08-23 15:03:40
[08-23 15:03:39.88] [           atv107] [           MITMBase:174 ] [S] Got the data requested
[08-23 15:03:39.88] [           atv107] [       WorkerQuests:721 ] [I] Spin Stop
[08-23 15:03:39.89] [           atv107] [           MITMBase:131 ] [I] Waiting for data after 2020-08-23 15:03:35.488163
[08-23 15:03:40.89] [           atv107] [           MITMBase:174 ] [S] Got the data requested
[08-23 15:03:41.90] [           atv107] [       WorkerQuests:782 ] [W] Softban - return to main screen and open again...
[08-23 15:03:45.94] [           atv107] [       WorkerQuests:613 ] [W] Can't spin stop - no map info in GMO!
[08-23 15:03:45.94] [           atv107] [           MITMBase:131 ] [I] Waiting for data after 2020-08-23 15:03:42.721225
[08-23 15:03:49.45] [           atv107] [  MITMDataProcessor:71  ] [I] Processing GMO received. Received at 2020-08-23 15:03:50
[08-23 15:04:00.41] [           atv107] [  MITMDataProcessor:71  ] [I] Processing GMO received. Received at 2020-08-23 15:04:00
```
With this new logging I caught another worker after it had been "sitting idle" at a pokestop for 20 minutes.  This time the MAD log showed a repetition of:
```
[09-01 08:04:32.81] [           atv108] [  MITMDataProcessor:71  ] [I] Processing GMO received. Received at 2020-09-01 08:04:31
[09-01 08:04:42.72] [           atv108] [  MITMDataProcessor:71  ] [I] Processing GMO received. Received at 2020-09-01 08:04:41
[09-01 08:04:43.31] [           atv108] [           MITMBase:188 ] [W] Timeout waiting for data
[09-01 08:04:46.39] [           atv108] [           MITMBase:131 ] [I] Waiting for data after 2020-09-01 08:04:41.273749
[09-01 08:04:47.39] [           atv108] [           MITMBase:174 ] [S] Got the data requested, type = LatestReceivedType.STOP
[09-01 08:04:47.41] [           atv108] [       WorkerQuests:721 ] [I] Spin Stop
[09-01 08:04:47.41] [           atv108] [           MITMBase:131 ] [I] Waiting for data after 2020-09-01 08:04:40.839417
[09-01 08:04:48.42] [           atv108] [           MITMBase:174 ] [S] Got the data requested, type = FortSearchResultTypes.OUT_OF_RANGE
[09-01 08:04:49.43] [           atv108] [       WorkerQuests:782 ] [W] Softban - return to main screen and open again...
[09-01 08:04:52.97] [           atv108] [  MITMDataProcessor:71  ] [I] Processing GMO received. Received at 2020-09-01 08:04:51
[09-01 08:04:53.55] [           atv108] [       WorkerQuests:613 ] [W] Can't spin stop - no map info in GMO!
[09-01 08:04:53.55] [           atv108] [           MITMBase:131 ] [I] Waiting for data after 2020-09-01 08:04:51.024755
[09-01 08:05:02.96] [           atv108] [  MITMDataProcessor:71  ] [I] Processing GMO received. Received at 2020-09-01 08:05:01
[09-01 08:05:13.22] [           atv108] [  MITMDataProcessor:71  ] [I] Processing GMO received. Received at 2020-09-01 08:05:11
```
So, for some reason the worker was returning "STOP" data, but also returning "OUT_OF_RANGE" data, even though when I looked at the screen of the worker it was standing directly on top of the stop to spin.  I'm guessing there was a problem with the client getting game data, which I understand can happen.  But, I'm wondering why MAD didn't restart/reboot the client after a few minutes of this?

Does anyone understand the internals of this and can think of a way to get the client to restart/reboot after a few minutes of this problem?