### PR TITLE
Update dev build to better support multi-os

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = PIL,aioconsole,apkutils,bitstring,configargparse,cv2,flask,flask_caching,gevent,google,gpapi,gpxdata,imutils,loguru,mysql,numpy,pkg_resources,psutil,pytesseract,pytest,requests,s2sphere,urllib3,websockets,werkzeug
+known_third_party = PIL,aioconsole,apkutils,bitstring,configargparse,cv2,dataclasses,flask,flask_caching,gevent,google,gpapi,gpxdata,imutils,loguru,mysql,numpy,pkg_resources,psutil,pytesseract,pytest,requests,s2sphere,urllib3,websockets,werkzeug

--- a/Makefile
+++ b/Makefile
@@ -98,11 +98,11 @@ clean-tox:
 
 build:
 	docker build --file docker/Dockerfile --tag ${LOCAL_MAD_IMAGE} .
-	docker-compose -f ${COMPOSE_FILE_DEV} build --no-cache  --build-arg UID=${UID} --build-arg GUID=${GID}
+	docker-compose -f ${COMPOSE_FILE_DEV} build --no-cache
 
 rebuild:
 	docker build --file docker/Dockerfile --tag ${LOCAL_MAD_IMAGE} .
-	docker-compose -f ${COMPOSE_FILE_DEV} build  --build-arg UID=${UID} --build-arg GID=${GID}
+	docker-compose -f ${COMPOSE_FILE_DEV} build
 
 setup-precommit:
 	$(pip_precommit_installation)
@@ -116,7 +116,7 @@ up:
 	docker-compose -f ${COMPOSE_FILE_DEV} up --detach
 
 shell: up
-	docker-compose -f ${COMPOSE_FILE_DEV} exec -u $(UID) $(CONTAINER_NAME) $(CMD)
+	docker-compose -f ${COMPOSE_FILE_DEV} exec $(CONTAINER_NAME) $(CMD)
 
 root-shell: up
 	docker-compose -f ${COMPOSE_FILE_DEV} exec -u root $(CONTAINER_NAME) $(CMD)
@@ -125,10 +125,10 @@ down:
 	docker-compose -f ${COMPOSE_FILE_DEV} down
 
 tests: up
-	docker-compose -f ${COMPOSE_FILE_DEV} exec -u $(UID) mapadroid-dev tox
+	docker-compose -f ${COMPOSE_FILE_DEV} exec mapadroid-dev tox
 
 unittests: up
-	docker-compose -f ${COMPOSE_FILE_DEV} exec -u $(UID) mapadroid-dev tox -e py37
+	docker-compose -f ${COMPOSE_FILE_DEV} exec mapadroid-dev tox -e py37
 
 # Run bash within a defined tox environment
 # Specify a valid tox environment as such:
@@ -137,9 +137,9 @@ unittests: up
 #   make shell-py37 RECREATE=1
 shell-%: up
 ifdef RECREATE
-	docker-compose -f ${COMPOSE_FILE_DEV} exec -u $(UID) mapadroid-dev tox -e $* --recreate -- bash
+	docker-compose -f ${COMPOSE_FILE_DEV} exec mapadroid-dev tox -e $* --recreate -- bash
 else
-	docker-compose -f ${COMPOSE_FILE_DEV} exec -u $(UID) mapadroid-dev tox -e $* -- bash
+	docker-compose -f ${COMPOSE_FILE_DEV} exec mapadroid-dev tox -e $* -- bash
 endif
 
 versions:

--- a/Makefile
+++ b/Makefile
@@ -98,11 +98,11 @@ clean-tox:
 
 build:
 	docker build --file docker/Dockerfile --tag ${LOCAL_MAD_IMAGE} .
-	docker-compose -f ${COMPOSE_FILE_DEV} build --no-cache
+	docker-compose -f ${COMPOSE_FILE_DEV} build --no-cache  --build-arg UID=${UID} --build-arg GUID=${GID}
 
 rebuild:
 	docker build --file docker/Dockerfile --tag ${LOCAL_MAD_IMAGE} .
