### PR TITLE
Add Stickers to not deletable items

### DIFF
--- a/mapadroid/worker/WorkerQuests.py
+++ b/mapadroid/worker/WorkerQuests.py
@@ -447,7 +447,7 @@ class WorkerQuests(MITMBase):
                      'Raid', 'Teil',
                      'Élément', 'mystérieux', 'Mysterious', 'Component', 'Mysteriöses', 'Remote', 'Fern',
                      'Fern-Raid-Pass', 'Pass', 'Passe', 'distance', 'Remote Raid', 'Remote Pass',
-                     'Remote Raid Pass', 'Battle Pass', 'Premium Battle Pass', 'Premium Battle')
+                     'Remote Raid Pass', 'Battle Pass', 'Premium Battle Pass', 'Premium Battle', 'Stickers')
         x, y = self._resocalc.get_close_main_button_coords(self)
         self._communicator.click(int(x), int(y))
         time.sleep(1 + int(delayadd))

--- a/mapadroid/worker/WorkerQuests.py
+++ b/mapadroid/worker/WorkerQuests.py
@@ -447,7 +447,7 @@ class WorkerQuests(MITMBase):
                      'Raid', 'Teil',
                      'Élément', 'mystérieux', 'Mysterious', 'Component', 'Mysteriöses', 'Remote', 'Fern',
                      'Fern-Raid-Pass', 'Pass', 'Passe', 'distance', 'Remote Raid', 'Remote Pass',
-                     'Remote Raid Pass', 'Battle Pass', 'Premium Battle Pass', 'Premium Battle', 'Stickers')
+                     'Remote Raid Pass', 'Battle Pass', 'Premium Battle Pass', 'Premium Battle', 'Sticker')
         x, y = self._resocalc.get_close_main_button_coords(self)
         self._communicator.click(int(x), int(y))
         time.sleep(1 + int(delayadd))


### PR DESCRIPTION
You can now click Stickers in inventory and it will open page full of stickers.
There is no trashcan on those stickers in main menu (for now, I can imagine Niantic QoL update).

Can't really get names in French/German, not translated in PokeMiners assets, will update later (or someone can comment).