### PR TITLE
plugins: handle exceptions in walk_package, ignore hidden directories

### DIFF
--- a/mapadroid/utils/pluginBase.py
+++ b/mapadroid/utils/pluginBase.py
@@ -132,9 +132,9 @@ class PluginCollection(object):
         zipobj = zipfile.ZipFile(plugin_file_temp, 'w', zipfile.ZIP_DEFLATED)
         rootlen = len(folder) + 1
         for base, _, files in os.walk(folder):
-            if "__pycache__" not in base:
+            if "__pycache__" not in base and "/." not in base:
                 for file_to_zip in files:
-                    if file_to_zip != "plugin.ini":
+                    if file_to_zip != "plugin.ini" and not file_to_zip.startswith("."):
                         fn = os.path.join(base, file_to_zip)
                         zipobj.write(fn, fn[rootlen:])
 

--- a/mapadroid/utils/pluginBase.py
+++ b/mapadroid/utils/pluginBase.py
@@ -79,37 +79,42 @@ class PluginCollection(object):
     def walk_package(self, package):
         """Recursively walk the supplied package to retrieve all plugins
         """
-        imported_package = __import__(package, fromlist=['MAD'])
+        try:
+            imported_package = __import__(package, fromlist=['MAD'])
 
-        for _, pluginname, ispkg in pkgutil.iter_modules(imported_package.__path__, imported_package.__name__ + '.'):
-            if not ispkg:
-                plugin_module = __import__(pluginname, fromlist=['MAD'])
-                clsmembers = inspect.getmembers(plugin_module, inspect.isclass)
-                for (_, plugin) in clsmembers:
-                    # Only add classes that are a sub class of Plugin, but NOT Plugin itself
-                    if issubclass(plugin, Plugin) & (plugin is not Plugin):
-                        self._logger.info(f'Found plugin class: {plugin.__name__}')
-                        self.plugins.append({"plugin": plugin(self._mad),
-                                             "path": [package for package in imported_package.__path__][0]})
+            for _, pluginname, ispkg in pkgutil.iter_modules(imported_package.__path__,
+                                                             imported_package.__name__ + '.'):
+                if not ispkg:
+                    plugin_module = __import__(pluginname, fromlist=['MAD'])
+                    clsmembers = inspect.getmembers(plugin_module, inspect.isclass)
+                    for (_, plugin) in clsmembers:
+                        # Only add classes that are a sub class of Plugin, but NOT Plugin itself
+                        if issubclass(plugin, Plugin) & (plugin is not Plugin):
+                            self._logger.info(f'Found plugin class: {plugin.__name__}')
+                            self.plugins.append({"plugin": plugin(self._mad),
+                                                 "path": [package for package in imported_package.__path__][0]})
 
-        # Now that we have looked at all the modules in the current package, start looking
-        # recursively for additional modules in sub packages
-        all_current_paths = []
-        if isinstance(imported_package.__path__, str):
-            all_current_paths.append(imported_package.__path__)
-        else:
-            all_current_paths.extend([x for x in imported_package.__path__])
+            # Now that we have looked at all the modules in the current package, start looking
+            # recursively for additional modules in sub packages
+            all_current_paths = []
+            if isinstance(imported_package.__path__, str):
+                all_current_paths.append(imported_package.__path__)
+            else:
+                all_current_paths.extend([x for x in imported_package.__path__])
 
-        for pkg_path in all_current_paths:
-            if pkg_path not in self.seen_paths:
-                self.seen_paths.append(pkg_path)
+            for pkg_path in all_current_paths:
+                if pkg_path not in self.seen_paths:
+                    self.seen_paths.append(pkg_path)
 
-                # Get all sub directory of the current package path directory
-                child_pkgs = [p for p in os.listdir(pkg_path) if os.path.isdir(os.path.join(pkg_path, p))]
+                    # Get all sub directory of the current package path directory
+                    child_pkgs = [p for p in os.listdir(pkg_path) if os.path.isdir(os.path.join(pkg_path, p))
+                                  and not p.startswith(".")]
 
-                # For each sub directory, apply the walk_package method recursively
-                for child_pkg in child_pkgs:
-                    self.walk_package(package + '.' + child_pkg)
+                    # For each sub directory, apply the walk_package method recursively
+                    for child_pkg in child_pkgs:
+                        self.walk_package(package + '.' + child_pkg)
+        except Exception as e:
+            self._logger.opt(exception=True).error("Exception in walk_package on package {}: {}", package, e)
 
     def zip_plugin(self, plugin_name, folder, version):
         plugin_file_temp = os.path.join(self._mad['args'].temp_path, str(plugin_name) + '.tmp')


### PR DESCRIPTION
Fixing two issues:

* previously, unhandled exceptions caused by faulty plugins would stop loading subsequent plugins, now it'll be visible which plugin caused issues and why, and we'll be able to continue with subsequent plugins

* recursing into hidden directories caused an exception because the contruction of package names as `package + '.' + child_pkg` with child_pkg starting with a dot seems to have caused invalid package names. There should be no reason to recurse into directories that are hidden / starting with a dot.

Found, applied and tested somewhat extensively during development of my recent poracle pvp plugin.
Running several other private and public plugins with these changes applied without problems.