### PR TITLE
Make it possible to show cell updates that are newer than a setting

### DIFF
--- a/static/madmin/templates/map.html
+++ b/static/madmin/templates/map.html
@@ -174,6 +174,12 @@ var setlng = {{ setlng }};
                 <input id="questcoordinateradius" type="number" v-model="settings.routes.coordinateRadius.quests" max="1100" class="form-control form-control-sm" />
               </div>
             </li>
+              <li class="list-group-item layer-item d-flex">
+              <div class="flex-grow-1">Draw tiles newer than</div>
+              <div class="custom-control custom-switch">
+                <input id="cellupdatetimelimit" type="number" v-model="settings.cellUpdateTimeout" max="99900" class="form-control form-control-sm" />
+              </div>
+            </li>
             <li class="list-group-item layer-item d-flex">
               <div class="flex-grow-1">Map tiles</div>
               <div class="form-group">


### PR DESCRIPTION
I pushed the rest of these code changes in by accident (and nobody seems to notice).

This PR adds a new setting in madmin map that allows users to only show cell updates that are newer than a number of milliseconds (I want to change this to minutes or hours before mergin this PR)