### PR TITLE
Implement PTC as PogoAuth

### DIFF
--- a/mapadroid/data_manager/modules/device.py
+++ b/mapadroid/data_manager/modules/device.py
@@ -1,4 +1,3 @@
-from flask import url_for
 import re
 from typing import List, Optional
 from .resource import Resource

--- a/mapadroid/data_manager/modules/pogoauth.py
+++ b/mapadroid/data_manager/modules/pogoauth.py
@@ -1,5 +1,4 @@
-from collections import OrderedDict
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 from .resource import Resource
 from mapadroid.data_manager.dm_exceptions import UnknownIdentifier
 

--- a/mapadroid/madmin/routes/autoconf.py
+++ b/mapadroid/madmin/routes/autoconf.py
@@ -63,7 +63,7 @@ class AutoConfigManager(object):
         if not session:
             return redirect(url_for('autoconfig_pending'), code=302)
         return render_template('autoconfig_logs.html',
-                               subtab="autoconf_logs",
+                               subtab="autoconf_dev",
                                responsive=str(self._args.madmin_noresponsive).lower(),
                                session_id=session_id
                                )
@@ -139,7 +139,7 @@ class AutoConfigManager(object):
             return redirect(url_for('autoconfig_pending'), code=302)
         sql = "SELECT ag.`account_id`, ag.`username`\n"\
               "FROM `settings_pogoauth` ag\n"\
-              "LEFT JOIN `settings_device` sd ON sd.`account_id` = ag.`account_id`\n"\
+              "LEFT JOIN `settings_device` sd ON sd.`device_id` = ag.`device_id`\n"\
               "WHERE ag.`instance_id` = %s AND (sd.`device_id` IS NULL OR sd.`device_id` = %s)"
         ac_issues = AutoConfIssueGenerator(self._db, self._data_manager, self._args, self._storage_obj)
         _, issues_critical = ac_issues.get_issues()

--- a/mapadroid/madmin/routes/config.py
+++ b/mapadroid/madmin/routes/config.py
@@ -1,8 +1,10 @@
+from _collections import OrderedDict
 import json
 import os
 import re
 from flask import (render_template, request, redirect, url_for, Response)
 from flask_caching import Cache
+from typing import List, Tuple
 from mapadroid.data_manager import DataManagerException
 from mapadroid.madmin.functions import auth_required
 from mapadroid.utils.MappingManager import MappingManager
@@ -12,6 +14,7 @@ from mapadroid.data_manager.dm_exceptions import (
     ModeNotSpecified,
     ModeUnknown
 )
+from mapadroid.data_manager.modules.pogoauth import PogoAuth
 from mapadroid.utils.logging import get_logger, LoggerEnums
 
 
@@ -238,20 +241,22 @@ class MADminConfig(object):
     @logger.catch
     @auth_required
     def settings_devices(self):
-        sql = "SELECT ag.`account_id`, ag.`username`\n"\
-              "FROM `settings_pogoauth` ag\n"\
-              "LEFT JOIN `settings_device` sd ON sd.`account_id` = ag.`account_id`\n"\
-              "WHERE ag.`instance_id` = %%s AND ag.`login_type` = %%s AND (%s)"
-        where = ["sd.`device_id` IS NULL"]
-        args = [self._db.instance_id, 'google']
         try:
             identifier = request.args.get('id')
             int(identifier)
-            where.append("sd.`device_id` = %s")
-            args.append(identifier)
         except (TypeError, ValueError):
             pass
-        accounts = self._db.autofetch_all(sql % ' OR '.join(where), tuple(args))
+        ggl_accounts = PogoAuth.get_avail_accounts(self._data_manager,
+                                                   'google',
+                                                   device_id=identifier)
+        ptc_accounts = []
+        for account_id, account in PogoAuth.get_avail_accounts(self._data_manager,
+                                                              'ptc',
+                                                              device_id=identifier).items():
+            ptc_accounts.append({
+                'text': account['username'],
+                'id': account_id
+            })
         required_data = {
             'identifier': 'id',
             'base_uri': 'api_device',
@@ -265,8 +270,10 @@ class MADminConfig(object):
                 'pools': 'devicepool'
             },
             'passthrough': {
-                'accounts': accounts,
-                'requires_auth': not self._args.autoconfig_no_auth
+                'ggl_accounts': ggl_accounts,
+                'ptc_accounts': ptc_accounts,
+                'requires_auth': not self._args.autoconfig_no_auth,
+                'responsive': str(self._args.madmin_noresponsive).lower()
             }
         }
         return self.process_element(**required_data)