-	docker-compose -f ${COMPOSE_FILE_DEV} build
+	docker-compose -f ${COMPOSE_FILE_DEV} build  --build-arg UID=${UID} --build-arg GID=${GID}
 
 setup-precommit:
 	$(pip_precommit_installation)

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -17,8 +17,8 @@ libffi-dev libgdbm-dev libsqlite3-dev libssl-dev zlib1g-dev
 
 # Map the user to avoid perm conflict
 ARG USER_NAME=dockeruser
-ARG UID=1000
-ARG GID=1000
+ARG UID=${UID}
+ARG GID=${GID}
 RUN groupadd -g $GID $USER_NAME; useradd -l -r -m -u $UID -g $GID $USER_NAME
 ENV USER $USER_NAME
 # Install pyenv

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,11 +1,15 @@
 # Development env
 FROM local_mad_production:latest AS dev_test
-RUN pip install tox
 # Versions of python to install for pyenv. These are used when tox executes specific
 # python versions. The correct versions need to be added to tox.ini under tox/envlist
 ENV PYTHON_VERSIONS 3.6.0 3.7.0 3.8.0
-COPY requirements-test.txt /usr/src/app/
+# User information related to how to run within the shell
+ARG USER_NAME=dockeruser
+ARG UID=1000
+ARG GID=1000
+ENV USER $USER_NAME
 ENTRYPOINT ["bash"]
+
 # Need to re-add some required dependencies for tox to compile the new envs
 RUN apt-get install -y --no-install-recommends \
 # pyenv
@@ -13,27 +17,26 @@ build-essential libssl-dev zlib1g-dev libbz2-dev \
 libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
 xz-utils tk-dev libffi-dev liblzma-dev python-openssl git \
 # python build
-libffi-dev libgdbm-dev libsqlite3-dev libssl-dev zlib1g-dev
+libffi-dev libgdbm-dev libsqlite3-dev libssl-dev zlib1g-dev && \
+# Create user
+groupadd -g $GID $USER_NAME; \
+useradd -l -r -m -u $UID -g $GID $USER_NAME && \
+# Install tox
+pip install tox
 
-# Map the user to avoid perm conflict
-ARG USER_NAME=dockeruser
-ARG UID=${UID}
-ARG GID=${GID}
-RUN groupadd -g $GID $USER_NAME; useradd -l -r -m -u $UID -g $GID $USER_NAME
-ENV USER $USER_NAME
 # Install pyenv
-# @TODO - How to install as a user and not root?
-ENV HOME=/home/dockeruser
+ENV HOME=/home/${USER}
 ENV PYENV_ROOT $HOME/.pyenv
-ENV PATH="$PYENV_ROOT/bin:$PATH"
-ENV PATH="$PYENV_ROOT/shims:$PATH"
-RUN curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
-RUN chown -R dockeruser:dockeruser -R $HOME
-RUN for version in $PYTHON_VERSIONS; do \
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+WORKDIR ${HOME}
+USER $USER_NAME
+RUN curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash && \
+for version in $PYTHON_VERSIONS; do \
       pyenv install $version; \
       pyenv local $version; \
       pip install --upgrade setuptools pip; \
       pyenv local --unset; \
-    done
-RUN echo "pyenv local $PYTHON_VERSIONS" >> ~/.bashrc
-RUN pyenv local $PYTHON_VERSIONS
+    done && \
+echo "pyenv local $PYTHON_VERSIONS" >> ~/.bashrc && \
+pyenv local $PYTHON_VERSIONS
+WORKDIR /usr/src/app


### PR DESCRIPTION
An issue was occurring where MacOS refused to build / run tests due to UID issues. This PR addresses those UID issues and optimizes the build for the development environment by reducing the layers and modifying some commands.