### PR TITLE
Add is_ar_scan_eligible flag to pokestop and gyms

### DIFF
--- a/mapadroid/db/DbPogoProtoSubmit.py
+++ b/mapadroid/db/DbPogoProtoSubmit.py
@@ -291,12 +291,14 @@ class DbPogoProtoSubmit:
 
         query_stops = (
             "INSERT INTO pokestop (pokestop_id, enabled, latitude, longitude, last_modified, lure_expiration, "
-            "last_updated, active_fort_modifier, incident_start, incident_expiration, incident_grunt_type) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
+            "last_updated, active_fort_modifier, incident_start, incident_expiration, incident_grunt_type, "
+            "is_ar_scan_eligible) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
             "ON DUPLICATE KEY UPDATE last_updated=VALUES(last_updated), lure_expiration=VALUES(lure_expiration), "
             "last_modified=VALUES(last_modified), latitude=VALUES(latitude), longitude=VALUES(longitude), "
             "active_fort_modifier=VALUES(active_fort_modifier), incident_start=VALUES(incident_start), "
-            "incident_expiration=VALUES(incident_expiration), incident_grunt_type=VALUES(incident_grunt_type)"
+            "incident_expiration=VALUES(incident_expiration), incident_grunt_type=VALUES(incident_grunt_type), "
+            "is_ar_scan_eligible=VALUES(is_ar_scan_eligible) "
         )
 
         stops_args = []
@@ -414,13 +416,13 @@ class DbPogoProtoSubmit:
 
         query_gym = (
             "INSERT INTO gym (gym_id, team_id, guard_pokemon_id, slots_available, enabled, latitude, longitude, "
-            "total_cp, is_in_battle, last_modified, last_scanned, is_ex_raid_eligible) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
+            "total_cp, is_in_battle, last_modified, last_scanned, is_ex_raid_eligible, is_ar_scan_eligible) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
             "ON DUPLICATE KEY UPDATE "
             "guard_pokemon_id=VALUES(guard_pokemon_id), team_id=VALUES(team_id), "
             "slots_available=VALUES(slots_available), last_scanned=VALUES(last_scanned), "
             "last_modified=VALUES(last_modified), latitude=VALUES(latitude), longitude=VALUES(longitude), "
-            "is_ex_raid_eligible=VALUES(is_ex_raid_eligible)"
+            "is_ex_raid_eligible=VALUES(is_ex_raid_eligible), is_ar_scan_eligible=VALUES(is_ar_scan_eligible)"
         )
         query_gym_details = (
             "INSERT INTO gymdetails (gym_id, name, url, last_scanned) "
@@ -442,6 +444,7 @@ class DbPogoProtoSubmit:
                     last_modified = datetime.utcfromtimestamp(
                         last_modified_ts).strftime("%Y-%m-%d %H:%M:%S")
                     is_ex_raid_eligible = gym["gym_details"]["is_ex_raid_eligible"]
+                    is_ar_scan_eligible = gym["is_ar_scan_eligible"]
 
                     gym_args.append(
                         (
@@ -452,7 +455,8 @@ class DbPogoProtoSubmit:
                             0,  # is_in_battle
                             last_modified,  # last_modified
                             now,  # last_scanned
-                            is_ex_raid_eligible
+                            is_ex_raid_eligible,
+                            is_ar_scan_eligible
                         )
                     )
 

--- a/mapadroid/db/DbPogoProtoSubmit.py
+++ b/mapadroid/db/DbPogoProtoSubmit.py
@@ -663,6 +663,7 @@ class DbPogoProtoSubmit:
         incident_start = None
         incident_expiration = None
         incident_grunt_type = None
+        is_ar_scan_eligible = stop_data["is_ar_scan_eligible"]
 
         if len(stop_data["active_fort_modifier"]) > 0:
             # get current lure duration

--- a/mapadroid/db/DbPogoProtoSubmit.py
+++ b/mapadroid/db/DbPogoProtoSubmit.py
@@ -709,7 +709,7 @@ class DbPogoProtoSubmit:
 
         return (stop_data["id"], 1, stop_data["latitude"], stop_data["longitude"],
                 last_modified, lure, now, active_fort_modifier,
-                incident_start, incident_expiration, incident_grunt_type
+                incident_start, incident_expiration, incident_grunt_type, is_ar_scan_eligible
                 )
 
     def _extract_args_single_stop_details(self, stop_data):

--- a/mapadroid/db/DbWebhookReader.py
+++ b/mapadroid/db/DbWebhookReader.py
@@ -102,7 +102,7 @@ class DbWebhookReader:
         query = (
             "SELECT name, description, url, gym.gym_id, team_id, guard_pokemon_id, slots_available, "
             "latitude, longitude, total_cp, is_in_battle, weather_boosted_condition, "
-            "last_modified, gym.last_scanned, gym.is_ex_raid_eligible "
+            "last_modified, gym.last_scanned, gym.is_ex_raid_eligible, gym.is_ar_scan_eligible "
             "FROM gym "
             "LEFT JOIN gymdetails ON gym.gym_id = gymdetails.gym_id "
             "WHERE gym.last_scanned >= %s"
@@ -129,7 +129,8 @@ class DbWebhookReader:
                 "name": name,
                 "url": url,
                 "description": description,
-                "is_ex_raid_eligible": is_ex_raid_eligible
+                "is_ex_raid_eligible": is_ex_raid_eligible,
+                "is_ar_scan_eligible": is_ar_scan_eligible
             })
         return ret
 

