### PR TITLE
Heatmap of non-IV's encounter

### DIFF
--- a/mapadroid/db/DbStatsReader.py
+++ b/mapadroid/db/DbStatsReader.py
@@ -374,7 +374,7 @@ class DbStatsReader:
     def get_noniv_encounters_count(self, minutes=240):
         logger.info("Fetching get_noniv_encounters_count")
         logger.debug3("Fetching get_noniv_encounters_count from db")
-        query_where = 'last_modified > \'%s\' ' % str(datetime.utcnow()-timedelta(minutes=int(minutes)))
+        query_where = 'last_modified > \'%s\' ' % str(datetime.utcnow() - timedelta(minutes=int(minutes)))
 
         query = (
             "SELECT count(1) as Count, latitude, longitude "

--- a/mapadroid/db/DbStatsReader.py
+++ b/mapadroid/db/DbStatsReader.py
@@ -370,3 +370,18 @@ class DbStatsReader:
         )
         count = self._db_exec.autofetch_value(query)
         return count
+    
+     def get_noniv_encounters_count(self, minutes=240):
+        logger.info("Fetching get_noniv_encounters_count")
+        logger.debug3("Fetching get_noniv_encounters_count from db")
+        query_where = 'last_modified > \'%s\' ' % str(datetime.utcnow()-timedelta(minutes=int(minutes)))
+
+        query = (
+            "SELECT count(1) as Count, latitude, longitude "
+            "FROM pokemon "
+            "WHERE cp IS NULL AND %s "
+            "GROUP BY latitude, longitude" % (query_where)
+        )
+        res = self._db_exec.execute(query)
+        logger.info("Done fetching get_noniv_encounters_count")
+        return res

--- a/mapadroid/db/DbStatsReader.py
+++ b/mapadroid/db/DbStatsReader.py
@@ -370,8 +370,8 @@ class DbStatsReader:
         )
         count = self._db_exec.autofetch_value(query)
         return count
-    
-     def get_noniv_encounters_count(self, minutes=240):
+
+    def get_noniv_encounters_count(self, minutes=240):
         logger.info("Fetching get_noniv_encounters_count")
         logger.debug3("Fetching get_noniv_encounters_count from db")
         query_where = 'last_modified > \'%s\' ' % str(datetime.utcnow()-timedelta(minutes=int(minutes)))

--- a/mapadroid/madmin/routes/statistics.py
+++ b/mapadroid/madmin/routes/statistics.py
@@ -793,7 +793,7 @@ class MADminStatistics(object):
         spawnpoints_total = self._db_stats_reader.get_all_spawnpoints_count()
         stats = {'fences': possible_fences, 'events': events, 'spawnpoints_count': spawnpoints_total}
         return jsonify(stats)
-    
+
     @logger.catch()
     @auth_required
     def get_noniv_encounters_count(self):
@@ -801,4 +801,3 @@ class MADminStatistics(object):
         data = self._db_stats_reader.get_noniv_encounters_count(minutes_spawn)
         stats = {'data': data}
         return jsonify(stats)
-

--- a/mapadroid/madmin/routes/statistics.py
+++ b/mapadroid/madmin/routes/statistics.py
@@ -55,6 +55,7 @@ class MADminStatistics(object):
             ("/reset_status_entry", self.reset_status_entry),
             ("/get_stop_quest_stats", self.get_stop_quest_stats),
             ("/statistics_stop_quest", self.statistics_stop_quest),
+            ("/get_noniv_encounters_count", self.get_noniv_encounters_count),
         ]
         for route, view_func in routes:
             self._app.route(route)(view_func)
@@ -792,3 +793,12 @@ class MADminStatistics(object):
         spawnpoints_total = self._db_stats_reader.get_all_spawnpoints_count()
         stats = {'fences': possible_fences, 'events': events, 'spawnpoints_count': spawnpoints_total}
         return jsonify(stats)
+    
+    @logger.catch()
+    @auth_required
+    def get_noniv_encounters_count(self):
+        minutes_spawn = request.args.get('minutes_spawn', 240)
+        data = self._db_stats_reader.get_noniv_encounters_count(minutes_spawn)
+        stats = {'data': data}
+        return jsonify(stats)
+