@@ -319,19 +326,20 @@ class MADminConfig(object):
     @logger.catch
     @auth_required
     def settings_pogoauth(self):
-        device_links = {}
-        available_devices = {}
-        for device_id, device in self._data_manager.get_root_resource('device').items():
-            if device['account_id'] is None:
-                available_devices[device_id] = device
-                continue
-            try:
-                current_id = request.args.get('id', None)
-                if current_id is not None and int(current_id) == device['account_id']:
-                    available_devices[device_id] = device
-            except ValueError:
-                pass
-            device_links[device['account_id']] = device
+        devices = self._data_manager.get_root_resource('device')
+        devs_google: List[Tuple[int, str]] = []
+        devs_ptc: List[Tuple[int, str]] = []
+        current_id = request.args.get('id', None)
+        try:
+            identifier = int(current_id)
+        except (TypeError, ValueError):
+            identifier = None
+        for dev_id, dev in PogoAuth.get_avail_devices(self._data_manager,
+                                                      auth_id=identifier).items():
+            devs_google.append((dev_id, dev['origin']))
+        for dev_id, dev in PogoAuth.get_avail_devices(self._data_manager,
+                                                      auth_id=identifier).items():
+            devs_ptc.append((dev_id, dev['origin']))
         required_data = {
             'identifier': 'id',
             'base_uri': 'api_pogoauth',
@@ -341,8 +349,9 @@ class MADminConfig(object):
             'html_all': 'settings_pogoauth.html',
             'subtab': 'pogoauth',
             'passthrough': {
-                'devices': available_devices,
-                'device_links': device_links
+                'devices': devices,
+                'devs_google': devs_google,
+                'devs_ptc': devs_ptc
             },
         }
         return self.process_element(**required_data)

--- a/mapadroid/madmin/routes/config.py
+++ b/mapadroid/madmin/routes/config.py
@@ -1,4 +1,3 @@
-from _collections import OrderedDict
 import json
 import os
 import re
