### PR TITLE
make questgen go fast

### DIFF
--- a/mapadroid/utils/questGen.py
+++ b/mapadroid/utils/questGen.py
@@ -108,7 +108,9 @@ def questtype(quest_type):
 
 
 def rewarditem(itemid):
-    return items[str(itemid)]['name']
+    if str(itemid) in items:
+        return items[str(itemid)]['name']
+    return "Item " + str(itemid)
 
 
 def pokemonname(id):

--- a/mapadroid/utils/questGen.py
+++ b/mapadroid/utils/questGen.py
@@ -9,12 +9,21 @@ gettext.find('quest', 'locales', all=True)
 lang = gettext.translation('quest', localedir='locale', fallback=True)
 lang.install()
 
+pokemon_types = open_json_file('pokemonTypes')
+items = open_json_file('items')
+quest_type_file = open_json_file('types')
+quest_templates = open_json_file('quest_templates')
+pokemen_file = open_json_file('pokemon')
+
+quest_rewards = {
+    2: _("Item"),
+    3: _("Stardust"),
+    7: _("Pokemon"),
+    12: _("Energy")
+}
+
 
 def generate_quest(quest):
-    gettext.find('quest', 'locales', all=True)
-    lang = gettext.translation('quest', localedir='locale', fallback=True)
-    lang.install()
-
     quest_reward_type = questreward(quest['quest_reward_type'])
     quest_type = questtype(quest['quest_type'])
     if '{0}' in quest_type:
@@ -88,44 +97,33 @@ def generate_quest(quest):
 
 
 def questreward(quest_reward_type):
-    type = {
-        2: _("Item"),
-        3: _("Stardust"),
-        7: _("Pokemon"),
-        12: _("Energy")
-    }
-    return type.get(quest_reward_type, "nothing")
+    return quest_rewards.get(quest_reward_type, "nothing")
 
 
 def questtype(quest_type):
-    file = open_json_file('types')
-    if str(quest_type) in file:
-        return file[str(quest_type)]['text']
+    if str(quest_type) in quest_type_file:
+        return quest_type_file[str(quest_type)]['text']
 
     return "Unknown quest type placeholder: {0}"
 
 
 def rewarditem(itemid):
-    file = open_json_file('items')
-    return (file[str(itemid)]['name'])
+    return items[str(itemid)]['name']
 
 
 def pokemonname(id):
-    file = open_json_file('pokemon')
-    return file[str(int(id))]["name"]
+    return pokemen_file[str(int(id))]["name"]
+
+
+def get_pokemon_type_str(pt):
+    return pokemon_types[str(pt)].title() + _('-type')
 
 
 def questtask(typeid, condition, target, quest_template):
     gettext.find('quest', 'locales', all=True)
-    lang = gettext.translation('quest', localedir='locale', fallback=True)
-    lang.install()
-
-    pokemonTypes = open_json_file('pokemonTypes')
-    items = open_json_file('items')
-    throwTypes = {"10": _("Nice"), "11": _("Great"),
-                  "12": _("Excellent"), "13": _("Curveball")}
-    arr = {}
-    arr['0'] = target
+    throw_types = {"10": _("Nice"), "11": _("Great"),
+                   "12": _("Excellent"), "13": _("Curveball")}
+    arr = {'0': target}
     text = questtype(typeid)
     # TODO use the dict instead of regex parsing in all logic
     condition_dict = {}
@@ -140,40 +138,43 @@ def questtask(typeid, condition, target, quest_template):
         arr['item'] = ""
 
         text = _("Catch {0}{different} {type}Pokemon{wb}")
-        match_object = re.search(r'"pokemon_type": \[([0-9, ]+)\]', condition)
-        if match_object is not None:
-            pt = match_object.group(1).split(', ')
-            last = len(pt)
-            cur = 1
-            if last == 1:
-                arr['type'] = pokemonTypes[pt[0]].title() + _('-type ')
-            else:
-                for ty in pt:
-                    arr['type'] += (_('or ') if last == cur else '') + \
-                                   pokemonTypes[ty].title() + (_('-type ')
-                                                               if last == cur else '-, ')
-                    cur += 1
-        if re.search(r'"type": 3', condition) is not None:
-            arr['wb'] = _(" with weather boost")
-        elif re.search(r'"type": 21', condition) is not None:
-            arr['different'] = _(" different species of")
-        match_object = re.search(r'"pokemon_ids": \[([0-9, ]+)\]', condition)
-        if match_object is not None:
-            pt = match_object.group(1).split(', ')
-            last = len(pt)
-            cur = 1
-            if last == 1:
-                arr['poke'] = i8ln(pokemonname(pt[0]))
-            else:
-                for ty in pt:
-                    arr['poke'] += (_('or ') if last == cur else '') + \
-                                   i8ln(pokemonname(ty)) + ('' if last == cur else ', ')
-                    cur += 1
-            text = _('Catch {0} {poke}')
+
+        for con in condition_dict:
+            condition_type = con.get('type', 0)
+            if condition_type == 1:
+                # Condition type 1 is pokemon_types
+                pokemon_type_array = con.get('with_pokemon_type', {}).get('pokemon_type', [])
+                num_of_pokemon_types = len(pokemon_type_array)
+                if num_of_pokemon_types > 1:
+                    arr['type'] = "{}- or {} ".format(
+                        _('-, ').join(pokemon_types[pt].title() for pt in pokemon_type_array[::-1]),
+                        get_pokemon_type_str(pokemon_type_array[-1]))
+                elif num_of_pokemon_types == 1:
+                    arr['type'] = get_pokemon_type_str(pokemon_type_array[0]) + " "
+            elif condition_type == 2:
+                # Condition type 2 is to catch certain kind of pokemons
+                pokemon_id_array = con.get('with_pokemon_category', {}).get('pokemon_ids', [])
+
+                if len(pokemon_id_array) > 0:
+                    text = _('Catch {0} {poke}')
+                    if len(pokemon_id_array) == 1:
+                        arr['poke'] = i8ln(pokemonname(pokemon_id_array[0]))
+                    else:
+                        # More than one mon, let's make sure to list them comma separated ending with or
+                        arr['poke'] = "{} or {} ".format(
+                            _(', ').join(i8ln(pokemonname(pt)) for pt in pokemon_id_array[::-1]),
+                            i8ln(pokemonname(pokemon_id_array[-1])))
+            elif condition_type == 3:
+                # Condition type 3 is weather boost.
+                arr['wb'] = _(" with weather boost")
+            elif condition_type == 21:
+                # condition type 21 is unique pokemon
+                arr['different'] = _(" different species of")
     elif typeid == 5:
