### PR TITLE
WorkerBase fixes

### DIFF
--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -705,7 +705,12 @@ class WorkerBase(AbstractWorker):
 
         cur_time = time.time()
         start_result = False
+        attempts = 0
         while not pogo_topmost:
+            attempts += 1
+            if attempts > 10:
+                self.logger.error("_start_pogo failed 10 times")
+                return False
             start_result = self._communicator.start_app(
                 "com.nianticlabs.pokemongo")
             time.sleep(1)

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -649,7 +649,10 @@ class WorkerBase(AbstractWorker):
 
             self._last_screen_type = screen_type
         self.logger.info('Checking pogo screen is finished')
-        return True
+        if screen_type in [ScreenType.POGO, ScreenType.QUEST]:
+            return True
+        else:
+            return False
 
     def _restart_pogo_safe(self):
         self.logger.warning("WorkerBase::_restart_pogo_safe restarting pogo the long way")

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -774,7 +774,8 @@ class WorkerBase(AbstractWorker):
                                                    99)
             return self._start_pogo()
         else:
-            return False
+            self.logger.error("Failed restarting PoGo - reboot device")
+            return self._reboot()
 
     def _get_trash_positions(self, full_screen=False):
         self.logger.debug2("_get_trash_positions: Get_trash_position.")


### PR DESCRIPTION
A little collection of small changes I made to WorkerBase and successfully tested on my setups over the last couple of weeks.

1. There are situations where `_ensure_pogo_topmost` can return without having accomplished the purpose its name indicates - imo it should truthfully return `False` in a case like that
1. There is a silent eternal loop in `_start_pogo` - if RGC is, for whatever reason (usually weird system freezes) permanently unable to launch pogo but still responding to MAD, it'll forever loop sleeping 1s, then trying to start pogo again, without any log output. Fixed by adding a counter + threshold and returning `False` upon reaching the threshold.
1. A failure of restarting pogo should not happen under normal circumstances and thus indicates an issue with the device, like (partial) freezing or improper operation of RGC. A reboot usually is the best way of handling situations like those.