@@ -251,8 +250,8 @@ class MADminConfig(object):
                                                    device_id=identifier)
         ptc_accounts = []
         for account_id, account in PogoAuth.get_avail_accounts(self._data_manager,
-                                                              'ptc',
-                                                              device_id=identifier).items():
+                                                               'ptc',
+                                                               device_id=identifier).items():
             ptc_accounts.append({
                 'text': account['username'],
                 'id': account_id

--- a/mapadroid/mitm_receiver/MITMReceiver.py
+++ b/mapadroid/mitm_receiver/MITMReceiver.py
@@ -407,8 +407,8 @@ class MITMReceiver(Process):
                 sql = "SELECT ag.`username`, ag.`password`\n"\
                       "FROM `settings_pogoauth` ag\n"\
                       "INNER JOIN `autoconfig_registration` ar ON ar.`device_id` = ag.`device_id`\n"\
-                      "WHERE ar.`session_id` = %s and ag.`instance_id` = %s"
-                login = self._db_wrapper.autofetch_row(sql, (session_id, self._db_wrapper.instance_id))
+                      "WHERE ar.`session_id` = %s and ag.`instance_id` = %s and ag.`login_type` = %s"
+                login = self._db_wrapper.autofetch_row(sql, (session_id, self._db_wrapper.instance_id, 'google'))
                 if login:
                     return Response(status=200, response='\n'.join([login['username'], login['password']]))
                 else:

--- a/mapadroid/mitm_receiver/MITMReceiver.py
+++ b/mapadroid/mitm_receiver/MITMReceiver.py
@@ -406,8 +406,7 @@ class MITMReceiver(Process):
             elif operation in ['google']:
                 sql = "SELECT ag.`username`, ag.`password`\n"\
                       "FROM `settings_pogoauth` ag\n"\
-                      "INNER JOIN `settings_device` sd ON sd.`account_id` = ag.`account_id`\n"\
-                      "INNER JOIN `autoconfig_registration` ar ON ar.`device_id` = sd.`device_id`\n"\
+                      "INNER JOIN `autoconfig_registration` ar ON ar.`device_id` = ag.`device_id`\n"\
                       "WHERE ar.`session_id` = %s and ag.`instance_id` = %s"
                 login = self._db_wrapper.autofetch_row(sql, (session_id, self._db_wrapper.instance_id))
                 if login:

--- a/mapadroid/patcher/__init__.py
+++ b/mapadroid/patcher/__init__.py
@@ -40,7 +40,8 @@ MAD_UPDATES = OrderedDict([
     (33, 'routecalc_rename'),
     (34, 'trs_stats_detect_raw_split'),
     (35, 'madrom_autoconfig'),
-    (36, 'pokemon_iv_index')
+    (36, 'pokemon_iv_index'),
+    (37, 'move_ptc_accounts'),
 ])
 
 

--- a/mapadroid/patcher/move_ptc_accounts.py
+++ b/mapadroid/patcher/move_ptc_accounts.py
@@ -55,7 +55,7 @@ class Patch(PatchBase):
                             'instance_id': self._db.instance_id
                         }
                         try:
-                            account_id = self._db.autoexec_insert('settings_pogoauth', auth_data)
+                            self._db.autoexec_insert('settings_pogoauth', auth_data)
                         except IntegrityError:
                             pass
         # Move Google / Incorrectly assigned PTC
@@ -89,4 +89,3 @@ class Patch(PatchBase):
             sql = "ALTER TABLE settings_device\n" \
                   "DROP COLUMN account_id;"
             self._db.execute(sql, raise_exc=False, suppress_log=True)
-

--- a/mapadroid/patcher/move_ptc_accounts.py
+++ b/mapadroid/patcher/move_ptc_accounts.py
@@ -15,11 +15,12 @@ class Patch(PatchBase):
     def _execute(self):
         # Backup the tables
         # Assume that the user has not been given GRANT FILE permissions so just do a manual export
-        sql = "SELECT `device_id`, `ptc_login`\n"\
-              "FROM `settings_device`\n"\
-              "WHERE `ptc_login` IS NOT NULL"
-        with open(os.path.join(self._application_args.temp_path, 'ptc_backup.json'), 'w+') as fh:
-            json.dump(self._db.autofetch_all(sql), fh)
+        if self._schema_updater.check_column_exists('settings_device', 'ptc_login'):
+            sql = "SELECT `device_id`, `ptc_login`\n"\
+                  "FROM `settings_device`\n"\
+                  "WHERE `ptc_login` IS NOT NULL"
+            with open(os.path.join(self._application_args.temp_path, 'ptc_backup.json'), 'w+') as fh:
+                json.dump(self._db.autofetch_all(sql), fh)
         # Add the device link
         if not self._schema_updater.check_column_exists('settings_pogoauth', 'device_id'):
             sql = "ALTER TABLE `settings_pogoauth`\n" \

--- a/mapadroid/patcher/move_ptc_accounts.py
+++ b/mapadroid/patcher/move_ptc_accounts.py
@@ -1,0 +1,92 @@
+import json
+import os
+from ._patch_base import PatchBase
+from mapadroid.utils.logging import get_logger, LoggerEnums
+from mysql.connector.errors import IntegrityError
+
+
+logger = get_logger(LoggerEnums.patcher)
+
+
+class Patch(PatchBase):
+    name = 'Move PTC Accounts'
+    descr = 'Move PTC accounts from device to pogoauth'
+
+    def _execute(self):
+        # Backup the tables
+        # Assume that the user has not been given GRANT FILE permissions so just do a manual export
+        sql = "SELECT `device_id`, `ptc_login`\n"\
+              "FROM `settings_device`\n"\
+              "WHERE `ptc_login` IS NOT NULL"
+        with open(os.path.join(self._application_args.temp_path, 'ptc_backup.json'), 'w+') as fh:
+            json.dump(self._db.autofetch_all(sql), fh)
+        # Add the device link
+        if not self._schema_updater.check_column_exists('settings_pogoauth', 'device_id'):
+            sql = "ALTER TABLE `settings_pogoauth`\n" \
+                  "     ADD `device_id` int(10) unsigned NULL\n" \
+                  "     AFTER `account_id`;"
+            self._db.execute(sql, raise_exc=True, suppress_log=True, commit=True)
+            sql = "ALTER TABLE `settings_pogoauth`\n"\
+                  "     ADD CONSTRAINT `fk_spa_device_id`\n"\
+                  "     FOREIGN KEY (`device_id`)\n"\
+                  "           REFERENCES `settings_device` (`device_id`)\n"\
+                  "           ON DELETE CASCADE"
+            self._db.execute(sql, raise_exc=True, suppress_log=True, commit=True)
+        # Move PTC
+        if self._schema_updater.check_column_exists('settings_device', 'ptc_login'):
+            sql = "SELECT `device_id`, `ptc_login`\n"\
+                  "FROM `settings_device`\n"\
+                  "WHERE `ptc_login` IS NOT NULL"
+            ptc_logins = self._db.autofetch_all(sql)
+            if ptc_logins:
+                for logins in ptc_logins:
+                    device_id = logins['device_id']
+                    for login in logins['ptc_login'].split("|"):
+                        try:
+                            username, password = login.split(',', 1)
+                        except ValueError:
+                            logger.critical('Invalid format for {}', login)
+                            continue
+                        auth_data = {
+                            'username': username,
+                            'password': password,
+                            'device_id': device_id,
+                            'login_type': 'ptc',
+                            'instance_id': self._db.instance_id
+                        }
+                        try:
+                            account_id = self._db.autoexec_insert('settings_pogoauth', auth_data)
+                        except IntegrityError:
+                            pass
+        # Move Google / Incorrectly assigned PTC
+        if self._schema_updater.check_column_exists('settings_device', 'account_id'):
+            sql = "SELECT `device_id`, `account_id`\n" \
+                  "FROM `settings_device`\n" \
+                  "WHERE `account_id` IS NOT NULL"
+            google_links = self._db.autofetch_all(sql)
+            if google_links:
+                for link in google_links:
+                    link_data = {
+                        'device_id': link['device_id'],
+                        'account_id': link['account_id']
+                    }
+                    where = {
+                        'account_id': link['account_id']
+                    }
+                    try:
+                        self._db.autoexec_update('settings_pogoauth', link_data, where_keyvals=where)
+                    except IntegrityError:
+                        pass
+        # Cleanup tables
+        if self._schema_updater.check_column_exists('settings_device', 'ptc_login'):
+            sql = "ALTER TABLE settings_device\n" \
+                  "DROP COLUMN ptc_login;"
+            self._db.execute(sql, raise_exc=False, suppress_log=True)
+        if self._schema_updater.check_column_exists('settings_device', 'account_id'):
+            sql = "ALTER TABLE settings_device\n"\
+                  " DROP FOREIGN KEY settings_device_ibfk_3"
+            self._db.execute(sql, raise_exc=False, suppress_log=True)
+            sql = "ALTER TABLE settings_device\n" \
+                  "DROP COLUMN account_id;"
+            self._db.execute(sql, raise_exc=False, suppress_log=True)
+

--- a/mapadroid/tests/api/test_device.py
+++ b/mapadroid/tests/api/test_device.py
@@ -66,3 +66,23 @@ class APIDevice(api_base.APITestBase):
         response = self.api.post(device_obj['uri'], json=payload, headers=headers)
         self.assertEqual(response.status_code, 204)
         self.remove_resources()
+
+    def test_ggl_as_ptc(self):
+        pogoauth = super().create_valid_resource('pogoauth')
+        payload = copy.copy(global_variables.DEFAULT_OBJECTS['device']['payload'])
+        payload['ptc_login'] = [pogoauth['uri']]
+        res = self.api.post(global_variables.DEFAULT_OBJECTS['device']['uri'], json=payload)
+        self.assertTrue(res.status_code == 422)
+        self.assertTrue('invalid' in res.json())
+        self.assertTrue(res.json()['invalid'][0][0] == 'ptc_login')
+
+    def test_ptc_as_ggl(self):
+        payload = copy.copy(global_variables.DEFAULT_OBJECTS['pogoauth']['payload'])
+        payload['login_type'] = 'ptc'
+        pogoauth = super().create_valid_resource('pogoauth', payload=payload)
+        payload = copy.copy(global_variables.DEFAULT_OBJECTS['device']['payload'])
+        payload['ggl_login'] = pogoauth['uri']
+        res = self.api.post(global_variables.DEFAULT_OBJECTS['device']['uri'], json=payload)
+        self.assertTrue(res.status_code == 422)
+        self.assertTrue('invalid' in res.json())
+        self.assertTrue(res.json()['invalid'][0][0] == 'ggl_login')

--- a/mapadroid/tests/api/test_pogoauth.py
+++ b/mapadroid/tests/api/test_pogoauth.py
@@ -66,39 +66,10 @@ class APIPogoAuth(api_base.APITestBase):
         self.remove_resources()
 
     def test_device_dependency(self):
-        pogoauth_obj = super().create_valid_resource('pogoauth')
-        dev_payload = copy.copy(global_variables.DEFAULT_OBJECTS['device']['payload'])
-        dev_payload['account_id'] = pogoauth_obj['uri']
-        super().create_valid_resource('device', payload=dev_payload)
+        dev_info = super().create_valid_resource('device')
+        pogo_payload = copy.copy(global_variables.DEFAULT_OBJECTS['pogoauth']['payload'])
+        pogo_payload['device_id'] = dev_info['uri']
+        pogoauth_obj = super().create_valid_resource('pogoauth', payload=pogo_payload)
         response = self.api.delete(pogoauth_obj['uri'])
         self.assertEqual(response.status_code, 412)
         self.remove_resources()
-
-    def test_duplicate_assignment_from_auth(self):
-        pogoauth_1 = super().create_valid_resource('pogoauth')
-        dev_payload = copy.copy(global_variables.DEFAULT_OBJECTS['device']['payload'])
-        dev_payload['account_id'] = pogoauth_1['uri']
-        dev_info_1 = super().create_valid_resource('device', payload=dev_payload)
-        pogoauth_2 = super().create_valid_resource('pogoauth')
-        dev_payload = copy.copy(global_variables.DEFAULT_OBJECTS['device']['payload'])
-        dev_payload['account_id'] = pogoauth_2['uri']
-        super().create_valid_resource('device', payload=dev_payload)
-        data = {
-            'device_id': dev_info_1['uri']
-        }
-        res = self.api.patch(pogoauth_2['uri'], json=data)
-        self.assertTrue(res.status_code == 422)
-
-    def test_duplicate_assignment_from_device(self):
-        pogoauth_1 = super().create_valid_resource('pogoauth')
-        dev_payload = copy.copy(global_variables.DEFAULT_OBJECTS['device']['payload'])
-        dev_payload['account_id'] = pogoauth_1['uri']
-        super().create_valid_resource('device', payload=dev_payload)
-        dev_payload = copy.copy(global_variables.DEFAULT_OBJECTS['device']['payload'])
-        dev_payload['account_id'] = pogoauth_1['uri']
-        dev_info = super().create_valid_resource('device',)
-        data = {
-            'account_id': pogoauth_1['uri']
-        }
-        res = self.api.patch(dev_info['uri'], json=data)
-        self.assertTrue(res.status_code == 422)

--- a/mapadroid/tests/test_autoconfig.py
+++ b/mapadroid/tests/test_autoconfig.py
@@ -3,7 +3,6 @@ from functools import wraps
 import json
 from typing import Any
 from unittest import TestCase
-import mapadroid.tests.test_variables as global_variables
 from mapadroid.tests.test_utils import get_connection_api, get_connection_mitm, ResourceCreator, GetStorage
 from mapadroid.utils.walkerArgs import parse_args
 from mapadroid.utils.autoconfig import AutoConfIssues

--- a/mapadroid/tests/test_autoconfig.py
+++ b/mapadroid/tests/test_autoconfig.py
@@ -52,18 +52,18 @@ def basic_autoconf(func) -> Any:
                 res = self.mitm.post('/autoconfig/register')
                 self.assertTrue(res.status_code == 201)
                 session_id = res.content.decode('utf-8')
+                # Create device
+                (dev_info, _) = api_creator.create_valid_resource('device')
                 # Create Google Account
                 gacc = {
                     "login_type": "google",
                     "username": "Unit",
-                    "password": "Test"
+                    "password": "Test",
+                    "device_id": dev_info['uri']
                 }
                 res = self.api.post('/api/pogoauth', json=gacc)
-                gacct = res.headers['X-URI']
                 self.assertTrue(res.status_code == 201)
-                dev_payload = copy.copy(global_variables.DEFAULT_OBJECTS['device']['payload'])
-                dev_payload['account_id'] = gacct
-                (dev_info, _) = api_creator.create_valid_resource('device', payload=dev_payload)
+                gacct = res.headers['X-URI']
                 accept_info = {
                     'status': 1,
                     'device_id': dev_info['uri']

--- a/mapadroid/utils/MappingManager.py
+++ b/mapadroid/utils/MappingManager.py
@@ -478,6 +478,10 @@ class MappingManager:
             walker = int(device["walker"])
             device_dict["adb"] = device.get("adbname", None)
             pool = device.get("pool", None)
+            device_dict['ptc_login'] = []
+            for account_id in device.get("ptc_login", []):
+                account = self.__data_manager.get_resource('pogoauth', identifier=account_id)
+                device_dict['ptc_login'].append((account['username'], account['password']))
             settings = device.get("settings", None)
             try:
                 device_dict["settings"] = self.__inherit_device_settings(settings,

--- a/mapadroid/utils/autoconfig.py
+++ b/mapadroid/utils/autoconfig.py
@@ -25,8 +25,7 @@ class AutoConfIssueGenerator(object):
         self.critical: List[AutoConfIssues] = []
         sql = "SELECT count(*)\n" \
               "FROM `settings_pogoauth` ag\n" \
-              "LEFT JOIN `settings_device` sd ON sd.`account_id` = ag.`account_id`\n" \
-              "WHERE ag.`instance_id` = %s AND sd.`device_id` IS NULL"
+              "WHERE ag.`instance_id` = %s AND ag.`device_id` IS NULL"
         if db.autofetch_value(sql, (db.instance_id)) == 0 and not args.autoconfig_no_auth:
             self.warnings.append(AutoConfIssues.no_ggl_login)
         if not validate_hopper_ready(data_manager):

--- a/scripts/SQL/rocketmap.sql
+++ b/scripts/SQL/rocketmap.sql
@@ -378,7 +378,6 @@ CREATE TABLE `settings_device` (
     `screendetection` tinyint(1) DEFAULT NULL,
     `logintype` enum('google','ptc') COLLATE utf8mb4_unicode_ci DEFAULT NULL,
     `ggl_login_mail` varchar(256) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-    `ptc_login` varchar(256) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
     `clear_game_data` tinyint(1) DEFAULT NULL,
     `account_rotation` tinyint(1) DEFAULT NULL,
     `rotation_waittime` float DEFAULT NULL,
@@ -388,7 +387,6 @@ CREATE TABLE `settings_device` (
     `enhanced_mode_quest_safe_items` VARCHAR(500) NULL,
     `mac_address` VARCHAR(17) CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_unicode_ci' NULL,
     `interface_type` enum('lan','wlan') COLLATE utf8mb4_unicode_ci DEFAULT 'lan',
-    `account_id` int(10) unsigned NULL,
     PRIMARY KEY (`device_id`),
     KEY `settings_device_ibfk_1` (`walker_id`),
     KEY `settings_device_ibfk_2` (`pool_id`),
@@ -399,9 +397,7 @@ CREATE TABLE `settings_device` (
     CONSTRAINT `settings_device_ibfk_1` FOREIGN KEY (`walker_id`)
         REFERENCES `settings_walker` (`walker_id`),
     CONSTRAINT `settings_device_ibfk_2` FOREIGN KEY (`pool_id`)
-        REFERENCES `settings_devicepool` (`pool_id`),
-    CONSTRAINT `settings_device_ibfk_3` FOREIGN KEY (`account_id`)
-        REFERENCES `settings_pogoauth` (`account_id`)
+        REFERENCES `settings_devicepool` (`pool_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `settings_devicepool` (
@@ -792,6 +788,7 @@ CREATE TABLE `autoconfig_logs` (
 CREATE TABLE `settings_pogoauth` (
     `instance_id` int(10) unsigned NOT NULL,
     `account_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `device_id` int(10) unsigned NULL,
     `login_type` enum('google','ptc') COLLATE utf8mb4_unicode_ci NOT NULL,
     `username` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL,
     `password` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -799,7 +796,10 @@ CREATE TABLE `settings_pogoauth` (
     CONSTRAINT `fk_ac_g_instance` FOREIGN KEY (`instance_id`)
         REFERENCES `madmin_instance` (`instance_id`)
         ON DELETE CASCADE,
-    CONSTRAINT `settings_pogoauth_u1` UNIQUE (`login_type`, `username`)
+    CONSTRAINT `settings_pogoauth_u1` UNIQUE (`login_type`, `username`),
+    CONSTRAINT `fk_spa_device_id` FOREIGN KEY (`device_id`)
+            REFERENCES `settings_device` (`device_id`)
+            ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `origin_hopper` (

--- a/static/madmin/templates/settings_pogoauth.html
+++ b/static/madmin/templates/settings_pogoauth.html
@@ -84,8 +84,8 @@ $(document).ready(function () {
             <a href="{{ url_for('settings_pogoauth', id=auth_id) }}">{{ auth.username }}</a>
           </td>
           <td>
-            {% if device_links and auth_id in device_links %}
-             <a href="{{ url_for('settings_devices', id=device_links[auth_id].identifier) }}">{{ device_links[auth_id].origin }}</a>
+            {% if auth.device_id is not none %}
+             <a href="{{ url_for('settings_devices', id=devices[auth.device_id].identifier) }}">{{ devices[auth.device_id].origin }}</a>
             {% endif %}
           <td class="text-right align-middle">
             <a href="{{ redirect }}?id={{ auth_id }}"><button type="button" class="btn btn-success btn-sm edit" data-identifier="{{ loop.index }}"><i class="far fa-edit"></i></button></a>

--- a/static/madmin/templates/settings_singledevice.html
+++ b/static/madmin/templates/settings_singledevice.html
@@ -2,6 +2,7 @@
 
 {% block header %}
 {{ super() }}
+<link type="text/css" href="https://cdn.datatables.net/select/1.3.0/css/select.dataTables.min.css" rel="stylesheet" />
 {% endblock %}
 
 {% block scripts %}
@@ -11,6 +12,10 @@
 <link href="https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css" rel="stylesheet" />
 
 <script>
+var table;
+var selected = false;
+var ptc_accounts = {{  ptc_accounts|tojson }};
+
 $(document).ready(function () {
     $("#clearLevelup").click(function() {
         if(!confirm('Do you really wanna delete all information about visited pokestops for device {{ element.origin }}?')) {
@@ -55,20 +60,40 @@ $(document).ready(function () {
 
     var questModeUndeleteableItems = $(".enhanced_mode_quest_safe_items").data('default');
     if (questModeUndeleteableItems != "") {
-
         questModeUndeleteableItems = questModeUndeleteableItems.toString().replace(/\s/g, "").split(",")
         $('.enhanced_mode_quest_safe_items').val(questModeUndeleteableItems);
         $('.enhanced_mode_quest_safe_items').trigger('change');
 
     }
 
+
+    $(".ptc_login").select2({
+        data: ptc_accounts,
+        escapeMarkup: function(m) {
+            return m;
+        }
+    });
+    let ptc_account_selector = $(".ptc_login").data('default');
+    if (ptc_account_selector.length > 0) {
+        $('.ptc_login').val(ptc_account_selector);
+        $('.ptc_login').trigger('change');
+
+    }
 });
+
+function translate_ptc() {
+    var ptc = [];
+    $.each($(".ptc_login").val(), function () {
+        ptc.push("{{ url_for('api_pogoauth') }}/" + this);
+    });
+    return ptc;
+}
 </script>
 {% endblock %}
 
 {% block content %}
 {{ super() }}
-{% if requires_auth and element.origin and (not element.ptc_login and not element.account_id) %}
+{% if requires_auth and element.origin and (not element.ptc_login and not element.ggl_login) %}
     <div class="alert alert-warning">No Pogo Auth (Google or PTC) selected for the device.  During auto-configuration the device will not be able to automatically sign-in.</div>
 {% endif %}
 
@@ -130,22 +155,25 @@ $(document).ready(function () {
       <small class="form-text text-muted">ADB device name</small>
     </div>
     <div class="form-group">
-      <label for="account_id">Assigned email address</label>
-      <select class="form-control" name="account_id" data-default="{{ element.account_id if element.account_id else 'None' }}">
+      <label for="ggl_login">Assigned Google address</label>
+      <select class="form-control" name="ggl_login" data-default="{{ url_for('api_pogoauth') + '/'+ element.ggl_login|string if element.ggl_login else 'None' }}">
         <option value='None'>None</option>
-        {% if accounts is not none %}
-        {% for account in accounts %}
-         <option value="{{ account.account_id }}" {{ 'selected=selected' if element.account_id == account.account_id else "" }}>{{ account.username }}</option>
+        {% for account_id, account in ggl_accounts.items() %}
+         <option value="{{ url_for('api_pogoauth') + '/'+ account_id|string }}" {{ 'selected=selected' if element.ggl_login == account_id else "" }}>{{ account.username }}</option>
         {% endfor %}
-        {% endif %}
       </select>
       <small class="form-text text-muted">Aligned email for auto-configuration</small>
+    </div>
+    <div class="form-group">
+      <label for="ptc_login">Assigned PTC Account(s)</label>
+      <select class="form-control ptc_login" name="ptc_login" data-default="{{ element.ptc_login|string }}" data-callback='translate_ptc' multiple="multiple"></select>
+      <small class="form-text text-muted">Aligned PTC accounts to be used on the device</small>
     </div>
     <div class="form-group">
       <label for="interface_type">Active Interface</label>
       <select class="form-control" name="interface_type" data-default="{{ element.interface_type if element.interface_type else 'lan' }}">
         <option value="lan" {{ 'selected=selected' if element.interface_type == 'lan' else "" }}>LAN</option>
-        <option value="wlan" {{ 'selected=selected' if element.interface_type == 'wlan' else "" }}>WLAN</option>
+{#        <option value="wlan" {{ 'selected=selected' if element.interface_type == 'wlan' else "" }}>WLAN</option>#}
       </select>
     </div>
     <div class="form-group">

--- a/static/madmin/templates/settings_singlepogoauth.html
+++ b/static/madmin/templates/settings_singlepogoauth.html
@@ -8,6 +8,9 @@
 {{ super() }}
 <script type="text/javascript" src="{{ url_for('static', filename='js/madmin_settings.js') }}"></script>
 <script>
+var devices_google = {{ devs_google|tojson }};
+var devices_ptc = {{ devs_ptc|tojson }};
+
 $(document).ready(function () {
     $("#submit").click(function() {
         loadingBlockUI('Saving {{ subtab }}');
@@ -19,7 +22,36 @@ $(document).ready(function () {
             process_api_request("{{ uri }}", "{{ method }}", "{{ redirect }}");
         }
     });
+    $("select[name='login_type']").change(function() {
+        let dev_select = $("select[name='device_id']");
+        let devices = {}
+        dev_select.empty();
+        if($(".login_type").val() == 'google') {
+            devices = devices_google;
+        } else if($(".login_type").val() == 'ptc') {
+            devices = devices_ptc;
+        }
+        default_val = dev_select.data("default");
+        let option = document.createElement("OPTION");
+        option.value = "None";
+        option.text = "None"
+        dev_select.append(option);
+        $.each(devices, function(index) {
+            let device = devices[index];
+            let dev_id = device[0];
+            let dev_name = device[1];
+            let option = document.createElement("OPTION");
+            option.value = "{{ url_for('api_device') }}/"+ dev_id;
+            option.text = dev_name;
+            if(option.value == default_val) {
+                option.setAttribute('selected', 'selected');
+            }
+            dev_select.append(option);
+        });
+    });
+    $("select[name='login_type']").trigger( "change" );
 });
+
 </script>
 {% endblock %}
 
@@ -48,13 +80,7 @@ $(document).ready(function () {
     </div>
     <div class="form-group">
       <label for="device_id">Assigned Device</label>
-      <select class="form-control" name="device_id" data-default="{{ url_for('api_device') + '/'+ element.device_id|string if element.device_id else 'None' }}">
-        <option value='None'>None</option>
-        {% if devices is not none %}
-        {% for device_id, device in devices.items() %}
-         <option value="{{ url_for('api_device') + '/'+ device_id|string }}" {{ 'selected=selected' if element.device_id == device_id else "" }}>{{ device.origin }}</option>
-        {% endfor %}
-        {% endif %}
+      <select id="device_id" class="form-control" name="device_id" data-default="{{ url_for('api_device') + '/'+ element.device_id|string if element.device_id else 'None' }}">
       </select>
       <small class="form-text text-muted">Aligned Device</small>
     </div>


### PR DESCRIPTION
Implement PTC accounts to be used as PogoAuth credentials. Moved existing PTC accounts (ptc_login) into PogoAuth and auto-assigned to the device. This change also fixes #775 as the character limit is now 128 for the usesername and password (separately) and not tied to the device.

![image](https://user-images.githubusercontent.com/13160095/92781680-58365b00-f372-11ea-89aa-e16dec668004.png)
