### PR TITLE
PTC / Data Manager fixes

### DIFF
--- a/mapadroid/data_manager/resource_search.py
+++ b/mapadroid/data_manager/resource_search.py
@@ -1,0 +1,19 @@
+import enum
+from typing import Tuple
+
+
+class SearchType(enum.Enum):
+    eq = 0
+    like = 1
+
+
+def get_search(search_key) -> Tuple[str, SearchType]:
+    """ Determines the searching parameters for the search field. Returns SearchType.eq if not present or invalid """
+    try:
+        search_key, search_type = search_key.split(".", 1)
+        if not hasattr(SearchType, search_type):
+            raise ValueError
+        search_type = getattr(SearchType, search_type)
+    except ValueError:
+        search_type = SearchType.eq
+    return search_key, search_type

--- a/mapadroid/patcher/move_ptc_accounts.py
+++ b/mapadroid/patcher/move_ptc_accounts.py
@@ -35,7 +35,7 @@ class Patch(PatchBase):
             self._db.execute(sql, raise_exc=True, suppress_log=True, commit=True)
         # Move PTC
         if self._schema_updater.check_column_exists('settings_device', 'ptc_login'):
-            sql = "SELECT `device_id`, `ptc_login`\n"\
+            sql = "SELECT `device_id`, `ptc_login`, `instance_id`\n"\
                   "FROM `settings_device`\n"\
                   "WHERE `ptc_login` IS NOT NULL"
             ptc_logins = self._db.autofetch_all(sql)
@@ -53,7 +53,7 @@ class Patch(PatchBase):
                             'password': password,
                             'device_id': device_id,
                             'login_type': 'ptc',
-                            'instance_id': self._db.instance_id
+                            'instance_id': logins['instance_id']
                         }
                         try:
                             self._db.autoexec_insert('settings_pogoauth', auth_data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ websockets>=7
 numpy~=1.18.0
 apkutils~=0.6.6
 matlink-gpapi~=0.4.4.5
-greenlet<0.4.17
+greenlet!=0.4.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ websockets>=7
 numpy~=1.18.0
 apkutils~=0.6.6
 matlink-gpapi~=0.4.4.5
+greenlet<0.4.17


### PR DESCRIPTION
 * Fixed an issue where conversion would not apply the correct instance_id to ptc accounts being converted
 * Implemented additional search functionality within the data manager (.eq and .like)
 * PogoAuth accounts are now pulled correctly with the search functionality update
 * Updated requirements.txt to not use greenlet 0.4.17 as it caused issues with py3.7