### PR TITLE
Add more variations of Remote Raid Pass/Premium Battle Pass

### DIFF
--- a/mapadroid/worker/WorkerQuests.py
+++ b/mapadroid/worker/WorkerQuests.py
@@ -446,7 +446,8 @@ class WorkerQuests(MITMBase):
                      'Cadeau', 'Appareil photo', 'Wunderbox', 'Mystery Box', 'Boîte Mystère', 'Premium',
                      'Raid', 'Teil',
                      'Élément', 'mystérieux', 'Mysterious', 'Component', 'Mysteriöses', 'Remote', 'Fern',
-                     'Fern-Raid-Pass', 'Pass', 'Passe', 'distance')
+                     'Fern-Raid-Pass', 'Pass', 'Passe', 'distance', 'Remote Raid', 'Remote Pass',
+                     'Remote Raid Pass', 'Battle Pass', 'Premium Battle Pass', 'Premium Battle')
         x, y = self._resocalc.get_close_main_button_coords(self)
         self._communicator.click(int(x), int(y))
         time.sleep(1 + int(delayadd))


### PR DESCRIPTION
This looks like a long string ("Remote Raid Pass") does not really match short strings provided ("Remote", "Raid"). Plus the premium was renamed to "Battle" pass long time ago and with nice OCR it was still trying to delete it.
```
0.1 for Gift vs Remote Raid Pass
0.16666666666666666 for Geschenk vs Remote Raid Pass
0.08333333333333333 for Glücksei vs Remote Raid Pass
0.08 for Glucks-Ei vs Remote Raid Pass
0.08 for Glücks-Ei vs Remote Raid Pass
0.08 for Lucky Egg vs Remote Raid Pass
0.14814814814814814 for CEuf Chance vs Remote Raid Pass
0.2727272727272727 for Cadeau vs Remote Raid Pass
0.2 for Appareil photo vs Remote Raid Pass
0.08 for Wunderbox vs Remote Raid Pass
0.2222222222222222 for Mystery Box vs Remote Raid Pass
0.3448275862068966 for Boîte Mystère vs Remote Raid Pass
0.2608695652173913 for Premium vs Remote Raid Pass
0.4 for Raid vs Remote Raid Pass
0.2 for Teil vs Remote Raid Pass
0.17391304347826086 for Élément vs Remote Raid Pass
0.15384615384615385 for mystérieux vs Remote Raid Pass
0.3076923076923077 for Mysterious vs Remote Raid Pass
0.16 for Component vs Remote Raid Pass
0.37037037037037035 for Mysteriöses vs Remote Raid Pass
0.5454545454545454 for Remote vs Remote Raid Pass
0.1 for Fern vs Remote Raid Pass
0.6 for Fern-Raid-Pass vs Remote Raid Pass
0.4 for Pass vs Remote Raid Pass
0.38095238095238093 for Passe vs Remote Raid Pass
0.16666666666666666 for distance vs Remote Raid Pass
Deleting Remote Raid Pass
```

Was on threshold edge on Fern-Raid-Pass (???????), but not enough.