### PR TITLE
Feature: Clear finished quests

### DIFF
--- a/mapadroid/ocr/matching_trash.py
+++ b/mapadroid/ocr/matching_trash.py
@@ -64,7 +64,7 @@ def trash_image_matching(origin, screen_img, full_screen):
 
         last_y_coord = 0
         res = cv2.matchTemplate(screen, resized, cv2.TM_CCOEFF_NORMED)
-        threshold = 0.5
+        threshold = 0.65
         loc = np.where(res >= threshold)
         boxcount = 0
         for pt in zip(*loc[::-1]):

--- a/mapadroid/ocr/pogoWindows.py
+++ b/mapadroid/ocr/pogoWindows.py
@@ -616,7 +616,7 @@ class PogoWindows:
 
     def __check_finished_quest_internal(self, image, identifier):
         origin_logger = get_origin_logger(logger, origin=identifier)
-        results = dict.fromkeys(["breakthrough", "finished", "blocked"], [])
+        results = {"breakthrough": [], "finished": [], "blocked": []}
         globaldict: Optional[dict] = {}
         diff: int = 1
         origin_logger.debug("__check_finished_quest_interal")
@@ -652,11 +652,11 @@ class PogoWindows:
                         # get rgb values of a close "orange pixel" - the color differs between:
                         # the quest stack, normal finished quests, and quests blocked bc of the breakthrough
                         r, g, b = frame_org.getpixel((globaldict["left"][index], globaldict["top"][index] - 20 / diff))
-                        origin_logger.debug("rgb of this quest: {}/{}/{}", r, g, b)
+                        origin_logger.debug("Quest at {},{} has RGB: {}/{}/{}", left, top, r, g, b)
 
                         # breakthrough reward is in the upper half of the screen
                         if top < height / 2:
-                            origin_logger.debug("Found breakthrough reward  at coords {},{}", left, top)
+                            origin_logger.debug("Found breakthrough reward at coords {},{}", left, top)
                             results["breakthrough"].append({'x': left, 'y': top})
                         # finished quest - can be retrieved
                         elif 250 > r > 228 and b < 90:

--- a/mapadroid/ocr/pogoWindows.py
+++ b/mapadroid/ocr/pogoWindows.py
@@ -610,3 +610,69 @@ class PogoWindows:
             return None
 
         return returntype, globaldict, width, height, diff
+
+    def check_finished_quest(self, image, identifier):
+        return self.__thread_pool.apply_async(self.__check_finished_quest_internal, (image, identifier)).get()
+
+    def __check_finished_quest_internal(self, image, identifier):
+        origin_logger = get_origin_logger(logger, origin=identifier)
+        results = dict.fromkeys(["breakthrough", "finished", "blocked"], [])
+        globaldict: Optional[dict] = {}
+        diff: int = 1
+        origin_logger.debug("__check_finished_quest_interal")
+
+        try:
+            with Image.open(image) as frame_org:
+                width, height = frame_org.size
+                origin_logger.debug("Screensize: W:{} x H:{}", width, height)
+
+                if width < 1080:
+                    origin_logger.info('Resize screen ...')
+                    frame_org = frame_org.resize([int(2 * s) for s in frame_org.size], Image.ANTIALIAS)
+                    diff: int = 2
+
+                try:
+                    globaldict = pytesseract.image_to_data(frame_org, output_type=Output.DICT, timeout=40,
+                                                           config='--dpi 70')
+                except Exception as e:
+                    origin_logger.error("Tesseract Error: {}. Exception: {}", globaldict, e)
+                    globaldict = None
+
+                origin_logger.debug("Screentext: {}", globaldict)
+                if globaldict is None or 'text' not in globaldict:
+                    return results
+
+                n_boxes = len(globaldict['text'])
+                for index in range(n_boxes):
+                    if globaldict['text'][index] in ["REWARD!", "ABHOLEN!"]:
+                        # original screen coordinates
+                        left = globaldict["left"][index] / diff
+                        top = globaldict["top"][index] / diff
+
+                        # get rgb values of a close "orange pixel" - the color differs between:
+                        # the quest stack, normal finished quests, and quests blocked bc of the breakthrough
+                        r, g, b = frame_org.getpixel((globaldict["left"][index], globaldict["top"][index] - 20 / diff))
+                        origin_logger.debug("rgb of this quest: {}/{}/{}", r, g, b)
+
+                        # breakthrough reward is in the upper half of the screen
+                        if top < height / 2:
+                            origin_logger.debug("Found breakthrough reward  at coords {},{}", left, top)
+                            results["breakthrough"].append({'x': left, 'y': top})
+                        # finished quest - can be retrieved
+                        elif 250 > r > 228 and b < 90:
+                            origin_logger.debug("Found finished quest at coords {},{}", left, top)
+                            results["finished"].append({'x': left, 'y': top})
+                        # quest stack - to be ignored
+                        elif r > 228 and b < 90:
+                            origin_logger.debug("Found stacked quest at coords {},{}", left, top)
+                        else:
+                            origin_logger.debug("Found blocked quest at coords {},{}", left, top)
+                            results["blocked"].append({'x': left, 'y': top})
+        except (FileNotFoundError, ValueError) as e:
+            origin_logger.error("Failed opening image {} with exception {}", image, e)
+            return results
+
+        # reverse sort by y so that clicking will start from the bottom - starting from the top causes entries to move
+        if results["finished"]:
+            results["finished"] = sorted(results["finished"], key=lambda k: k['y'], reverse=True)
+        return results

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -784,6 +784,18 @@ class WorkerBase(AbstractWorker):
 
         return trashes
 
