### PR TITLE
Message error when can't save file to temp_path

### DIFF
--- a/mapadroid/ocr/pogoWindows.py
+++ b/mapadroid/ocr/pogoWindows.py
@@ -344,7 +344,7 @@ class PogoWindows:
         if not imwrite_status:
             origin_logger.error("Could not save file: {} - check permissions and path",
                                 os.path.join(self.temp_dir_path, str(identifier) + '_exitcircle.jpg'))
-            return False                
+            return False
 
         if self.__read_circle_count(os.path.join(self.temp_dir_path, str(identifier) + '_exitcircle.jpg'),
                                     identifier,

--- a/mapadroid/ocr/pogoWindows.py
+++ b/mapadroid/ocr/pogoWindows.py
@@ -339,8 +339,12 @@ class PogoWindows:
             origin_logger.error("Screenshot corrupted: {}", e)
             return False
 
-        cv2.imwrite(os.path.join(self.temp_dir_path,
+        imwrite_status = cv2.imwrite(os.path.join(self.temp_dir_path,
                                  str(identifier) + '_exitcircle.jpg'), image)
+        if not imwrite_status:
+            origin_logger.error("Could not save file: {} - check permissions and path",
+                              os.path.join(self.temp_dir_path, str(identifier) + '_exitcircle.jpg'))
+            return False                   
 
         if self.__read_circle_count(os.path.join(self.temp_dir_path, str(identifier) + '_exitcircle.jpg'),
                                     identifier,
@@ -428,7 +432,10 @@ class PogoWindows:
 
         # resize image
         gray = cv2.resize(gray, dim, interpolation=cv2.INTER_AREA)
-        cv2.imwrite(temp_path_item, gray)
+        imwrite_status = cv2.imwrite(temp_path_item, gray)
+        if not imwrite_status:
+            logger.error("Could not save file: {} - check permissions and path", temp_path_item)
+            return None
         try:
             with Image.open(temp_path_item) as im:
                 try:

--- a/mapadroid/ocr/pogoWindows.py
+++ b/mapadroid/ocr/pogoWindows.py
@@ -434,7 +434,7 @@ class PogoWindows:
         gray = cv2.resize(gray, dim, interpolation=cv2.INTER_AREA)
         imwrite_status = cv2.imwrite(temp_path_item, gray)
         if not imwrite_status:
-            logger.error("Could not save file: {} - check permissions and path", temp_path_item)
+            origin_logger.error("Could not save file: {} - check permissions and path", temp_path_item)
             return None
         try:
             with Image.open(temp_path_item) as im:

--- a/mapadroid/ocr/pogoWindows.py
+++ b/mapadroid/ocr/pogoWindows.py
@@ -340,11 +340,11 @@ class PogoWindows:
             return False
 
         imwrite_status = cv2.imwrite(os.path.join(self.temp_dir_path,
-                                 str(identifier) + '_exitcircle.jpg'), image)
+                                     str(identifier) + '_exitcircle.jpg'), image)
         if not imwrite_status:
             origin_logger.error("Could not save file: {} - check permissions and path",
-                              os.path.join(self.temp_dir_path, str(identifier) + '_exitcircle.jpg'))
-            return False                   
+                                os.path.join(self.temp_dir_path, str(identifier) + '_exitcircle.jpg'))
+            return False                
 
         if self.__read_circle_count(os.path.join(self.temp_dir_path, str(identifier) + '_exitcircle.jpg'),
                                     identifier,


### PR DESCRIPTION
cv2.imwrite will silently fail if it can't save image (for example due to permissions). It will not throw any error, just False/True as return.
Let's handle it, so next guy will waste less time on debugging