--- a/mapadroid/db/DbWebhookReader.py
+++ b/mapadroid/db/DbWebhookReader.py
@@ -113,7 +113,7 @@ class DbWebhookReader:
         ret = []
         for (name, description, url, gym_id, team_id, guard_pokemon_id, slots_available,
              latitude, longitude, total_cp, is_in_battle, weather_boosted_condition,
-             last_modified, last_scanned, is_ex_raid_eligible) in res:
+             last_modified, last_scanned, is_ex_raid_eligible, is_ar_scan_eligible) in res:
             ret.append({
                 "gym_id": gym_id,
                 "team_id": team_id,

--- a/mapadroid/db/DbWrapper.py
+++ b/mapadroid/db/DbWrapper.py
@@ -293,7 +293,7 @@ class DbWrapper:
             "trs_quest.quest_pokemon_costume_id, trs_quest.quest_reward_type, "
             "trs_quest.quest_item_id, trs_quest.quest_item_amount, pokestop.name, pokestop.image, "
             "trs_quest.quest_target, trs_quest.quest_condition, trs_quest.quest_timestamp, "
-            "trs_quest.quest_task, trs_quest.quest_reward, trs_quest.quest_template "
+            "trs_quest.quest_task, trs_quest.quest_reward, trs_quest.quest_template, pokestop.is_ar_scan_eligible "
             "FROM pokestop INNER JOIN trs_quest ON pokestop.pokestop_id = trs_quest.GUID "
             "WHERE DATE(from_unixtime(trs_quest.quest_timestamp,'%Y-%m-%d')) = CURDATE() "
         )
@@ -328,7 +328,7 @@ class DbWrapper:
         for (pokestop_id, latitude, longitude, quest_type, quest_stardust, quest_pokemon_id,
              quest_pokemon_form_id, quest_pokemon_costume_id, quest_reward_type,
              quest_item_id, quest_item_amount, name, image, quest_target, quest_condition,
-             quest_timestamp, quest_task, quest_reward, quest_template) in res:
+             quest_timestamp, quest_task, quest_reward, quest_template, is_ar_scan_eligible) in res:
             mon = "%03d" % quest_pokemon_id
             form_id = "%02d" % quest_pokemon_form_id
             costume_id = "%02d" % quest_pokemon_costume_id
