### PR TITLE
[RFC] Allow quest routes to always be recalculated dynamically

### DIFF
--- a/mapadroid/data_manager/modules/area_pokestops.py
+++ b/mapadroid/data_manager/modules/area_pokestops.py
@@ -113,6 +113,15 @@ class AreaPokestops(Area):
                     "description": "Cleanup quest inventory after every stop (Default: False)",
                     "expected": bool
                 }
+            },
+            "clear_route_every_time": {
+                "settings": {
+                    "type": "option",
+                    "require": False,
+                    "values": [False, True],
+                    "description": "Recalculate route every time",
+                    "expected": bool
+                }
             }
         }
     }

--- a/mapadroid/data_manager/modules/routecalc.py
+++ b/mapadroid/data_manager/modules/routecalc.py
@@ -7,7 +7,6 @@ from mapadroid.route.routecalc.ClusteringHelper import ClusteringHelper
 from mapadroid.utils.collections import Location
 from mapadroid.utils.logging import get_logger, LoggerEnums
 
-
 logger = get_logger(LoggerEnums.data_manager)
 
 
@@ -31,7 +30,7 @@ class RouteCalc(Resource):
     def _default_load(self) -> None:
         self.recalc_status = False
 
-    def get_dependencies(self) -> None:
+    def get_dependencies(self) -> List:
         tables = ['settings_area_idle',
                   'settings_area_iv_mitm',
                   'settings_area_mon_mitm',
@@ -103,47 +102,21 @@ class RouteCalc(Resource):
     # ============ Resource-Specific Functions ============
     # =====================================================
 
-    def calculate_new_route(self, coords: List[Tuple[str, str]], max_radius: int, max_coords_within_radius: int,
-                            delete_old_route: bool, calc_type: str, use_s2: bool, s2_level: int, num_procs: int = 0,
+    def calculate_new_route(self, coords: np.ndarray, max_radius: int, max_coords_within_radius: int,
+                            calc_type: str, use_s2: bool, s2_level: int, num_procs: int = 0,
                             overwrite_calculation: bool = False, in_memory: bool = False, route_name: str = 'Unknown'
                             ) -> List[Dict[str, float]]:
         if overwrite_calculation:
             calc_type = 'route'
         self.set_recalc_status(True)
-        if in_memory is False:
-            if delete_old_route:
-                logger.debug("Deleting routefile...")
-                self._data['fields']['routefile'] = []
-                self.save()
-        new_route = self.get_json_route(coords, max_radius, max_coords_within_radius, in_memory,
-                                        num_processes=num_procs,
-                                        algorithm=calc_type, use_s2=use_s2, s2_level=s2_level,
-                                        route_name=route_name)
-        self.set_recalc_status(False)
-        return new_route
 
-    def get_json_route(self, coords: List[Tuple[str, str]], max_radius: int, max_coords_within_radius: int,
-                       in_memory: bool, num_processes: int = 1, algorithm: str = 'route', use_s2: bool = False,
-                       s2_level: int = 15, route_name: str = 'Unknown') -> List[Dict[str, float]]:
-        export_data = []
         if use_s2:
             logger.debug("Using S2 method for calculation with S2 level: {}", s2_level)
-        if not in_memory and \
-                (self._data['fields']['routefile'] is not None and len(
-                    self._data['fields']['routefile']) > 0):
-            logger.debug('Using routefile from DB')
-            for line in self._data['fields']['routefile']:
-                # skip empty lines
-                if not line.strip():
-                    continue
-                line_split = line.split(',')
-                export_data.append({'lat': float(line_split[0].strip()),
-                                    'lng': float(line_split[1].strip())})
-            return export_data
 
+        new_route = []
         less_coords = coords
         if len(coords) > 0 and max_radius and max_coords_within_radius:
-            logger.info("Calculating route for {}", route_name)
+            logger.info("Calculating route of {} coords for {}", len(coords), route_name)
             new_coords = self.get_less_coords(coords, max_radius, max_coords_within_radius, use_s2, s2_level)
             less_coords = np.zeros(shape=(len(new_coords), 2))
             for i in range(len(less_coords)):
@@ -153,19 +126,17 @@ class RouteCalc(Resource):
         logger.debug("Got {} coordinates", len(less_coords))
         if len(less_coords) < 3:
             logger.debug("less than 3 coordinates... not gonna take a shortest route on that")
-            export_data = []
             for i in range(len(less_coords)):
-                export_data.append({'lat': less_coords[i][0].item(),
-                                    'lng': less_coords[i][1].item()})
+                new_route.append({'lat': less_coords[i][0].item(),
+                                  'lng': less_coords[i][1].item()})
         else:
-            logger.info("Calculating a short route through all those coords. Might take a while")
+            logger.info("Calculating route through all those coords. Might take a while")
             from timeit import default_timer as timer
             start = timer()
             from mapadroid.route.routecalc.calculate_route_all import route_calc_all
-            sol_best = route_calc_all(less_coords, route_name, num_processes, algorithm)
+            sol_best = route_calc_all(less_coords, route_name, num_procs, calc_type)
 
             end = timer()
-
             calc_dur = (end - start) / 60
             time_unit = 'minutes'
             if calc_dur < 1:
@@ -173,21 +144,46 @@ class RouteCalc(Resource):
                 time_unit = 'seconds'
 
             logger.info("Calculated route for {} in {} {}", route_name, calc_dur, time_unit)
-
             for i in range(len(sol_best)):
-                export_data.append({'lat': less_coords[int(sol_best[i])][0].item(),
-                                    'lng': less_coords[int(sol_best[i])][1].item()})
+                new_route.append({'lat': less_coords[int(sol_best[i])][0].item(),
+                                  'lng': less_coords[int(sol_best[i])][1].item()})
         if not in_memory:
             calc_coords = []
-            for coord in export_data:
+            for coord in new_route:
                 calc_coord = '%s,%s' % (coord['lat'], coord['lng'])
                 calc_coords.append(calc_coord)
             # Only save if we aren't calculating in memory
             self._data['fields']['routefile'] = calc_coords
             self.save(update_time=True)
+        self.set_recalc_status(False)
+        return new_route
+
+    def get_saved_routefile(self) -> Optional[List[Dict[str, float]]]:
+        if self._data['fields']['routefile'] is not None and len(self._data['fields']['routefile']) > 0:
+            logger.debug('Using routefile from DB since in_memory is false')
+            new_route = self.routefile_to_list()
+            self.set_recalc_status(False)
+            return new_route
+        else:
+            return None
+
+    def delete_route(self):
+        logger.debug("Deleting routefile...")
+        self._data['fields']['routefile'] = []
+        self.save()
+
+    def routefile_to_list(self):
+        export_data = []
+        for line in self._data['fields']['routefile']:
+            # skip empty lines
+            if not line.strip():
+                continue
+            line_split = line.split(',')
+            export_data.append({'lat': float(line_split[0].strip()),
+                                'lng': float(line_split[1].strip())})
         return export_data
 
-    def get_less_coords(self, np_coords: List[Tuple[str, str]], max_radius: int, max_coords_within_radius: int,
+    def get_less_coords(self, np_coords: np.ndarray, max_radius: int, max_coords_within_radius: int,
                         use_s2: bool = False, s2_level: int = 15):
         coordinates = []
         for coord in np_coords:

--- a/mapadroid/mitm_receiver/SerializedMitmDataProcessor.py
+++ b/mapadroid/mitm_receiver/SerializedMitmDataProcessor.py
@@ -38,46 +38,49 @@ class SerializedMitmDataProcessor(Process):
         origin_logger.debug2("Processing received data")
         processed_timestamp = datetime.fromtimestamp(received_timestamp)
 
-        if data_type and not data.get("raw", False):
-            self.__mitm_mapper.run_stats_collector(origin)
+        if not data_type or data.get("raw", False):
+            return
 
-            origin_logger.debug4("Received data: {}", data)
-            if data_type == 106:
-                # process GetMapObject
-                origin_logger.info("Processing GMO received. Received at {}", processed_timestamp)
+        self.__mitm_mapper.run_stats_collector(origin)
 
-                self.__db_submit.weather(origin, data["payload"], received_timestamp)
+        origin_logger.debug4("Received data: {}", data)
+        data_payload = data["payload"]
+        if data_type == 106:
+            # process GetMapObject
+            origin_logger.info("Processing GMO received. Received at {}", processed_timestamp)
 
-                self.__db_submit.stops(origin, data["payload"])
-                self.__db_submit.gyms(origin, data["payload"])
-                self.__db_submit.raids(origin, data["payload"], self.__mitm_mapper)
+            self.__db_submit.weather(origin, data_payload, received_timestamp)
 
-                self.__db_submit.spawnpoints(origin, data["payload"], processed_timestamp)
-                self.__db_submit.mons(origin, received_timestamp, data["payload"], self.__mitm_mapper)
-                self.__db_submit.cells(origin, data["payload"])
-                self.__mitm_mapper.submit_gmo_for_location(origin, data["payload"])
-                origin_logger.debug2("Done processing GMO")
-            elif data_type == 102:
-                playerlevel = self.__mitm_mapper.get_playerlevel(origin)
-                if playerlevel >= 30:
-                    origin_logger.debug("Processing encounter received at {}", processed_timestamp)
-                    self.__db_submit.mon_iv(origin, received_timestamp, data["payload"], self.__mitm_mapper)
-                    origin_logger.debug2("Done processing encounter")
-                else:
-                    origin_logger.warning("Playerlevel lower than 30 - not processing encounter IVs")
-            elif data_type == 101:
-                origin_logger.debug2("Processing proto 101")
-                self.__db_submit.quest(origin, data["payload"], self.__mitm_mapper)
-                origin_logger.debug2("Done processing proto 101")
-            elif data_type == 104:
-                origin_logger.debug2("Processing proto 104")
-                self.__db_submit.stop_details(data["payload"])
-                origin_logger.debug2("Done processing proto 104")
-            elif data_type == 4:
-                origin_logger.debug2("Processing proto 4")
-                self.__mitm_mapper.generate_player_stats(origin, data["payload"])
-                origin_logger.debug2("Done processing proto 4")
-            elif data_type == 156:
-                origin_logger.debug2("Processing proto 156")
-                self.__db_submit.gym(origin, data["payload"])
-                origin_logger.debug2("Done processing proto 156")
+            self.__db_submit.stops(origin, data_payload)
+            self.__db_submit.gyms(origin, data_payload)
+            self.__db_submit.raids(origin, data_payload, self.__mitm_mapper)
+
+            self.__db_submit.spawnpoints(origin, data_payload, processed_timestamp)
+            self.__db_submit.mons(origin, received_timestamp, data_payload, self.__mitm_mapper)
+            self.__db_submit.cells(origin, data_payload)
+            self.__mitm_mapper.submit_gmo_for_location(origin, data_payload)
+            origin_logger.debug2("Done processing GMO")
+        elif data_type == 102:
+            playerlevel = self.__mitm_mapper.get_playerlevel(origin)
+            if playerlevel >= 30:
+                origin_logger.debug("Processing encounter received at {}", processed_timestamp)
+                self.__db_submit.mon_iv(origin, received_timestamp, data_payload, self.__mitm_mapper)
+                origin_logger.debug2("Done processing encounter")
+            else:
+                origin_logger.warning("Playerlevel lower than 30 - not processing encounter IVs")
+        elif data_type == 101:
+            origin_logger.debug2("Processing proto 101")
+            self.__db_submit.quest(origin, data_payload, self.__mitm_mapper)
+            origin_logger.debug2("Done processing proto 101")
+        elif data_type == 104:
+            origin_logger.debug2("Processing proto 104")
+            self.__db_submit.stop_details(data_payload)
+            origin_logger.debug2("Done processing proto 104")
+        elif data_type == 4:
+            origin_logger.debug2("Processing proto 4")
+            self.__mitm_mapper.generate_player_stats(origin, data_payload)
+            origin_logger.debug2("Done processing proto 4")
+        elif data_type == 156:
+            origin_logger.debug2("Processing proto 156")
+            self.__db_submit.gym(origin, data_payload)
+            origin_logger.debug2("Done processing proto 156")

--- a/mapadroid/mitm_receiver/SerializedMitmDataProcessor.py
+++ b/mapadroid/mitm_receiver/SerializedMitmDataProcessor.py
@@ -47,7 +47,7 @@ class SerializedMitmDataProcessor(Process):
         data_payload = data["payload"]
         if data_type == 106:
             # process GetMapObject
-            origin_logger.info("Processing GMO received. Received at {}", processed_timestamp)
+            origin_logger.info("Processing GMO received {}", processed_timestamp)
 
             self.__db_submit.weather(origin, data_payload, received_timestamp)
 
@@ -63,11 +63,11 @@ class SerializedMitmDataProcessor(Process):
         elif data_type == 102:
             playerlevel = self.__mitm_mapper.get_playerlevel(origin)
             if playerlevel >= 30:
-                origin_logger.debug("Processing encounter received at {}", processed_timestamp)
+                origin_logger.debug("Processing encounter received {}", processed_timestamp)
                 self.__db_submit.mon_iv(origin, received_timestamp, data_payload, self.__mitm_mapper)
                 origin_logger.debug2("Done processing encounter")
             else:
-                origin_logger.warning("Playerlevel lower than 30 - not processing encounter IVs")
+                origin_logger.warning("Playerlevel below 30 - ignoring IVs")
         elif data_type == 101:
             origin_logger.debug2("Processing proto 101")
             self.__db_submit.quest(origin, data_payload, self.__mitm_mapper)

--- a/mapadroid/patcher/__init__.py
+++ b/mapadroid/patcher/__init__.py
@@ -42,7 +42,8 @@ MAD_UPDATES = OrderedDict([
     (35, 'madrom_autoconfig'),
     (36, 'pokemon_iv_index'),
     (37, 'move_ptc_accounts'),
-    (38, 'remove_hatch_delay')
+    (38, 'remove_hatch_delay'),
+    (39, 'area_pokestop_clear_route_every')
 ])
 
 

--- a/mapadroid/patcher/area_pokestop_clear_route_every.py
+++ b/mapadroid/patcher/area_pokestop_clear_route_every.py
@@ -1,0 +1,17 @@
+from ._patch_base import PatchBase
+
+
+class Patch(PatchBase):
+    name = 'Add clear_route_every_time'
+    descr = 'Add setting for clear_route_every_time to settings for pokestop area'
+
+    def _execute(self):
+        origin_sql = """
+            ALTER TABLE `settings_area_pokestops`
+            ADD COLUMN `clear_route_every_time` tinyint(0) not null default 0;
+        """
+        try:
+            self._db.execute(origin_sql, commit=True, raise_exec=True)
+        except Exception as e:
+            self._logger.exception("Unexpected error: {}", e)
+            self.issues = True

--- a/mapadroid/route/RouteManagerFactory.py
+++ b/mapadroid/route/RouteManagerFactory.py
@@ -1,4 +1,6 @@
 from typing import Optional
+
+from mapadroid.data_manager.modules import GeoFence, RouteCalc
 from mapadroid.route.RouteManagerMon import RouteManagerMon
 from mapadroid.route.RouteManagerIV import RouteManagerIV
 from mapadroid.route.RouteManagerLeveling import RouteManagerLeveling
@@ -10,17 +12,15 @@ from mapadroid.worker.WorkerType import WorkerType
 
 class RouteManagerFactory:
     @staticmethod
-    def get_routemanager(db_wrapper, dbm, area_id, coords, max_radius, max_coords_within_radius,
-                         path_to_include_geofence,
-                         path_to_exclude_geofence: Optional[int], routefile: str,
-                         mode: WorkerType = WorkerType.UNDEFINED,
-                         init: bool = False, name: str = "unknown", settings=None,
-                         coords_spawns_known: bool = True,
-                         level: bool = False, calctype: str = "route", use_s2: bool = False,
-                         s2_level: int = 15, joinqueue=None, include_event_id=None):
+    def get_routemanager(db_wrapper, dbm, area_id, max_radius, max_coords_within_radius,
+                         path_to_include_geofence: Optional[GeoFence],
+                         path_to_exclude_geofence: Optional[GeoFence], routefile: RouteCalc,
+                         mode: WorkerType = WorkerType.UNDEFINED, init: bool = False, name: str = "unknown",
+                         settings=None, coords_spawns_known: bool = True, level: bool = False, calctype: str = "route",
+                         use_s2: bool = False, s2_level: int = 15, joinqueue=None, include_event_id=None):
 
         if mode == WorkerType.RAID_MITM.value:
-            route_manager = RouteManagerRaids(db_wrapper, dbm, area_id, coords, max_radius,
+            route_manager = RouteManagerRaids(db_wrapper, dbm, area_id, max_radius,
                                               max_coords_within_radius,
                                               path_to_include_geofence, path_to_exclude_geofence, routefile,
                                               mode=mode, settings=settings, init=init, name=name,
@@ -28,7 +28,7 @@ class RouteManagerFactory:
                                               use_s2=use_s2, s2_level=s2_level
                                               )
         elif mode == WorkerType.MON_MITM.value:
-            route_manager = RouteManagerMon(db_wrapper, dbm, area_id, coords, max_radius,
+            route_manager = RouteManagerMon(db_wrapper, dbm, area_id, max_radius,
                                             max_coords_within_radius,
                                             path_to_include_geofence, path_to_exclude_geofence, routefile,
                                             mode=mode, settings=settings, init=init, name=name,
@@ -37,30 +37,21 @@ class RouteManagerFactory:
                                             include_event_id=include_event_id
                                             )
         elif mode == WorkerType.IV_MITM.value:
-            route_manager = RouteManagerIV(db_wrapper, dbm, area_id, coords, 0, 99999999,
+            route_manager = RouteManagerIV(db_wrapper, dbm, area_id, 0, 99999999,
                                            path_to_include_geofence, path_to_exclude_geofence, routefile,
                                            mode=mode, settings=settings, init=False, name=name,
                                            joinqueue=joinqueue
                                            )
         elif mode == WorkerType.IDLE.value:
-            route_manager = RouteManagerRaids(db_wrapper, dbm, area_id, coords, max_radius,
+            route_manager = RouteManagerRaids(db_wrapper, dbm, area_id, max_radius,
                                               max_coords_within_radius,
                                               path_to_include_geofence, path_to_exclude_geofence, routefile,
                                               mode=mode, settings=settings, init=init, name=name,
                                               joinqueue=joinqueue
                                               )
         elif mode == WorkerType.STOPS.value:
-            if level and calctype == 'routefree':
-                route_manager = RouteManagerLevelingRoutefree(db_wrapper, dbm, area_id, coords, max_radius,
-                                                              max_coords_within_radius,
-                                                              path_to_include_geofence, path_to_exclude_geofence,
-                                                              routefile,
-                                                              mode=mode, settings=settings, init=init, name=name,
-                                                              level=True,
-                                                              calctype=calctype, joinqueue=joinqueue
-                                                              )
-            elif level:
-                route_manager = RouteManagerLeveling(db_wrapper, dbm, area_id, coords, max_radius,
+            if level and calctype == 'route':
+                route_manager = RouteManagerLeveling(db_wrapper, dbm, area_id, max_radius,
                                                      max_coords_within_radius,
                                                      path_to_include_geofence, path_to_exclude_geofence,
                                                      routefile,
@@ -68,8 +59,17 @@ class RouteManagerFactory:
                                                      level=True,
                                                      calctype=calctype, joinqueue=joinqueue
                                                      )
+            elif level and calctype == 'routefree':
+                route_manager = RouteManagerLevelingRoutefree(db_wrapper, dbm, area_id, max_radius,
+                                                              max_coords_within_radius,
+                                                              path_to_include_geofence, path_to_exclude_geofence,
+                                                              routefile,
+                                                              mode=mode, settings=settings, init=init, name=name,
+                                                              level=True,
+                                                              calctype=calctype, joinqueue=joinqueue
+                                                              )
             else:
-                route_manager = RouteManagerQuests(db_wrapper, dbm, area_id, coords, max_radius,
+                route_manager = RouteManagerQuests(db_wrapper, dbm, area_id, max_radius,
                                                    max_coords_within_radius,
                                                    path_to_include_geofence, path_to_exclude_geofence,
                                                    routefile,

--- a/mapadroid/route/RouteManagerFactory.py
+++ b/mapadroid/route/RouteManagerFactory.py
@@ -13,8 +13,8 @@ from mapadroid.worker.WorkerType import WorkerType
 class RouteManagerFactory:
     @staticmethod
     def get_routemanager(db_wrapper, dbm, area_id, max_radius, max_coords_within_radius,
-                         path_to_include_geofence: Optional[GeoFence],
-                         path_to_exclude_geofence: Optional[GeoFence], routefile: RouteCalc,
+                         include_geofence: Optional[GeoFence],
+                         exclude_geofence: Optional[GeoFence], routefile: RouteCalc,
                          mode: WorkerType = WorkerType.UNDEFINED, init: bool = False, name: str = "unknown",
                          settings=None, coords_spawns_known: bool = True, level: bool = False, calctype: str = "route",
                          use_s2: bool = False, s2_level: int = 15, joinqueue=None, include_event_id=None):
@@ -22,7 +22,7 @@ class RouteManagerFactory:
         if mode == WorkerType.RAID_MITM.value:
             route_manager = RouteManagerRaids(db_wrapper, dbm, area_id, max_radius,
                                               max_coords_within_radius,
-                                              path_to_include_geofence, path_to_exclude_geofence, routefile,
+                                              include_geofence, exclude_geofence, routefile,
                                               mode=mode, settings=settings, init=init, name=name,
                                               joinqueue=joinqueue,
                                               use_s2=use_s2, s2_level=s2_level
@@ -30,7 +30,7 @@ class RouteManagerFactory:
         elif mode == WorkerType.MON_MITM.value:
             route_manager = RouteManagerMon(db_wrapper, dbm, area_id, max_radius,
                                             max_coords_within_radius,
-                                            path_to_include_geofence, path_to_exclude_geofence, routefile,
+                                            include_geofence, exclude_geofence, routefile,
                                             mode=mode, settings=settings, init=init, name=name,
                                             joinqueue=joinqueue,
                                             coords_spawns_known=coords_spawns_known,
@@ -38,14 +38,14 @@ class RouteManagerFactory:
                                             )
         elif mode == WorkerType.IV_MITM.value:
             route_manager = RouteManagerIV(db_wrapper, dbm, area_id, 0, 99999999,
-                                           path_to_include_geofence, path_to_exclude_geofence, routefile,
+                                           include_geofence, exclude_geofence, routefile,
                                            mode=mode, settings=settings, init=False, name=name,
                                            joinqueue=joinqueue
                                            )
         elif mode == WorkerType.IDLE.value:
             route_manager = RouteManagerRaids(db_wrapper, dbm, area_id, max_radius,
                                               max_coords_within_radius,
-                                              path_to_include_geofence, path_to_exclude_geofence, routefile,
+                                              include_geofence, exclude_geofence, routefile,
                                               mode=mode, settings=settings, init=init, name=name,
                                               joinqueue=joinqueue
                                               )
@@ -53,7 +53,7 @@ class RouteManagerFactory:
             if level and calctype == 'route':
                 route_manager = RouteManagerLeveling(db_wrapper, dbm, area_id, max_radius,
                                                      max_coords_within_radius,
-                                                     path_to_include_geofence, path_to_exclude_geofence,
+                                                     include_geofence, exclude_geofence,
                                                      routefile,
                                                      mode=mode, settings=settings, init=init, name=name,
                                                      level=True,
@@ -62,7 +62,7 @@ class RouteManagerFactory:
             elif level and calctype == 'routefree':
                 route_manager = RouteManagerLevelingRoutefree(db_wrapper, dbm, area_id, max_radius,
                                                               max_coords_within_radius,
-                                                              path_to_include_geofence, path_to_exclude_geofence,
+                                                              include_geofence, exclude_geofence,
                                                               routefile,
                                                               mode=mode, settings=settings, init=init, name=name,
                                                               level=True,
@@ -71,7 +71,7 @@ class RouteManagerFactory:
             else:
                 route_manager = RouteManagerQuests(db_wrapper, dbm, area_id, max_radius,
                                                    max_coords_within_radius,
-                                                   path_to_include_geofence, path_to_exclude_geofence,
+                                                   include_geofence, exclude_geofence,
                                                    routefile,
                                                    mode=mode, settings=settings, init=init, name=name,
                                                    level=level,

--- a/mapadroid/route/RouteManagerIV.py
+++ b/mapadroid/route/RouteManagerIV.py
@@ -8,11 +8,11 @@ logger = get_logger(LoggerEnums.routemanager)
 
 
 class RouteManagerIV(RouteManagerBase):
-    def __init__(self, db_wrapper, dbm, area_id, coords, max_radius, max_coords_within_radius,
+    def __init__(self, db_wrapper, dbm, area_id, max_radius, max_coords_within_radius,
                  path_to_include_geofence,
                  path_to_exclude_geofence, routefile, mode=None, init=False,
                  name="unknown", settings=None, joinqueue=None):
-        RouteManagerBase.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id, coords=coords,
+        RouteManagerBase.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id,
                                   max_radius=max_radius,
                                   max_coords_within_radius=max_coords_within_radius,
                                   path_to_include_geofence=path_to_include_geofence,

--- a/mapadroid/route/RouteManagerIV.py
+++ b/mapadroid/route/RouteManagerIV.py
@@ -9,14 +9,14 @@ logger = get_logger(LoggerEnums.routemanager)
 
 class RouteManagerIV(RouteManagerBase):
     def __init__(self, db_wrapper, dbm, area_id, max_radius, max_coords_within_radius,
-                 path_to_include_geofence,
-                 path_to_exclude_geofence, routefile, mode=None, init=False,
+                 include_geofence,
+                 exclude_geofence, routefile, mode=None, init=False,
                  name="unknown", settings=None, joinqueue=None):
         RouteManagerBase.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id,
                                   max_radius=max_radius,
                                   max_coords_within_radius=max_coords_within_radius,
-                                  path_to_include_geofence=path_to_include_geofence,
-                                  path_to_exclude_geofence=path_to_exclude_geofence,
+                                  include_geofence=include_geofence,
+                                  exclude_geofence=exclude_geofence,
                                   routefile=routefile, init=init,
                                   name=name, settings=settings, mode=mode, joinqueue=joinqueue
                                   )

--- a/mapadroid/route/RouteManagerLeveling.py
+++ b/mapadroid/route/RouteManagerLeveling.py
@@ -1,6 +1,8 @@
 import time
-from typing import List
+from typing import List, Optional
 import numpy as np
+
+from mapadroid.data_manager.modules import GeoFence, RouteCalc
 from mapadroid.db.DbWrapper import DbWrapper
 from mapadroid.route.RouteManagerBase import RoutePoolEntry
 from mapadroid.route.RouteManagerQuests import RouteManagerQuests
@@ -13,13 +15,13 @@ logger = get_logger(LoggerEnums.routemanager)
 
 class RouteManagerLeveling(RouteManagerQuests):
     def __init__(self, db_wrapper: DbWrapper, dbm, area_id, max_radius: float,
-                 max_coords_within_radius: int, path_to_include_geofence: str, path_to_exclude_geofence: str,
-                 routefile: str, mode=None, init: bool = False, name: str = "unknown", settings: dict = None,
+                 max_coords_within_radius: int, include_geofence: Optional[GeoFence], exclude_geofence: Optional[GeoFence],
+                 routefile: RouteCalc, mode=None, init: bool = False, name: str = "unknown", settings: dict = None,
                  level: bool = False, calctype: str = "route", joinqueue=None):
         RouteManagerQuests.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id,
                                     max_radius=max_radius, max_coords_within_radius=max_coords_within_radius,
-                                    path_to_include_geofence=path_to_include_geofence,
-                                    path_to_exclude_geofence=path_to_exclude_geofence,
+                                    include_geofence=include_geofence,
+                                    exclude_geofence=exclude_geofence,
                                     routefile=routefile, init=init,
                                     name=name, settings=settings, mode=mode, level=level, calctype=calctype,
                                     joinqueue=joinqueue

--- a/mapadroid/route/RouteManagerLeveling.py
+++ b/mapadroid/route/RouteManagerLeveling.py
@@ -12,11 +12,11 @@ logger = get_logger(LoggerEnums.routemanager)
 
 
 class RouteManagerLeveling(RouteManagerQuests):
-    def __init__(self, db_wrapper: DbWrapper, dbm, area_id, coords: List[Location], max_radius: float,
+    def __init__(self, db_wrapper: DbWrapper, dbm, area_id, max_radius: float,
                  max_coords_within_radius: int, path_to_include_geofence: str, path_to_exclude_geofence: str,
                  routefile: str, mode=None, init: bool = False, name: str = "unknown", settings: dict = None,
                  level: bool = False, calctype: str = "route", joinqueue=None):
-        RouteManagerQuests.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id, coords=coords,
+        RouteManagerQuests.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id,
                                     max_radius=max_radius, max_coords_within_radius=max_coords_within_radius,
                                     path_to_include_geofence=path_to_include_geofence,
                                     path_to_exclude_geofence=path_to_exclude_geofence,

--- a/mapadroid/route/RouteManagerLevelingRoutefree.py
+++ b/mapadroid/route/RouteManagerLevelingRoutefree.py
@@ -11,11 +11,11 @@ logger = get_logger(LoggerEnums.routemanager)
 
 
 class RouteManagerLevelingRoutefree(RouteManagerQuests):
-    def __init__(self, db_wrapper: DbWrapper, dbm, area_id, coords: List[Location], max_radius: float,
+    def __init__(self, db_wrapper: DbWrapper, dbm, area_id, max_radius: float,
                  max_coords_within_radius: int, path_to_include_geofence: str, path_to_exclude_geofence: str,
                  routefile: str, mode=None, init: bool = False, name: str = "unknown", settings: dict = None,
                  level: bool = False, calctype: str = "route", joinqueue=None):
-        RouteManagerQuests.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id, coords=coords,
+        RouteManagerQuests.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id,
                                     max_radius=max_radius, max_coords_within_radius=max_coords_within_radius,
                                     path_to_include_geofence=path_to_include_geofence,
                                     path_to_exclude_geofence=path_to_exclude_geofence,

--- a/mapadroid/route/RouteManagerLevelingRoutefree.py
+++ b/mapadroid/route/RouteManagerLevelingRoutefree.py
@@ -1,24 +1,24 @@
-from typing import List
 import numpy as np
+
+from mapadroid.data_manager.modules import GeoFence, RouteCalc
 from mapadroid.db.DbWrapper import DbWrapper
 from mapadroid.route.RouteManagerBase import RoutePoolEntry
 from mapadroid.route.RouteManagerQuests import RouteManagerQuests
 from mapadroid.utils.collections import Location
 from mapadroid.utils.logging import get_logger, LoggerEnums
 
-
 logger = get_logger(LoggerEnums.routemanager)
 
 
 class RouteManagerLevelingRoutefree(RouteManagerQuests):
     def __init__(self, db_wrapper: DbWrapper, dbm, area_id, max_radius: float,
-                 max_coords_within_radius: int, path_to_include_geofence: str, path_to_exclude_geofence: str,
-                 routefile: str, mode=None, init: bool = False, name: str = "unknown", settings: dict = None,
+                 max_coords_within_radius: int, include_geofence: GeoFence, exclude_geofence: GeoFence,
+                 routefile: RouteCalc, mode=None, init: bool = False, name: str = "unknown", settings: dict = None,
                  level: bool = False, calctype: str = "route", joinqueue=None):
         RouteManagerQuests.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id,
                                     max_radius=max_radius, max_coords_within_radius=max_coords_within_radius,
-                                    path_to_include_geofence=path_to_include_geofence,
-                                    path_to_exclude_geofence=path_to_exclude_geofence,
+                                    include_geofence=include_geofence,
+                                    exclude_geofence=exclude_geofence,
                                     routefile=routefile, init=init,
                                     name=name, settings=settings, mode=mode, level=level, calctype=calctype,
                                     joinqueue=joinqueue

--- a/mapadroid/route/RouteManagerMon.py
+++ b/mapadroid/route/RouteManagerMon.py
@@ -6,11 +6,11 @@ logger = get_logger(LoggerEnums.routemanager)
 
 
 class RouteManagerMon(RouteManagerBase):
-    def __init__(self, db_wrapper, dbm, area_id, coords, max_radius, max_coords_within_radius,
+    def __init__(self, db_wrapper, dbm, area_id, max_radius, max_coords_within_radius,
                  path_to_include_geofence,
                  path_to_exclude_geofence, routefile, mode=None, coords_spawns_known=True, init=False,
                  name="unknown", settings=None, joinqueue=None, include_event_id=None):
-        RouteManagerBase.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id, coords=coords,
+        RouteManagerBase.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id,
                                   max_radius=max_radius,
                                   max_coords_within_radius=max_coords_within_radius,
                                   path_to_include_geofence=path_to_include_geofence,

--- a/mapadroid/route/RouteManagerMon.py
+++ b/mapadroid/route/RouteManagerMon.py
@@ -7,14 +7,14 @@ logger = get_logger(LoggerEnums.routemanager)
 
 class RouteManagerMon(RouteManagerBase):
     def __init__(self, db_wrapper, dbm, area_id, max_radius, max_coords_within_radius,
-                 path_to_include_geofence,
-                 path_to_exclude_geofence, routefile, mode=None, coords_spawns_known=True, init=False,
+                 include_geofence,
+                 exclude_geofence, routefile, mode=None, coords_spawns_known=True, init=False,
                  name="unknown", settings=None, joinqueue=None, include_event_id=None):
         RouteManagerBase.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id,
                                   max_radius=max_radius,
                                   max_coords_within_radius=max_coords_within_radius,
-                                  path_to_include_geofence=path_to_include_geofence,
-                                  path_to_exclude_geofence=path_to_exclude_geofence,
+                                  include_geofence=include_geofence,
+                                  exclude_geofence=exclude_geofence,
                                   routefile=routefile, init=init,
                                   name=name, settings=settings, mode=mode, joinqueue=joinqueue
                                   )

--- a/mapadroid/route/RouteManagerQuests.py
+++ b/mapadroid/route/RouteManagerQuests.py
@@ -1,27 +1,25 @@
-import collections
 import time
-from typing import List
+from typing import List, Optional
 
 from mapadroid.data_manager.modules import GeoFence, RouteCalc
 from mapadroid.db.DbWrapper import DbWrapper
 from mapadroid.route.RouteManagerBase import RouteManagerBase
+from mapadroid.utils.collections import Location
 from mapadroid.utils.logging import get_logger, LoggerEnums
 
-
 logger = get_logger(LoggerEnums.routemanager)
-Location = collections.namedtuple('Location', ['lat', 'lng'])
 
 
 class RouteManagerQuests(RouteManagerBase):
     def __init__(self, db_wrapper: DbWrapper, dbm, area_id, max_radius: float,
-                 max_coords_within_radius: int, path_to_include_geofence: GeoFence, path_to_exclude_geofence: GeoFence,
+                 max_coords_within_radius: int, include_geofence: Optional[GeoFence], exclude_geofence: Optional[GeoFence],
                  routefile: RouteCalc, mode=None, init: bool = False, name: str = "unknown", settings: dict = None,
                  level: bool = False, calctype: str = "route", joinqueue=None):
         RouteManagerBase.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id,
                                   max_radius=max_radius,
                                   max_coords_within_radius=max_coords_within_radius,
-                                  path_to_include_geofence=path_to_include_geofence,
-                                  path_to_exclude_geofence=path_to_exclude_geofence,
+                                  include_geofence=include_geofence,
+                                  exclude_geofence=exclude_geofence,
                                   routefile=routefile, init=init,
                                   name=name, settings=settings, mode=mode, level=level, calctype=calctype,
                                   joinqueue=joinqueue
@@ -103,6 +101,7 @@ class RouteManagerQuests(RouteManagerBase):
             if self._clear_route_every_time:
                 self.recalc_route(self._max_radius, self._max_coords_within_radius, 0,
                                   delete_old_route=True, in_memory=False)
+                self._routecopy = self._route.copy()
             else:
                 self._route = self._routecopy.copy()
 

--- a/mapadroid/route/RouteManagerQuests.py
+++ b/mapadroid/route/RouteManagerQuests.py
@@ -99,6 +99,9 @@ class RouteManagerQuests(RouteManagerBase):
         if not self._tempinit:
             self.logger.info("Restoring original route")
             if self._clear_route_every_time:
+                self._clear_coords()
+                coords = self._get_coords_post_init()
+                self.add_coords_list(coords)
                 self.recalc_route(self._max_radius, self._max_coords_within_radius, 0,
                                   delete_old_route=True, in_memory=False)
                 self._routecopy = self._route.copy()
@@ -225,6 +228,7 @@ class RouteManagerQuests(RouteManagerBase):
         # clear not processed stops
         self._stops_not_processed.clear()
         self._coords_to_be_ignored.clear()
+        self._restore_original_route()
 
     def _check_coords_before_returning(self, lat, lng, origin):
         if self.init:

--- a/mapadroid/route/RouteManagerQuests.py
+++ b/mapadroid/route/RouteManagerQuests.py
@@ -101,8 +101,8 @@ class RouteManagerQuests(RouteManagerBase):
         if not self._tempinit:
             self.logger.info("Restoring original route")
             if self._clear_route_every_time:
-                self._route = self.recalc_route(self._max_radius, self._max_coords_within_radius, 0,
-                                                delete_old_route=True, in_memory=False)
+                self.recalc_route(self._max_radius, self._max_coords_within_radius, 0,
+                                  delete_old_route=True, in_memory=False)
             else:
                 self._route = self._routecopy.copy()
 

--- a/mapadroid/route/RouteManagerRaids.py
+++ b/mapadroid/route/RouteManagerRaids.py
@@ -7,14 +7,14 @@ logger = get_logger(LoggerEnums.routemanager)
 
 class RouteManagerRaids(RouteManagerBase):
     def __init__(self, db_wrapper, dbm, area_id, max_radius, max_coords_within_radius,
-                 path_to_include_geofence,
-                 path_to_exclude_geofence, routefile, mode=None, settings=None, init=False,
+                 include_geofence,
+                 exclude_geofence, routefile, mode=None, settings=None, init=False,
                  name="unknown", joinqueue=None, use_s2: bool = False, s2_level: int = 15):
         RouteManagerBase.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id,
                                   max_radius=max_radius,
                                   max_coords_within_radius=max_coords_within_radius,
-                                  path_to_include_geofence=path_to_include_geofence,
-                                  path_to_exclude_geofence=path_to_exclude_geofence,
+                                  include_geofence=include_geofence,
+                                  exclude_geofence=exclude_geofence,
                                   routefile=routefile, init=init,
                                   name=name, settings=settings, mode=mode, use_s2=True, s2_level=s2_level,
                                   joinqueue=joinqueue

--- a/mapadroid/route/RouteManagerRaids.py
+++ b/mapadroid/route/RouteManagerRaids.py
@@ -6,11 +6,11 @@ logger = get_logger(LoggerEnums.routemanager)
 
 
 class RouteManagerRaids(RouteManagerBase):
-    def __init__(self, db_wrapper, dbm, area_id, coords, max_radius, max_coords_within_radius,
+    def __init__(self, db_wrapper, dbm, area_id, max_radius, max_coords_within_radius,
                  path_to_include_geofence,
                  path_to_exclude_geofence, routefile, mode=None, settings=None, init=False,
                  name="unknown", joinqueue=None, use_s2: bool = False, s2_level: int = 15):
-        RouteManagerBase.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id, coords=coords,
+        RouteManagerBase.__init__(self, db_wrapper=db_wrapper, dbm=dbm, area_id=area_id,
                                   max_radius=max_radius,
                                   max_coords_within_radius=max_coords_within_radius,
                                   path_to_include_geofence=path_to_include_geofence,

--- a/mapadroid/utils/MappingManager.py
+++ b/mapadroid/utils/MappingManager.py
@@ -399,21 +399,18 @@ class MappingManager:
                                                                                                 99999999),
                                                                  geofence_included,
                                                                  path_to_exclude_geofence=geofence_excluded,
-                                                                 mode=mode,
-                                                                 settings=area.get("settings", None),
+                                                                 routefile=route_resource, mode=mode,
                                                                  init=area.get("init", False),
                                                                  name=area.get("name", "unknown"),
-                                                                 level=area.get("level", False),
+                                                                 settings=area.get("settings", None),
                                                                  coords_spawns_known=area.get(
                                                                      "coords_spawns_known", True),
-                                                                 routefile=route_resource,
-                                                                 calctype=calc_type,
-                                                                 joinqueue=self.join_routes_queue,
+                                                                 level=area.get("level", False), calctype=calc_type,
                                                                  s2_level=mode_mapping.get(mode, {}).get(
                                                                      "s2_cell_level", 30),
+                                                                 joinqueue=self.join_routes_queue,
                                                                  include_event_id=area.get(
-                                                                     "settings", {}).get("include_event_id", None)
-                                                                 )
+                                                                     "settings", {}).get("include_event_id", None))
             logger.info("Initializing area {}", area["name"])
             if mode not in ("iv_mitm", "idle") and calc_type != "routefree":
                 coords = self.__fetch_coords(mode, geofence_helper,
@@ -422,15 +419,15 @@ class MappingManager:
                                              range_init=mode_mapping.get(mode, {}).get("range_init", 630),
                                              including_stops=area.get("including_stops", False),
                                              include_event_id=area.get("settings", {}).get("include_event_id", None))
-
                 route_manager.add_coords_list(coords)
                 max_radius = mode_mapping[mode]["range"]
                 max_count_in_radius = mode_mapping[mode]["max_count"]
                 if not area.get("init", False):
-
+                    logger.info("Not init mode, run initial calculation")
+                    clear_route_every_time = area.get("settings", {}).get("clear_route_every_time", False)
                     proc = thread_pool.apply_async(route_manager.initial_calculation,
                                                    args=(max_radius, max_count_in_radius,
-                                                         0, False))
+                                                         0, clear_route_every_time))
                     areas_procs[area_id] = proc
                 else:
                     logger.info("Init mode enabled. Going row-based for {}", area.get("name", "unknown"))

--- a/mapadroid/utils/s2Helper.py
+++ b/mapadroid/utils/s2Helper.py
@@ -25,7 +25,8 @@ class S2Helper:
 
         # Get the CellId of this LatLng
         cid = s2sphere.CellId.from_lat_lng(ll)
-        # Travers up to the parent ID and return this
+
+        # Traverse up to the parent ID and return this
         return cid.parent(level).id()
 
     # RM stores lat, long as well...

--- a/mapadroid/utils/walkerArgs.py
+++ b/mapadroid/utils/walkerArgs.py
@@ -137,7 +137,7 @@ def parse_args():
                         help=('Set Lng from the center of your scan location.'
                               'Especially for using MADBOT (User submitted Raidscreens). Default: 0.0'))
     parser.add_argument('-L', '--language', default='en',
-                        help=('Set Language for MadMin / Quests. Default: en'))
+                        help='Set Language for MadMin / Quests. Default: en')
 
     # MADmin
     parser.add_argument('-dm', '--disable_madmin', action='store_true', default=False,

--- a/mapadroid/worker/WorkerMITM.py
+++ b/mapadroid/worker/WorkerMITM.py
@@ -17,7 +17,6 @@ from mapadroid.websocket.AbstractCommunicator import AbstractCommunicator
 from mapadroid.worker.MITMBase import MITMBase, LatestReceivedType
 from mapadroid.utils.logging import get_logger, LoggerEnums
 
-
 logger = get_logger(LoggerEnums.worker)
 
 
@@ -95,7 +94,7 @@ class WorkerMITM(MITMBase):
                                                                float(
                                                                    self.current_location.lat) + lat_offset,
                                                                float(self.current_location.lng) + lng_offset)
-                self.logger.info("Walking roughly: {:.2f}m", to_walk)
+                self.logger.debug("Walking roughly: {:.2f}m", to_walk)
                 time.sleep(0.3)
                 self._communicator.walk_from_to(self.current_location,
                                                 Location(self.current_location.lat + lat_offset,
@@ -104,7 +103,7 @@ class WorkerMITM(MITMBase):
                 self.logger.debug("Walking back")
                 time.sleep(0.3)
                 self._communicator.walk_from_to(Location(self.current_location.lat + lat_offset,
-                                                self.current_location.lng + lng_offset),
+                                                         self.current_location.lng + lng_offset),
                                                 self.current_location,
                                                 11)
                 self.logger.debug("Done walking")

--- a/mapadroid/worker/WorkerQuests.py
+++ b/mapadroid/worker/WorkerQuests.py
@@ -276,7 +276,7 @@ class WorkerQuests(MITMBase):
                                                            float(
                                                                self.current_location.lat) + lat_offset,
                                                            float(self.current_location.lng) + lng_offset)
-            self.logger.info("Walking roughly: {:.2f}m", to_walk)
+            self.logger.debug("Walking roughly: {:.2f}m", to_walk)
             time.sleep(0.3)
             self._communicator.walk_from_to(self.current_location,
                                             Location(self.current_location.lat + lat_offset,
@@ -776,7 +776,6 @@ class WorkerQuests(MITMBase):
                                 raise InternalStopWorkerException
                         self.clear_thread_task = ClearThreadTasks.QUEST
                     break
-
             elif (data_received == FortSearchResultTypes.TIME or data_received ==
                   FortSearchResultTypes.OUT_OF_RANGE):
                 self.logger.warning('Softban - return to main screen and open again...')


### PR DESCRIPTION
Adds a new setting to every quest area: "clear_route_every_time" - when set, this setting will make MAD always recalculate the route of a quest area instead of using the saved area. This will allow for faster questing in areas where stops tends to convert into gyms at a high rate, which will make MAD spend time trying to spin stops.

This commit also removes quite a bit of old unused code that looked very important, but was never used.

WARNING: testing this PR WILL add a new column to one table. If you can't figure out how to revert this or what table is affected on your own, DO NOT TEST!

I'm also looking for a code review to make sure I didn't add any code that doesn't belong in here by mistake