+    def _check_finished_quest(self, full_screen=False):
+        self.logger.warning("_check_finished_quest: Check finished quest.")
+        if not self._take_screenshot(delay_before=self.get_devicesettings_value("post_screenshot_delay", 1)):
+            self.logger.debug("_check_finished_quest: Failed getting screenshot")
+            return None
+
+        if os.path.isdir(self.get_screenshot_path()):
+            self.logger.error("_check_finished_quest: screenshot.png is not a file/corrupted")
+            return None
+
+        return self._pogoWindowManager.check_finished_quest(self.get_screenshot_path(), self._origin)
+
     def _take_screenshot(self, delay_after=0.0, delay_before=0.0, errorscreen: bool = False):
         self.logger.debug2("Taking screenshot...")
         time.sleep(delay_before)

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -785,7 +785,7 @@ class WorkerBase(AbstractWorker):
         return trashes
 
     def _check_finished_quest(self, full_screen=False):
-        self.logger.warning("_check_finished_quest: Check finished quest.")
+        self.logger.debug("_check_finished_quest: Check finished quest.")
         if not self._take_screenshot(delay_before=self.get_devicesettings_value("post_screenshot_delay", 1)):
             self.logger.debug("_check_finished_quest: Failed getting screenshot")
             return None


### PR DESCRIPTION
# Review and testing required !!!

Related issue: #869

The recent event bringing a "spin 3 pokestops" quest highlighted the problem of handling finished quests during quest scan. While it's not usually a problem on pure scanner accounts, events and changes can severely impact scan performance by introducing quests a quest scanner unintentionally finishes before it's able to delete them.

**The most stable way to handle this issue is usually to set `cleanup_every_spin` in area settings to `True`** (or using quest enhancer addon). However, this negatively impacts scan performance in dense areas, because the time and resource heavy ocr routines have to run more frequently.

However, this PR attempts to handle finished quests as far as a scanning software is able to. It works as follows:

1. If during quest deletion, less than the expected amount of trashcans is found, a check for finished quests will follow.
1. Using OCR, finished quests are identified by keyword
1. Finished quests are categorized according to screen position and color tint (stack, retrieveable, blocked have slightly different tints of orange)
1. Quests are handled accordingly - finished quests will be retrieved; when quests are blocked, it will be attempted to claim the weekly breakthrough and run. This will enable another 7 days of claiming quests
1. If quests remain blocked, an error will be logged saying the breakthrough has to be caught

In the end, this PR results in - ideally - requiring manual intervention once every 14 days to retrieve weekly breakthroughs, instead of possibly every day to clear up individual finished quests. It'll also explicitly identify the issue in the logs instead of the workers failing without an explicit cause.

Notes:

- the change in ` mapadroid/ocr/matching_trash.py` was necessary because quests blocked by the breakthrough were identified as having a trashcan - raising the threshold to `0.65` reliably fixed this without causing any false negatives
- successfully tested on a setup of >30 x96mini devices scanning > 2k quests daily. I achieved close to normal scanning performance despite the ongoing event with `cleanup_every_spin` set to `False`
- ...with default settings regarding screenshot filetype, quality
- I don't think it is necessary to make this feature optional as I can't see any negative impact - I'm open to other opinions on that, though
- **I consider further testing across different devices necessary**