-        text = _("Spin {0} Pokestops or Gyms")
-        if re.search(r'"type": 12', condition) is not None:
+        if '"type": 12' in condition:
             text = _("Spin {0} Pokestops you haven't visited before")
+        else:
+            text = _("Spin {0} Pokestops or Gyms")
     elif typeid == 6:
         text = _("Hatch {0} Eggs")
     elif typeid == 7:
@@ -234,10 +235,10 @@ def questtask(typeid, condition, target, quest_template):
                     last = len(pt)
                     cur = 1
                     if last == 1:
-                        arr['type'] = pokemonTypes[pt[0]].title() + _('-type ')
+                        arr['type'] = pokemon_types[pt[0]].title() + _('-type ')
                     else:
                         for ty in pt:
-                            arr['type'] += (_('or ') if last == cur else '') + pokemonTypes[ty].title() + (
+                            arr['type'] += (_('or ') if last == cur else '') + pokemon_types[ty].title() + (
                                 _('-type ') if last == cur else '-, ')
                             cur += 1
             if con.get('type', 0) == 2:
@@ -268,7 +269,7 @@ def questtask(typeid, condition, target, quest_template):
             arr['curve'] = _("Curveball ")
         match_object = re.search(r'"throw_type": ([0-9]{2})', condition)
         if match_object is not None:
-            arr['type'] = throwTypes[match_object.group(1)] + " "
+            arr['type'] = throw_types[match_object.group(1)] + " "
         text = _("Make {0} {type}{curve}Throws{inrow}")
     elif typeid == 17:
         text = _('Earn {0} Candies walking with your buddy')
@@ -346,10 +347,10 @@ def questtask(typeid, condition, target, quest_template):
                 last = len(pt)
                 cur = 1
                 if last == 1:
-                    arr['type'] = pokemonTypes[pt[0]].title() + _('-type ')
+                    arr['type'] = pokemon_types[pt[0]].title() + _('-type ')
                 else:
                     for ty in pt:
-                        arr['type'] += (_('or ') if last == cur else '') + pokemonTypes[ty].title() + (
+                        arr['type'] += (_('or ') if last == cur else '') + pokemon_types[ty].title() + (
                             _('-type ') if last == cur else '-, ')
                         cur += 1
     elif typeid == 29:
@@ -366,7 +367,6 @@ def questtask(typeid, condition, target, quest_template):
                 # TODO change WIN to Defeat like in-game
                 text = text.replace(_('Battle'), _('Defeat'))
 
-    quest_templates = open_json_file('quest_templates')
     if quest_template is not None and quest_template in quest_templates:
         text = _(quest_templates[quest_template])
 

--- a/start.py
+++ b/start.py
@@ -1,16 +1,22 @@
 import sys
+import os
+from mapadroid.utils.walkerArgs import parse_args
 
 py_version = sys.version_info
 if py_version.major < 3 or (py_version.major == 3 and py_version.minor < 6):
     print("MAD requires at least python 3.6! Your version: {}.{}"
           .format(py_version.major, py_version.minor))
     sys.exit(1)
+
+args = parse_args()
+os.environ['LANGUAGE'] = args.language
+
 from multiprocessing import Process
 from typing import Optional
 import calendar
 import datetime
 import gc
-import os
+
 import pkg_resources
 import time
 from threading import Thread, active_count
@@ -24,7 +30,7 @@ from mapadroid.utils.madGlobals import terminate_mad
 from mapadroid.utils.rarity import Rarity
 from mapadroid.utils.event import Event
 from mapadroid.patcher import MADPatcher
-from mapadroid.utils.walkerArgs import parse_args
+
 from mapadroid.websocket.WebsocketServer import WebsocketServer
 from mapadroid.utils.updater import DeviceUpdater
 from mapadroid.data_manager import DataManager
@@ -37,8 +43,7 @@ import unittest
 from mapadroid.utils.logging import init_logging, get_logger, LoggerEnums
 
 
-args = parse_args()
-os.environ['LANGUAGE'] = args.language
+
 init_logging(args)
 logger = get_logger(LoggerEnums.system)
 

--- a/start.py
+++ b/start.py
@@ -43,7 +43,6 @@ import unittest
 from mapadroid.utils.logging import init_logging, get_logger, LoggerEnums
 
 
-
 init_logging(args)
 logger = get_logger(LoggerEnums.system)
 


### PR DESCRIPTION
Only read quest related JSON once
Don't parse tasks as regex when we already have the condition objects at hand, or when regex is just a roundabout way to do str.contains()