### PR TITLE
Remove repeated trashcan click in _clear_quests

### DIFF
--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -313,13 +313,8 @@ class MITMBase(WorkerBase):
             self._clear_quests_failcount = 0
             self.set_devicesettings_value('last_questclear_time', time.time())
             self.logger.info("Delete old quest {}", int(trash) + 1)
-            for i in range(3):
-                self.logger.debug("repeated trash click #{}", i + 1)
-                self._communicator.click(int(trashcancheck[0].x), int(trashcancheck[0].y))
-                time.sleep(0.3 + int(delayadd))
-            self.logger.debug("final trash click ...")
             self._communicator.click(int(trashcancheck[0].x), int(trashcancheck[0].y))
-            time.sleep(2.5 + int(delayadd))
+            time.sleep(4.5 + int(delayadd))
             self._communicator.click(int(x), int(y))
             time.sleep(1 + int(delayadd))
 


### PR DESCRIPTION
In earlier game versions, the confirmation dialogue to delete a quest wouldn't reliably pop up. Repeatedly clicking the trashcan symbol helped making sure we got the dialogue up.

Unfortunately, in recent game versions, clicking outside of the dialogue when it is already up causes it to close again. The repeated trashcan click is outside of the dialogue, thus it will close it and prevent confirming the deletion.

I observed this on a scanner device and confirmed it by manually trying it on my phone. Applying this fix improved the general quest scanning flow.