### PR TITLE
QuickFix for scanned location

### DIFF
--- a/mapadroid/db/DbWrapper.py
+++ b/mapadroid/db/DbWrapper.py
@@ -137,7 +137,7 @@ class DbWrapper:
             "ON DUPLICATE KEY UPDATE last_modified=VALUES(last_modified)"
         )
         # TODO: think of a better "unique, real number"
-        sql_args = (cell_id, lat, lng, now, -1, -1, -1, -1, -1, -1, -1, -1)
+        sql_args = (cell_id, lat, lng, now, -1, -1, -1, -1, -1, -1, -1, 0)
         self.execute(query, sql_args, commit=True)
 
         return True


### PR DESCRIPTION
scannedlocation was off by default and now it's on by default. People will old af databases schema has some strange CONSTRAINTS there, so let's just quickfix value from -1 to 0 before final decision what to do.

https://discord.com/channels/465247740553592832/467318193141317659/768947899748843591