### PR TITLE
Remove Wikimedia tileserver from maptiles

### DIFF
--- a/static/madmin/static/js/madmin.js
+++ b/static/madmin/static/js/madmin.js
@@ -226,10 +226,6 @@ new Vue({
                 name: "OpenStreetMap HOT",
                 url: "https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png"
             },
-            wikimedia: {
-                name: "Wikimedia",
-                url: "https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}{r}.png"
-            },
             hydda: {
                 name: "Hydda",
                 url: "https://{s}.tile.openstreetmap.se/hydda/full/{z}/{x}/{y}.png"


### PR DESCRIPTION
It's deprecated for 3rd parties, and use will be disallowed in the near future (slated for 2020-10-12; ie tomorrow as of writing)

https://lists.wikimedia.org/pipermail/maps-l/2020-August/001729.html
https://phabricator.wikimedia.org/T261424