### PR TITLE
Add missing items names to items.json (and langs)

### DIFF
--- a/locale/de/items.json
+++ b/locale/de/items.json
@@ -1,4 +1,8 @@
 {
+  "0": {
+    "protoname": "ITEM_UNKNOWN",
+    "name": "ITEM_UNKNOWN"
+  },
   "1": {
     "protoname": "ITEM_POKE_BALL",
     "name": "Pokéball"
@@ -17,7 +21,7 @@
   },
   "5": {
     "protoname": "ITEM_PREMIER_BALL",
-    "name": "Premierball"
+    "name": "ITEM_PREMIER_BALL"
   },
   "101": {
     "protoname": "ITEM_POTION",
@@ -53,15 +57,19 @@
   },
   "402": {
     "protoname": "ITEM_INCENSE_SPICY",
-    "name": "Incense Spicy"
+    "name": "ITEM_INCENSE_SPICY"
   },
   "403": {
     "protoname": "ITEM_INCENSE_COOL",
-    "name": "Incense Cool"
+    "name": "ITEM_INCENSE_COOL"
   },
   "404": {
     "protoname": "ITEM_INCENSE_FLORAL",
-    "name": "Incense Floral"
+    "name": "ITEM_INCENSE_FLORAL"
+  },
+  "405": {
+    "protoname": "ITEM_INCENSE_BELUGA_BOX",
+    "name": "Wunderbox"
   },
   "501": {
     "protoname": "ITEM_TROY_DISK",
@@ -81,15 +89,15 @@
   },
   "602": {
     "protoname": "ITEM_X_ATTACK",
-    "name": "X Attack"
+    "name": "X-Angriff"
   },
   "603": {
     "protoname": "ITEM_X_DEFENSE",
-    "name": "X Defense"
+    "name": "X-Verteidigung"
   },
   "604": {
     "protoname": "ITEM_X_MIRACLE",
-    "name": "X Miracle"
+    "name": "Nicht definiert"
   },
   "701": {
     "protoname": "ITEM_RAZZ_BERRY",
@@ -97,7 +105,7 @@
   },
   "702": {
     "protoname": "ITEM_BLUK_BERRY",
-    "name": "Bluk Berry"
+    "name": "Morbbeere"
   },
   "703": {
     "protoname": "ITEM_NANAB_BERRY",
@@ -105,7 +113,7 @@
   },
   "704": {
     "protoname": "ITEM_WEPAR_BERRY",
-    "name": "Wepar Berry"
+    "name": "Nirbebeere"
   },
   "705": {
     "protoname": "ITEM_PINAP_BERRY",
@@ -117,11 +125,15 @@
   },
   "707": {
     "protoname": "ITEM_GOLDEN_NANAB_BERRY",
-    "name": "Goldene Nanabbeere"
+    "name": "ITEM_GOLDEN_NANAB_BERRY"
   },
   "708": {
     "protoname": "ITEM_GOLDEN_PINAP_BERRY",
     "name": "Silberne Sananabeere"
+  },
+  "709": {
+    "protoname": "ITEM_POFFIN",
+    "name": "Knursp"
   },
   "801": {
     "protoname": "ITEM_SPECIAL_CAMERA",
@@ -129,23 +141,23 @@
   },
   "901": {
     "protoname": "ITEM_INCUBATOR_BASIC_UNLIMITED",
-    "name": "Brutmaschine"
+    "name": "Ei-Brutmaschine ∞"
   },
   "902": {
     "protoname": "ITEM_INCUBATOR_BASIC",
-    "name": "Brutmaschine"
+    "name": "Ei-Brutmaschine"
   },
   "903": {
     "protoname": "ITEM_INCUBATOR_SUPER",
-    "name": "Super Brutmaschine"
+    "name": "Super-Brutmaschine"
   },
   "1001": {
     "protoname": "ITEM_POKEMON_STORAGE_UPGRADE",
-    "name": "Pokémon Storage Upgrade"
+    "name": "ITEM_POKEMON_STORAGE_UPGRADE"
   },
   "1002": {
     "protoname": "ITEM_ITEM_STORAGE_UPGRADE",
-    "name": "Item Storage Upgrade"
+    "name": "ITEM_ITEM_STORAGE_UPGRADE"
   },
   "1101": {
     "protoname": "ITEM_SUN_STONE",
@@ -177,11 +189,19 @@
   },
   "1201": {
     "protoname": "ITEM_MOVE_REROLL_FAST_ATTACK",
-    "name": "Sofort TM"
+    "name": "Sofort-TM"
   },
   "1202": {
     "protoname": "ITEM_MOVE_REROLL_SPECIAL_ATTACK",
-    "name": "Lade TM"
+    "name": "Lade-TM"
+  },
+  "1203": {
+    "protoname": "ITEM_MOVE_REROLL_ELITE_FAST_ATTACK",
+    "name": "Top-Sofort-TM"
+  },
+  "1204": {
+    "protoname": "ITEM_MOVE_REROLL_ELITE_SPECIAL_ATTACK",
+    "name": "Top-Lade-TM"
   },
   "1301": {
     "protoname": "ITEM_RARE_CANDY",
@@ -189,15 +209,15 @@
   },
   "1401": {
     "protoname": "ITEM_FREE_RAID_TICKET",
-    "name": "Raid Pass"
+    "name": "Raid-Pass"
   },
   "1402": {
     "protoname": "ITEM_PAID_RAID_TICKET",
-    "name": "Paid Raid Pass"
+    "name": "Premium-Kampf-Pass"
   },
   "1403": {
     "protoname": "ITEM_LEGENDARY_RAID_TICKET",
-    "name": "EX Raid Pass"
+    "name": "EX-Raid-Pass"
   },
   "1404": {
     "protoname": "ITEM_STAR_PIECE",
@@ -206,5 +226,33 @@
   "1405": {
     "protoname": "ITEM_FRIEND_GIFT_BOX",
     "name": "Geschenk"
+  },
+  "1406": {
+    "protoname": "ITEM_TEAM_CHANGE",
+    "name": "Team-Medaillon"
+  },
+  "1408": {
+    "protoname": "ITEM_REMOTE_RAID_TICKET",
+    "name": "Fern-Raid-Pass"
+  },
+  "1501": {
+    "protoname": "ITEM_LEADER_MAP_FRAGMENT",
+    "name": "Mysteriöses Teil"
+  },
+  "1502": {
+    "protoname": "ITEM_LEADER_MAP",
+    "name": "Rocket-Radar"
+  },
+  "1503": {
+    "protoname": "ITEM_GIOVANNI_MAP",
+    "name": "Super-Rocket-Radar"
+  },
+  "1600": {
+    "protoname": "ITEM_GLOBAL_EVENT_TICKET",
+    "name": "Ticket"
+  },
+  "1601": {
+    "protoname": "ITEM_EVENT_TICKET_PINK",
+    "name": "Ticket"
   }
 }

--- a/locale/en/items.json
+++ b/locale/en/items.json
@@ -1,23 +1,27 @@
 {
+  "0": {
+    "protoname": "ITEM_UNKNOWN",
+    "name": "ITEM_UNKNOWN"
+  },
   "1": {
     "protoname": "ITEM_POKE_BALL",
-    "name": "Pokéball"
+    "name": "Poké Ball"
   },
   "2": {
     "protoname": "ITEM_GREAT_BALL",
-    "name": "Greatball"
+    "name": "Great Ball"
   },
   "3": {
     "protoname": "ITEM_ULTRA_BALL",
-    "name": "Ultraball"
+    "name": "Ultra Ball"
   },
   "4": {
     "protoname": "ITEM_MASTER_BALL",
-    "name": "Masterball"
+    "name": "Master Ball"
   },
   "5": {
     "protoname": "ITEM_PREMIER_BALL",
-    "name": "Premierball"
+    "name": "ITEM_PREMIER_BALL"
   },
   "101": {
     "protoname": "ITEM_POTION",
@@ -53,15 +57,19 @@
   },
   "402": {
     "protoname": "ITEM_INCENSE_SPICY",
-    "name": "Incense Spicy"
+    "name": "ITEM_INCENSE_SPICY"
   },
   "403": {
     "protoname": "ITEM_INCENSE_COOL",
-    "name": "Incense Cool"
+    "name": "ITEM_INCENSE_COOL"
   },
   "404": {
     "protoname": "ITEM_INCENSE_FLORAL",
-    "name": "Incense Floral"
+    "name": "ITEM_INCENSE_FLORAL"
+  },
+  "405": {
+    "protoname": "ITEM_INCENSE_BELUGA_BOX",
+    "name": "Mystery Box"
   },
   "501": {
     "protoname": "ITEM_TROY_DISK",
@@ -89,7 +97,7 @@
   },
   "604": {
     "protoname": "ITEM_X_MIRACLE",
-    "name": "X Miracle"
+    "name": "UNDEFINED"
   },
   "701": {
     "protoname": "ITEM_RAZZ_BERRY",
@@ -105,7 +113,7 @@
   },
   "704": {
     "protoname": "ITEM_WEPAR_BERRY",
-    "name": "Wepar Berry"
+    "name": "Wepear Berry"
   },
   "705": {
     "protoname": "ITEM_PINAP_BERRY",
@@ -113,15 +121,19 @@
   },
   "706": {
     "protoname": "ITEM_GOLDEN_RAZZ_BERRY",
-    "name": "Golden Razz"
+    "name": "Golden Razz Berry"
   },
   "707": {
     "protoname": "ITEM_GOLDEN_NANAB_BERRY",
-    "name": "Golden Pinap"
+    "name": "ITEM_GOLDEN_NANAB_BERRY"
   },
   "708": {
     "protoname": "ITEM_GOLDEN_PINAP_BERRY",
-    "name": "Silver Pinap"
+    "name": "Silver Pinap Berry"
+  },
+  "709": {
+    "protoname": "ITEM_POFFIN",
+    "name": "Poffin"
   },
   "801": {
     "protoname": "ITEM_SPECIAL_CAMERA",
@@ -129,11 +141,11 @@
   },
   "901": {
     "protoname": "ITEM_INCUBATOR_BASIC_UNLIMITED",
-    "name": "Unlimited Incubator"
+    "name": "Egg Incubator ∞"
   },
   "902": {
     "protoname": "ITEM_INCUBATOR_BASIC",
-    "name": "Incubator"
+    "name": "Egg Incubator"
   },
   "903": {
     "protoname": "ITEM_INCUBATOR_SUPER",
@@ -141,11 +153,11 @@
   },
   "1001": {
     "protoname": "ITEM_POKEMON_STORAGE_UPGRADE",
-    "name": "Pokémon Storage Upgrade"
+    "name": "ITEM_POKEMON_STORAGE_UPGRADE"
   },
   "1002": {
     "protoname": "ITEM_ITEM_STORAGE_UPGRADE",
-    "name": "Item Storage Upgrade"
+    "name": "ITEM_ITEM_STORAGE_UPGRADE"
   },
   "1101": {
     "protoname": "ITEM_SUN_STONE",
@@ -153,7 +165,7 @@
   },
   "1102": {
     "protoname": "ITEM_KINGS_ROCK",
-    "name": "Kings Rock"
+    "name": "King's Rock"
   },
   "1103": {
     "protoname": "ITEM_METAL_COAT",
@@ -165,7 +177,7 @@
   },
   "1105": {
     "protoname": "ITEM_UP_GRADE",
-    "name": "Item Upgrade"
+    "name": "Upgrade"
   },
   "1106": {
     "protoname": "ITEM_GEN4_EVOLUTION_STONE",
@@ -181,7 +193,15 @@
   },
   "1202": {
     "protoname": "ITEM_MOVE_REROLL_SPECIAL_ATTACK",
-    "name": "Charge TM"
+    "name": "Charged TM"
+  },
+  "1203": {
+    "protoname": "ITEM_MOVE_REROLL_ELITE_FAST_ATTACK",
+    "name": "Elite Fast TM"
+  },
+  "1204": {
+    "protoname": "ITEM_MOVE_REROLL_ELITE_SPECIAL_ATTACK",
+    "name": "Elite Charged TM"
   },
   "1301": {
     "protoname": "ITEM_RARE_CANDY",
@@ -189,11 +209,11 @@
   },
   "1401": {
     "protoname": "ITEM_FREE_RAID_TICKET",
-    "name": "Free Raid Pass"
+    "name": "Raid Pass"
   },
   "1402": {
     "protoname": "ITEM_PAID_RAID_TICKET",
-    "name": "Paid Raid Pass"
+    "name": "Premium Battle Pass"
   },
   "1403": {
     "protoname": "ITEM_LEGENDARY_RAID_TICKET",
@@ -206,5 +226,33 @@
   "1405": {
     "protoname": "ITEM_FRIEND_GIFT_BOX",
     "name": "Gift"
+  },
+  "1406": {
+    "protoname": "ITEM_TEAM_CHANGE",
+    "name": "Team Medallion"
+  },
+  "1408": {
+    "protoname": "ITEM_REMOTE_RAID_TICKET",
+    "name": "Remote Raid Pass"
+  },
+  "1501": {
+    "protoname": "ITEM_LEADER_MAP_FRAGMENT",
+    "name": "Mysterious Component"
+  },
+  "1502": {
+    "protoname": "ITEM_LEADER_MAP",
+    "name": "Rocket Radar"
+  },
+  "1503": {
+    "protoname": "ITEM_GIOVANNI_MAP",
+    "name": "Super Rocket Radar"
+  },
+  "1600": {
+    "protoname": "ITEM_GLOBAL_EVENT_TICKET",
+    "name": "Ticket"
+  },
+  "1601": {
+    "protoname": "ITEM_EVENT_TICKET_PINK",
+    "name": "Ticket"
   }
 }

--- a/locale/fr/items.json
+++ b/locale/fr/items.json
@@ -1,4 +1,8 @@
 {
+  "0": {
+    "protoname": "ITEM_UNKNOWN",
+    "name": "ITEM_UNKNOWN"
+  },
   "1": {
     "protoname": "ITEM_POKE_BALL",
     "name": "Poké Ball"
@@ -17,7 +21,7 @@
   },
   "5": {
     "protoname": "ITEM_PREMIER_BALL",
-    "name": "Honor Ball"
+    "name": "ITEM_PREMIER_BALL"
   },
   "101": {
     "protoname": "ITEM_POTION",
@@ -53,15 +57,19 @@
   },
   "402": {
     "protoname": "ITEM_INCENSE_SPICY",
-    "name": "Incense Spicy"
+    "name": "ITEM_INCENSE_SPICY"
   },
   "403": {
     "protoname": "ITEM_INCENSE_COOL",
-    "name": "Incense Cool"
+    "name": "ITEM_INCENSE_COOL"
   },
   "404": {
     "protoname": "ITEM_INCENSE_FLORAL",
-    "name": "Incense Floral"
+    "name": "ITEM_INCENSE_FLORAL"
+  },
+  "405": {
+    "protoname": "ITEM_INCENSE_BELUGA_BOX",
+    "name": "Boîte Mystère"
   },
   "501": {
     "protoname": "ITEM_TROY_DISK",
@@ -89,7 +97,7 @@
   },
   "604": {
     "protoname": "ITEM_X_MIRACLE",
-    "name": "X Miracle"
+    "name": "UNDEFINED"
   },
   "701": {
     "protoname": "ITEM_RAZZ_BERRY",
@@ -117,11 +125,15 @@
   },
   "707": {
     "protoname": "ITEM_GOLDEN_NANAB_BERRY",
-    "name": "Baie Nanab dorée"
+    "name": "ITEM_GOLDEN_NANAB_BERRY"
   },
   "708": {
     "protoname": "ITEM_GOLDEN_PINAP_BERRY",
     "name": "Baie Nanana argentée"
+  },
+  "709": {
+    "protoname": "ITEM_POFFIN",
+    "name": "Poffin"
   },
   "801": {
     "protoname": "ITEM_SPECIAL_CAMERA",
@@ -141,11 +153,11 @@
   },
   "1001": {
     "protoname": "ITEM_POKEMON_STORAGE_UPGRADE",
-    "name": "Pokémon Storage Upgrade"
+    "name": "ITEM_POKEMON_STORAGE_UPGRADE"
   },
   "1002": {
     "protoname": "ITEM_ITEM_STORAGE_UPGRADE",
-    "name": "Item Storage Upgrade"
+    "name": "ITEM_ITEM_STORAGE_UPGRADE"
   },
   "1101": {
     "protoname": "ITEM_SUN_STONE",
@@ -183,6 +195,14 @@
     "protoname": "ITEM_MOVE_REROLL_SPECIAL_ATTACK",
     "name": "CT Attaque Chargée"
   },
+  "1203": {
+    "protoname": "ITEM_MOVE_REROLL_ELITE_FAST_ATTACK",
+    "name": "CT Attaque Immédiate d’élite"
+  },
+  "1204": {
+    "protoname": "ITEM_MOVE_REROLL_ELITE_SPECIAL_ATTACK",
+    "name": "CT Attaque Chargée d’élite"
+  },
   "1301": {
     "protoname": "ITEM_RARE_CANDY",
     "name": "Super Bonbon"
@@ -193,7 +213,7 @@
   },
   "1402": {
     "protoname": "ITEM_PAID_RAID_TICKET",
-    "name": "Passe de Raid Premium"
+    "name": "Passe de combat premium"
   },
   "1403": {
     "protoname": "ITEM_LEGENDARY_RAID_TICKET",
@@ -206,5 +226,33 @@
   "1405": {
     "protoname": "ITEM_FRIEND_GIFT_BOX",
     "name": "Cadeau"
+  },
+  "1406": {
+    "protoname": "ITEM_TEAM_CHANGE",
+    "name": "Médaillon d’équipe"
+  },
+  "1408": {
+    "protoname": "ITEM_REMOTE_RAID_TICKET",
+    "name": "Passe de Raid à distance"
+  },
+  "1501": {
+    "protoname": "ITEM_LEADER_MAP_FRAGMENT",
+    "name": "Élément mystérieux"
+  },
+  "1502": {
+    "protoname": "ITEM_LEADER_MAP",
+    "name": "Radar Rocket"
+  },
+  "1503": {
+    "protoname": "ITEM_GIOVANNI_MAP",
+    "name": "Super Radar Rocket"
+  },
+  "1600": {
+    "protoname": "ITEM_GLOBAL_EVENT_TICKET",
+    "name": "Ticket"
+  },
+  "1601": {
+    "protoname": "ITEM_EVENT_TICKET_PINK",
+    "name": "Ticket"
   }
 }

--- a/scripts/parse_items_for_items_json.py
+++ b/scripts/parse_items_for_items_json.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import requests
+import json
+
+PROTO_URL = "https://raw.githubusercontent.com/Furtif/POGOProtos/master/src/POGOProtos/Inventory/Item/ItemId.proto"
+
+LANGS = {
+       "en": "https://raw.githubusercontent.com/PokeMiners/pogo_assets/master/Texts/Latest%20APK/i18n_english.json",
+       "de": "https://raw.githubusercontent.com/PokeMiners/pogo_assets/master/Texts/Latest%20APK/i18n_german.json",
+       "fr": "https://raw.githubusercontent.com/PokeMiners/pogo_assets/master/Texts/Latest%20APK/i18n_french.json"
+}
+
+ITEMS_DICT = {}
+
+# Get all items + numbers
+PROTO_TEXT = requests.get(PROTO_URL).text
+for line in PROTO_TEXT.split("\n"):
+    line = line.strip()
+    if not line.startswith("ITEM_"):
+        continue
+    #split power!
+    entry = line.split("=");
+    ITEMS_DICT[entry[1].strip().replace(";", "")] = { "protoname": entry[0].strip() }
+
+for LANG in LANGS:
+    ITEMS_LANG = ITEMS_DICT.copy();
+    LANG_DATA = requests.get(LANGS[LANG]).json()["data"]
+    # That is not really a json, this is array, convert to proper json
+    it = iter(LANG_DATA)
+    LANG_DICT = dict(zip(it, it))
+    for item_id in ITEMS_LANG:
+        item_key = ITEMS_LANG[item_id]["protoname"].lower() + "_name"
+        if item_key in LANG_DICT:
+           ITEMS_LANG[item_id]["name"] = LANG_DICT[item_key]
+        else:
+           ITEMS_LANG[item_id]["name"] = ITEMS_LANG[item_id]["protoname"]
+    filename = LANG + "_items.json"
+    with open(filename, "w") as outfile:
+        json.dump(ITEMS_LANG, outfile, indent=2, sort_keys=False, ensure_ascii=False)
+
+    # print everything
+    # print(json.dumps(ITEMS_LANG, indent=2, sort_keys=False, ensure_ascii=False))


### PR DESCRIPTION
It fixes some names, adds some missing items but it also adds items that are defined in protos, but do not have a name in lang files - so in theory not implemented(?) in-game. It uses theirs protoname for name there. In theory we could skip those if you guys want, but that is @fosJoddie decision I guess :D

Plus add a script that parses Furtif/POGOProtos and Poke_Miners in-game language files for future use, so no more copy-pasting if they put new things in, maybe.