### PR TITLE
Warning message when trying to run init and level

### DIFF
--- a/mapadroid/data_manager/modules/area.py
+++ b/mapadroid/data_manager/modules/area.py
@@ -108,7 +108,8 @@ class Area(Resource):
         try:
             if self._data['fields']['level'] and self._data['fields']['init']:
                 issues = {
-                    'invalid': [('init', 'You cannot run init and level at the same time. For leveling up init must be false')]
+                    'invalid': [('init', 'Cannot have init and level True at the same time. '
+                                         'For leveling up init must be set False')]
                 }
         except KeyError:
             pass

--- a/mapadroid/data_manager/modules/area.py
+++ b/mapadroid/data_manager/modules/area.py
@@ -105,4 +105,11 @@ class Area(Resource):
                 }
         except KeyError:
             pass
+        try:
+            if self._data['fields']['level'] and self._data['fields']['init']:
+                issues = {
+                    'invalid': [('init', 'You cannot run init and level at the same time. For leveling up init must be false')]
+                }
+        except KeyError:
+            pass
         return issues

--- a/mapadroid/data_manager/modules/area.py
+++ b/mapadroid/data_manager/modules/area.py
@@ -108,8 +108,8 @@ class Area(Resource):
         try:
             if self._data['fields']['level'] and self._data['fields']['init']:
                 issues = {
-                    'invalid': [('init', 'Cannot have init and level True at the same time. '
-                                         'For leveling up init must be set False')]
+                    'invalid': [('init', 'Cannot have init and level set to True at the same time. '
+                                         'For leveling up init must be set False.')]
                 }
         except KeyError:
             pass

--- a/mapadroid/tests/api/test_area.py
+++ b/mapadroid/tests/api/test_area.py
@@ -163,3 +163,19 @@ class APIArea(api_base.APITestBase):
         self.assertDictEqual(response.json(), expected)
         self.assertEqual(response.status_code, 422)
         self.remove_resources()
+
+    def test_invalid_initlevel_settings(self):
+        headers = {
+            'X-Mode': 'pokestop'
+        }
+        area_obj = super().create_valid_resource('area', headers=headers)
+        patch = {
+            'init': True,
+            'level': True
+        }
+        response = self.api.patch(area_obj['uri'], json=patch)
+        expected = {'invalid': [['init', 'Cannot have init and level set to True at the same time. '
+                                         'For leveling up init must be set False.']]}
+        self.assertDictEqual(response.json(), expected)
+        self.assertEqual(response.status_code, 422)
+        self.remove_resources()

--- a/mapadroid/tests/api/test_area.py
+++ b/mapadroid/tests/api/test_area.py
@@ -169,7 +169,7 @@ class APIArea(api_base.APITestBase):
             "name": "%s - Test Pokestop Area - %s",
         }
         headers = {
-            'X-Mode': 'pokestop'
+            'X-Mode': 'pokestops'
         }
         area_obj, resp = self.creator.create_valid_resource('area', payload=payload, headers=headers)
         patch = {

--- a/mapadroid/tests/api/test_area.py
+++ b/mapadroid/tests/api/test_area.py
@@ -165,10 +165,13 @@ class APIArea(api_base.APITestBase):
         self.remove_resources()
 
     def test_invalid_initlevel_settings(self):
+        payload = {
+            "name": "%s - Test Pokestop Area - %s",
+        }
         headers = {
             'X-Mode': 'pokestop'
         }
-        area_obj, resp = self.creator.create_valid_resource('area', headers=headers)
+        area_obj, resp = self.creator.create_valid_resource('area', payload=payload, headers=headers)
         patch = {
             'init': True,
             'level': True

--- a/mapadroid/tests/api/test_area.py
+++ b/mapadroid/tests/api/test_area.py
@@ -168,7 +168,7 @@ class APIArea(api_base.APITestBase):
         headers = {
             'X-Mode': 'pokestop'
         }
-        area_obj = super().create_valid_resource('area', headers=headers)
+        area_obj, resp = self.creator.create_valid_resource('area', headers=headers)
         patch = {
             'init': True,
             'level': True


### PR DESCRIPTION
This should be a proper place to put it, I guess.
I would assume we don't really need to check if mode is `pokestops` due to `level` being only in pokestops thing