@@ -341,7 +341,9 @@ class DbWrapper:
                 'quest_item_amount': quest_item_amount, 'name': name, 'image': image,
                 'quest_target': quest_target,
                 'quest_condition': quest_condition, 'quest_timestamp': quest_timestamp,
-                'task': quest_task, 'quest_reward': quest_reward, 'quest_template': quest_template})
+                'task': quest_task, 'quest_reward': quest_reward, 'quest_template': quest_template,
+                'is_ar_scan_eligible': is_ar_scan_eligible
+            })
 
         return questinfo
 

--- a/mapadroid/patcher/__init__.py
+++ b/mapadroid/patcher/__init__.py
@@ -45,7 +45,8 @@ MAD_UPDATES = OrderedDict([
     (36, 'pokemon_iv_index'),
     (37, 'move_ptc_accounts'),
     (38, 'remove_hatch_delay'),
-    (39, 'extend_trs_quest_pogodroid_190')
+    (39, 'extend_trs_quest_pogodroid_190'),
+    (40, 'add_is_ar_scan_eligible')
 ])
 
 

--- a/mapadroid/patcher/add_is_ar_scan_eligible.py
+++ b/mapadroid/patcher/add_is_ar_scan_eligible.py
@@ -11,7 +11,8 @@ class Patch(PatchBase):
             ADD COLUMN `is_ar_scan_eligible` tinyint(1) NOT NULL DEFAULT '0';
         """
         try:
-            self._db.execute(alter_pokestop, commit=True, raise_exec=True)
+            if not self._schema_updater.check_column_exists("pokestop", "is_ar_scan_eligible"):
+                self._db.execute(alter_pokestop, commit=True, raise_exec=True)
         except Exception as e:
             self._logger.exception("Unexpected error: {}", e)
             self.issues = True
@@ -21,7 +22,8 @@ class Patch(PatchBase):
             ADD COLUMN `is_ar_scan_eligible` tinyint(1) NOT NULL DEFAULT '0';
         """
         try:
-            self._db.execute(alter_gym, commit=True, raise_exec=True)
+            if not self._schema_updater.check_column_exists("gym", "is_ar_scan_eligible"):
+                self._db.execute(alter_gym, commit=True, raise_exec=True)
         except Exception as e:
             self._logger.exception("Unexpected error: {}", e)
             self.issues = True

--- a/mapadroid/patcher/add_is_ar_scan_eligible.py
+++ b/mapadroid/patcher/add_is_ar_scan_eligible.py
@@ -7,7 +7,7 @@ class Patch(PatchBase):
 
     def _execute(self):
         alter_pokestop = """
-            ALTER TABLE `pokestop` 
+            ALTER TABLE `pokestop`
             ADD COLUMN `is_ar_scan_eligible` tinyint(1) NOT NULL DEFAULT '0';
         """
         try:
@@ -15,9 +15,9 @@ class Patch(PatchBase):
         except Exception as e:
             self._logger.exception("Unexpected error: {}", e)
             self.issues = True
-            
+
         alter_gym = """
-            ALTER TABLE `gym` 
+            ALTER TABLE `gym`
             ADD COLUMN `is_ar_scan_eligible` tinyint(1) NOT NULL DEFAULT '0';
         """
         try:

--- a/mapadroid/patcher/add_is_ar_scan_eligible.py
+++ b/mapadroid/patcher/add_is_ar_scan_eligible.py
@@ -1,0 +1,27 @@
+from ._patch_base import PatchBase
+
+
+class Patch(PatchBase):
+    name = 'Add add_is_ar_scan_eligible flag to pokestop and gyms'
+    descr = 'New Protos, more useless data!'
+
+    def _execute(self):
+        alter_pokestop = """
+            ALTER TABLE `pokestop` 
+            ADD COLUMN `is_ar_scan_eligible` tinyint(1) NOT NULL DEFAULT '0';
+        """
+        try:
+            self._db.execute(alter_pokestop, commit=True, raise_exec=True)
+        except Exception as e:
+            self._logger.exception("Unexpected error: {}", e)
+            self.issues = True
+            
+        alter_gym = """
+            ALTER TABLE `gym` 
+            ADD COLUMN `is_ar_scan_eligible` tinyint(1) NOT NULL DEFAULT '0';
+        """
+        try:
+            self._db.execute(alter_gym, commit=True, raise_exec=True)
+        except Exception as e:
+            self._logger.exception("Unexpected error: {}", e)
+            self.issues = True

