### PR TITLE
Add Quest Type/Template for New AR Task

### DIFF
--- a/locale/en/types.json
+++ b/locale/en/types.json
@@ -146,5 +146,9 @@
   "43": {
     "prototext": "QUEST_MEGA_EVOLVE",
     "text": "Mega Evolve {0} Pokemon"
+  },
+  "46": {
+    "prototext": "GEOTARGETED_AR_SCAN",
+    "text": "AR Scan a Nearby Stop/Gym"
   }
 }


### PR DESCRIPTION
This probably isn't the ideal implementation as it would be nice to know where the quest is going to send you but from my limited programming knowledge it doesn't seem to be saved into the database at this time.

At least it is better than "Unknown quest type placeholder: a" :)