--- a/static/madmin/templates/statistics/mon_statistics.html
+++ b/static/madmin/templates/statistics/mon_statistics.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 
 {% block header %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.4/dist/leaflet.css" integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA==" crossorigin="" />
+<link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css" crossorigin="anonymous">
 {% endblock %}
 
 {% block scripts %}
@@ -15,8 +17,17 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.68/pdfmake.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.68/vfs_fonts.js"></script>
 <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.6/js/buttons.html5.min.js"></script>
+<script type="text/javascript" src="https://unpkg.com/leaflet@1.3.4/dist/leaflet.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.heat/0.2.0/leaflet-heat.js"></script>
+<script type="text/javascript" src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script
 <script>
     $(function () {
+		
+        const storedCenter = getStoredCenter();
+        var map = L.map("heatmap").setView(storedCenter.split(","), 12);
+        var tiles = L.tileLayer("https://{s}.basemaps.cartocdn.com/rastertiles/light_all/{z}/{x}/{y}.png").addTo(map);
+        var heat = L.heatLayer([], {radius: 10, blur: 5}).addTo(map);
+        var unfiltered_points = [];
 
         var options_dots = {
             xaxis: {
@@ -150,8 +161,20 @@
             }
 
         });
+	
+        $.ajax({
+            "url": "get_noniv_encounters_count",
+            "type": "GET",
+            "cache": false,
+            "dataType": "json",
+            success: function (result) {
+                console.log(result);
+                unfiltered_points = result.data.map(function (p) { return {"count": p[0], "lat": p[1], "lon": p[2]}; })
+                setupSlider();
+            }
+        });
 
-        var previousPoint = null, previousLabel = null;
+	var previousPoint = null, previousLabel = null;
 
         $.fn.UseTooltip = function () {
             $(this).bind("plothover", function (event, pos, item) {
@@ -244,6 +267,40 @@
                 'font-family': 'Verdana, Arial, Helvetica, Tahoma, sans-serif',
                 opacity: 0.9
             }).appendTo("body").fadeIn(200);
+        }
+	     
+        function setupSlider() {
+            $("#slider-range-max").slider({
+                range: "max",
+                min: 1,
+                max: Math.max.apply(Math, unfiltered_points.map(function(p) { return p.count; })),
+                value: 2,
+                slide: function(event, ui) {
+                    $("#slider-amount").val(ui.value);
+                    slider_redrawHeatmap();
+                }
+	    });
+            $("#slider-amount").val($("#slider-range-max").slider("value"));
+            slider_redrawHeatmap();
+        }
+
+        function slider_redrawHeatmap() {
+            min_val = $("#slider-amount").val()
+            heatmap_points = unfiltered_points.filter(p => p.count >= min_val)
+                             .map(p => [p.lat, p.lon]);
+            heat.setLatLngs(heatmap_points);
+        }
+
+        function getStoredCenter() {
+            var val = localStorage.getItem("settings");
+            if (val == null) {
+                return "52.521374,13.411201";
+            }
+            var settings = JSON.parse(val);
+            if (settings["center"] === undefined) {
+                return "52.521374,13.411201";
+            }
+            return settings["center"];
         }
 
         function setGrid(tableGridHtmlId, gridData, columns, defs) {
@@ -344,4 +401,11 @@
 <br>
 <h2>Recent IV 100 mon</h2>
 <table id="show-data-good-pokemon" class="table" style="width:100%;"></table>
+<h2>Heatmap of non-iv encounters in last 4 hours</h2>
+<div id="slider-range-max"></div>
+<p>
+  <label for="slider-amount">Minimum number of non-IV encounters per spawn:</label>
+  <input type="text" id="slider-amount" readonly style="border:0; color:#f6931f; font-weight:bold;">
+</p>
+<div id="heatmap" style="width:100%; height:600px;"></div>
 {% endblock %}

--- a/static/madmin/templates/statistics/mon_statistics.html
+++ b/static/madmin/templates/statistics/mon_statistics.html
@@ -19,7 +19,7 @@
 <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.6/js/buttons.html5.min.js"></script>
 <script type="text/javascript" src="https://unpkg.com/leaflet@1.3.4/dist/leaflet.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.heat/0.2.0/leaflet-heat.js"></script>
-<script type="text/javascript" src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script
+<script type="text/javascript" src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
 <script>
     $(function () {
 		


### PR DESCRIPTION
This should add heatmap of non-IV's encounters at the end of Statistics -> Mon Stats. This should help visualize where IV's are not getting checked enough and it's probably worth to add one more worker. This uses 4 hour window (by default, not configurable at this point, yet it's semi-ready) - please do check if after 4 hours of normal mon work (so don't try to check it in middle of questing at 4:00 am - it won't really show anything useful).

By default it will show location with 2+ times no IV checked at coords, slider should allow you to adjust how many non-IV encounters per spawn you want to see. You can in theory lower the slider back to 1 non-IV encounter but this will probably produce a lot of points and won't be useful.

I need someone with a lot (A LOT) of data to test it please - does it takes years to load? At the moment it downloads *all* data and filter it out in browser on each slider move - I would like to know if that does not LAG/KILL browser with a lot of data and it's probably worth to move data check to each slider move - request data again, with param of slider.

Also as always this will read your 'map position' from normal madmin map (default to Germany if never used) - just like shiny heatmap thing.
           