--- a/mapadroid/utils/questGen.py
+++ b/mapadroid/utils/questGen.py
@@ -82,6 +82,7 @@ def generate_quest(quest):
         'quest_target': quest['quest_target'],
         'quest_condition': quest['quest_condition'],
         'quest_template': quest['quest_template'],
+        'is_ar_scan_eligible': quest['is_ar_scan_eligible'],
 
     })
     return quest_raw

--- a/mapadroid/webhook/webhookworker.py
+++ b/mapadroid/webhook/webhookworker.py
@@ -164,6 +164,7 @@ class WebhookWorker:
                 "quest_task": quest["quest_task"],
                 "quest_condition": quest["quest_condition"].replace("'", '"').lower(),
                 "quest_template": quest["quest_template"],
+                "is_ar_scan_eligible": quest["is_ar_scan_eligible"],
             }
 
         # Other known type is Poracle/RDM compatible.

--- a/mapadroid/webhook/webhookworker.py
+++ b/mapadroid/webhook/webhookworker.py
@@ -441,6 +441,7 @@ class WebhookWorker:
                 "team_id": gym["team_id"],
                 "name": gym["name"],
                 "slots_available": gym["slots_available"],
+                "is_ar_scan_eligible": gym["is_ar_scan_eligible"]
             }
 
             if gym.get("description", None) is not None:

--- a/scripts/SQL/rocketmap.sql
+++ b/scripts/SQL/rocketmap.sql
@@ -40,6 +40,7 @@ CREATE TABLE `gym` (
     `last_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `last_scanned` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `is_ex_raid_eligible` tinyint(1) NOT NULL DEFAULT '0',
+    `is_ar_scan_eligible` tinyint(1) NOT NULL DEFAULT '0'
     PRIMARY KEY (`gym_id`),
     KEY `gym_last_modified` (`last_modified`),
     KEY `gym_last_scanned` (`last_scanned`),
@@ -136,6 +137,7 @@ CREATE TABLE `pokestop` (
     `incident_start` datetime DEFAULT NULL,
     `incident_expiration` datetime DEFAULT NULL,
     `incident_grunt_type` smallint(1) DEFAULT NULL,
+    `is_ar_scan_eligible` tinyint(1) NOT NULL DEFAULT '0',
     `encounter_id` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
     PRIMARY KEY (`pokestop_id`),
     KEY `pokestop_last_modified` (`last_modified`),

--- a/scripts/SQL/rocketmap.sql
+++ b/scripts/SQL/rocketmap.sql
@@ -40,7 +40,7 @@ CREATE TABLE `gym` (
     `last_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `last_scanned` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `is_ex_raid_eligible` tinyint(1) NOT NULL DEFAULT '0',
-    `is_ar_scan_eligible` tinyint(1) NOT NULL DEFAULT '0'
+    `is_ar_scan_eligible` tinyint(1) NOT NULL DEFAULT '0',
     PRIMARY KEY (`gym_id`),
     KEY `gym_last_modified` (`last_modified`),
     KEY `gym_last_scanned` (`last_scanned`),


### PR DESCRIPTION
This is totally useless now, nothing supports this, but could be useful in future.

gyms & quests webhook uses that flag. We don't have webhook for pokestop changes (and that would need a lot of logic), so I ended up and put that in quests - once day, should be good enough.