### PR TITLE
Unit-tests for the ResourceTracker / Data Manager

### DIFF
--- a/.github/workflows/tox_testing.yml
+++ b/.github/workflows/tox_testing.yml
@@ -1,6 +1,10 @@
 name: Python package
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/tox_testing.yml
+++ b/.github/workflows/tox_testing.yml
@@ -1,0 +1,24 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -28,6 +28,7 @@ services:
       - .dev.env
     tty: true
     command: ["bash"]
+    # command: ["/usr/src/app/.tox/py37/bin/python", "/usr/src/app/start.py", "-ut"]
 
   mariadb:
     image: mariadb:10.3

--- a/mapadroid/data_manager/__init__.py
+++ b/mapadroid/data_manager/__init__.py
@@ -1,17 +1,14 @@
 import collections
 import copy
-from typing import Optional, List, Dict
-from . import modules
-from .dm_exceptions import (
-    ModeUnknown,
-    ModeNotSpecified,
-    InvalidSection,
-    DataManagerException
-)
-from .modules.resource import Resource
-from mapadroid.db.DbWrapper import DbWrapper
-from mapadroid.utils.logging import get_logger, LoggerEnums
+from typing import Dict, List, Optional
 
+from mapadroid.db.DbWrapper import DbWrapper
+from mapadroid.utils.logging import LoggerEnums, get_logger
+
+from . import modules
+from .dm_exceptions import (DataManagerException, InvalidSection,
+                            ModeNotSpecified, ModeUnknown)
+from .modules.resource import Resource
 
 logger = get_logger(LoggerEnums.data_manager)
 
@@ -68,9 +65,10 @@ class DataManager(object):
         if section == 'area':
             return modules.area_factory(self, identifier=identifier)
         try:
-            return modules.MAPPINGS[section](self, identifier=identifier)
+            class_def = modules.MAPPINGS[section]
         except KeyError:
             raise InvalidSection()
+        return class_def(self, identifier=identifier)
 
     def get_resource_def(self, section: str, **kwargs) -> Resource:
         mode = kwargs.get('mode', None)

--- a/mapadroid/data_manager/modules/resource.py
+++ b/mapadroid/data_manager/modules/resource.py
@@ -1,10 +1,13 @@
 import copy
 from collections import UserDict
-import mysql
-from ..dm_exceptions import DependencyError, SaveIssue, UnknownIdentifier, UpdateIssue
-from ..resource_search import get_search, SearchType
-from mapadroid.utils.logging import get_logger, LoggerEnums
 
+import mysql
+
+from mapadroid.utils.logging import LoggerEnums, get_logger
+
+from ..dm_exceptions import (DependencyError, SaveIssue, UnknownIdentifier,
+                             UpdateIssue)
+from ..resource_search import SearchType, get_search
 
 logger = get_logger(LoggerEnums.data_manager)
 
@@ -19,7 +22,7 @@ USER_READABLE_ERRORS = {
 
 
 class ResourceTracker(UserDict):
-    def __init__(self, config, data_manager, initialdata={}):
+    def __init__(self, config, data_manager, initialdata=None):
         self.__config = config
         self._data_manager = data_manager
         self.issues = {
@@ -30,6 +33,8 @@ class ResourceTracker(UserDict):
         }
         self.removal = []
         self.completed = False
+        if initialdata is None:
+            initialdata = {}
         super().__init__(initialdata)
         for key, entry in self.__config.items():
             try:
@@ -70,64 +75,20 @@ class ResourceTracker(UserDict):
             'missing': False,
             'unknown': False
         }
-        if key not in self.__config:
-            this_iteration['unknown'] = True
-            if key not in self.issues['unknown']:
-                self.issues['unknown'].append(key)
+        if not self.check_known_key(key):
             return
-        expected = self.__config[key]['settings'].get('expected', str)
-        required = self.__config[key]['settings'].get('require', False)
-        resource = self.__config[key]['settings'].get('data_source', None)
+        lookups = self.get_lookups(key)
         try:
-            empty = self.__config[key]['settings']['empty']
-            has_empty = True
-        except KeyError:
-            has_empty = False
-        if not isinstance(value, expected):
-            try:
-                if value is None and required is False:
-                    pass
-                else:
-                    try:
-                        if expected is list:
-                            raise ValueError
-                        value = self.format_value(value, expected)
-                    except Exception:
-                        if has_empty and (value == empty or value is None):
-                            if value != empty and value is None:
-                                value = empty
-                        else:
-                            this_iteration['invalid'] = True
-                            self.issues['invalid'].append((key, USER_READABLE_ERRORS[expected]))
-            except KeyError:
-                pass
-        try:
-            if len(value) == 0 and required:
-                if has_empty:
-                    value = empty
-                else:
-                    this_iteration['missing'] = True
-                    if key not in self.issues['missing']:
-                        self.issues['missing'].append(key)
-        except TypeError:
-            pass
-        # We only want to check sub-resources if we have finished the load from the DB
-        if resource and self.completed:
-            tmp = value
-            if type(value) != list:
-                tmp = [value]
-            invalid = []
-            for identifier in tmp:
-                try:
-                    self._data_manager.get_resource(resource, identifier=identifier)
-                except UnknownIdentifier:
-                    invalid.append((key, resource, identifier))
-            if invalid:
-                this_iteration['invalud_uri'] = True
-                if type(value) != list:
-                    self.issues['invalid_uri'].append(invalid[0])
-                else:
-                    self.issues['invalid_uri'].append(invalid)
+            value = self.process_format_value(lookups, key, value)
+        except ValueError:
+            this_iteration['invalid'] = True
+        if not self.check_required(lookups, key, value):
+            this_iteration['missing'] = True
+        # We only want to check sub-resources if we have finished the load from the DB. This is useful
+        # during DB migration when things arent fully updated yet
+        if lookups["resource"] and self.completed:
+            if not self.check_dependencies(lookups, key, value):
+                this_iteration['invalid_uri'] = True
         super().__setitem__(key, value)
         try:
             self.removal.remove(key)
@@ -142,10 +103,64 @@ class ResourceTracker(UserDict):
             except ValueError:
                 pass
 
-    def format_value(self, value, expected):
+    def check_dependencies(self, lookups, key, value):
+        tmp = value
+        if type(value) != list:
+            tmp = [value]
+        invalid = []
+        for identifier in tmp:
+            try:
+                self._data_manager.get_resource(lookups["resource"], identifier=identifier)
+            except UnknownIdentifier:
+                invalid.append((key, lookups["resource"], identifier))
+        if invalid:
+            if type(value) != list:
+                self.issues['invalid_uri'].append(invalid[0])
+            else:
+                self.issues['invalid_uri'].extend(invalid)
+            return False
+        return True
+
+    def check_known_key(self, key):
+        """ Determines if the key is valid for the config
+
+        :param str key: Key to check if it exists in the configuration
+
+        :return: If the key is valid
+        :rtype: bool
+        """
+        if key not in self.__config:
+            if key not in self.issues['unknown']:
+                self.issues['unknown'].append(key)
+            return False
+        return True
+
+    def check_required(self, lookups, key, value):
+        try:
+            if len(value) == 0 and lookups["required"]:
+                if not lookups["has_empty"]:
+                    if key not in self.issues['missing']:
+                        self.issues['missing'].append(key)
+                    return False
+        except TypeError:
+            pass
+        return True
+
+    @classmethod
+    def format_value(cls, value, expected):
         if expected == bool:
             if type(value) is str:
-                value = True if value.lower() == "true" else False
+                try:
+                    value = bool(int(value))
+                except ValueError as err:
+                    value = value.lower().strip()
+                    if value not in ["true", "false"]:
+                        raise ValueError from err
+                    value = True if value == "true" else False
+                except TypeError as err:
+                    raise ValueError from err
+            elif value is None:
+                raise ValueError
             else:
                 value = bool(value)
         elif expected == float:
@@ -154,6 +169,46 @@ class ResourceTracker(UserDict):
             value = int(value)
         elif expected == str:
             value = value.strip()
+        return value
+
+    def get_lookups(self, key):
+        """ Lookup required values and return as a dict"""
+        expected = self.__config[key]['settings'].get('expected', str)
+        required = self.__config[key]['settings'].get('require', False)
+        resource = self.__config[key]['settings'].get('data_source', None)
+        try:
+            empty = self.__config[key]['settings']['empty']
+            has_empty = True
+        except KeyError:
+            empty = None
+            has_empty = False
+        return {
+            "expected": expected,
+            "required": required,
+            "resource": resource,
+            "has_empty": has_empty,
+            "empty": empty
+        }
+
+    def process_format_value(self, lookups, key, value):
+        if not isinstance(value, lookups["expected"]):
+            try:
+                if value is None and lookups["required"] is False:
+                    pass
+                else:
+                    try:
+                        if lookups["expected"] is list:
+                            raise ValueError
+                        value = ResourceTracker.format_value(value, lookups["expected"])
+                    except Exception:  # noqa
+                        if lookups["has_empty"] and (value == lookups["empty"] or value is None):
+                            if value != lookups["empty"] and value is None:
+                                value = lookups["empty"]
+                        else:
+                            self.issues['invalid'].append((key, USER_READABLE_ERRORS[lookups["expected"]]))
+                            raise ValueError
+            except KeyError:
+                pass
         return value
 
 
@@ -355,10 +410,12 @@ class Resource(object):
             except TypeError:
                 continue
 
-    def presave_validation(self, ignore_issues=[]):
+    def presave_validation(self, ignore_issues=None):
         # Validate required data has been set
         top_levels = ['fields', 'settings']
         issues = {}
+        if ignore_issues is None:
+            ignore_issues = []
         for top_level in top_levels:
             try:
                 for issue_section, issue in self._data[top_level].issues.items():
@@ -385,7 +442,9 @@ class Resource(object):
                            issues)
             raise UpdateIssue(**issues)
 
-    def save(self, core_data=None, force_insert=False, ignore_issues=[], **kwargs):
+    def save(self, core_data=None, force_insert=False, ignore_issues=None, **kwargs):
+        if ignore_issues is None:
+            ignore_issues = []
         self.presave_validation(ignore_issues=ignore_issues)
         if core_data is None:
             data = self.get_core(clear=True)

--- a/tests/data_manager/test_core.py
+++ b/tests/data_manager/test_core.py
@@ -1,6 +1,9 @@
+from unittest.mock import call
+
 import pytest
 
 from mapadroid.data_manager import dm_exceptions, modules
+from mapadroid.data_manager.modules.auth import Auth
 
 
 def test_get_resource_class(data_manager):
@@ -23,4 +26,33 @@ def test_get_resource_class(data_manager):
 
 def test_get_resource_invalid(data_manager):
     with pytest.raises(dm_exceptions.UnknownIdentifier):
+        data_manager.dbc.autofetch_row.return_value = None
         data_manager.get_resource("device", 1)
+    with pytest.raises(dm_exceptions.UnknownIdentifier):
+        data_manager.dbc.autofetch_row.return_value = None
+        data_manager.get_resource("area", 1)
+
+
+def test_clear_on_boot(data_manager):
+    data_manager.clear_on_boot()
+    assert data_manager.dbc.mock_calls[0] == call.autoexec_update('settings_routecalc', {'recalc_status': 0},
+                                                                  where_keyvals={'instance_id': 1})
+    data_manager.instance_id = 1234
+    data_manager.clear_on_boot()
+    assert data_manager.dbc.mock_calls[1] == call.autoexec_update('settings_routecalc', {'recalc_status': 0},
+                                                                  where_keyvals={'instance_id': 1234})
+
+
+def test_save_resource(data_manager):
+    resource = Auth(data_manager)
+    resource["username"] = "test"
+    resource["password"] = "pass"
+    resource.save()
+    assert data_manager.dbc.mock_calls[-1] == call.autoexec_insert("settings_auth", {'username': 'test',
+                                                                                     'password': 'pass',
+                                                                                     'instance_id': 1})
+    resource = Auth(data_manager)
+    resource["username"] = "test"
+    with pytest.raises(dm_exceptions.UpdateIssue) as issues:
+        resource.save()
+    assert issues.value.issues == {'missing': ['password']}

--- a/tests/data_manager/test_resource_tracker.py
+++ b/tests/data_manager/test_resource_tracker.py
@@ -1,0 +1,250 @@
+import copy
+
+import pytest
+
+from mapadroid.data_manager.modules import PogoAuth, Walker, area_pokestops
+from mapadroid.data_manager.modules.resource import ResourceTracker
+
+
+def get_resource_tracker(data_manager, resource, section, populate_defaults=False, initial_data=None):
+    defaults = {}
+    if populate_defaults:
+        for field, default_value in resource.configuration[section].items():
+            try:
+                defaults[field] = default_value['settings']['empty']
+            except KeyError:
+                continue
+    elif initial_data:
+        defaults = initial_data
+    return ResourceTracker(copy.deepcopy(resource.configuration[section]), data_manager, initialdata=defaults)
+
+
+@pytest.mark.usefixtures("data_manager")
+def test_check_known_key(data_manager):
+    tracker = get_resource_tracker(data_manager, PogoAuth, "fields")
+    assert not tracker.check_known_key("asdf")
+    assert "asdf" in tracker.issues["unknown"]
+    assert tracker.check_known_key("username")
+    assert "username" not in tracker.issues["unknown"]
+
+
+@pytest.mark.usefixtures("data_manager")
+def test_get_lookups(data_manager):
+    tracker = get_resource_tracker(data_manager, PogoAuth, "fields")
+    expected = {
+        "expected": str,
+        "required": True,
+        "resource": None,
+        "has_empty": False,
+        "empty": None
+    }
+    assert tracker.get_lookups("login_type") == expected
+    tracker = get_resource_tracker(data_manager, PogoAuth, "fields")
+    expected = {
+        "expected": int,
+        "required": False,
+        "resource": "device",
+        "has_empty": True,
+        "empty": None
+    }
+    assert tracker.get_lookups("device_id") == expected
+    tracker = get_resource_tracker(data_manager, area_pokestops.AreaPokestops, "fields")
+    expected = {
+        "expected": str,
+        "required": True,
+        "resource": None,
+        "has_empty": False,
+        "empty": None
+    }
+    assert tracker.get_lookups("name") == expected
+    tracker = get_resource_tracker(data_manager, area_pokestops.AreaPokestops, "fields")
+    expected = {
+        "expected": bool,
+        "required": True,
+        "resource": None,
+        "has_empty": True,
+        "empty": False
+    }
+    assert tracker.get_lookups("init") == expected
+    tracker = get_resource_tracker(data_manager, Walker, "fields")
+    expected = {
+        "expected": list,
+        "required": True,
+        "has_empty": True,
+        "empty": [],
+        "resource": "walkerarea"
+    }
+    assert tracker.get_lookups("setup") == expected
+
+
+def test_format_value():
+    assert ResourceTracker.format_value("True", bool)
+    assert not ResourceTracker.format_value("False", bool)
+    with pytest.raises(ValueError):
+        assert ResourceTracker.format_value("something", bool)
+    with pytest.raises(ValueError):
+        assert ResourceTracker.format_value(None, bool)
+    assert ResourceTracker.format_value("1", bool)
+    assert ResourceTracker.format_value(1, bool)
+    assert not ResourceTracker.format_value("0", bool)
+    assert not ResourceTracker.format_value(0, bool)
+    assert ResourceTracker.format_value(0, float) == 0.0
+    assert ResourceTracker.format_value(0.0, float) == 0.0
+    assert ResourceTracker.format_value("0", float) == 0.0
+    assert ResourceTracker.format_value(1.1, float) == 1.1
+    assert ResourceTracker.format_value("1.1", float) == 1.1
+    assert ResourceTracker.format_value(0, int) == 0
+    assert ResourceTracker.format_value(0.0, int) == 0
+    assert ResourceTracker.format_value("0", int) == 0
+    assert ResourceTracker.format_value(1.1, int) == 1
+    assert ResourceTracker.format_value("1", int) == 1
+    assert ResourceTracker.format_value("test", str) == "test"
+    assert ResourceTracker.format_value("test ", str) == "test"
+    assert ResourceTracker.format_value(" test ", str) == "test"
+
+
+@pytest.mark.usefixtures("data_manager")
+def test_process_format_value(data_manager):
+    tracker = get_resource_tracker(data_manager, PogoAuth, "fields")
+    lookups = {
+        "expected": str,
+        "required": True,
+        "has_empty": False,
+        "empty": None
+    }
+    assert tracker.process_format_value(lookups, "login_type", "ptc") == "ptc"
+    lookups = {
+        "expected": str,
+        "required": True,
+        "has_empty": False,
+        "empty": None
+    }
+    assert tracker.process_format_value(lookups, "login_type", "ptc2") == "ptc2"
+    lookups = {
+        "expected": str,
+        "required": True,
+        "has_empty": True,
+        "empty": "empty val"
+    }
+    assert tracker.process_format_value(lookups, "login_type", None) == lookups["empty"]
+    lookups = {
+        "expected": str,
+        "required": False,
+        "has_empty": False,
+        "empty": None
+    }
+    assert tracker.process_format_value(lookups, "login_type", None) is None
+    lookups = {
+        "expected": bool,
+        "required": True,
+        "has_empty": False,
+        "empty": None
+    }
+    with pytest.raises(ValueError):
+        tracker.process_format_value(lookups, "login_type", "f")
+    assert tracker.issues["invalid"][0][0] == "login_type"
+    with pytest.raises(ValueError):
+        tracker.process_format_value(lookups, "login_type", None)
+    assert tracker.issues["invalid"][1][0] == "login_type"
+    tracker = get_resource_tracker(data_manager, Walker, "fields")
+    lookups = {
+        "expected": list,
+        "required": True,
+        "has_empty": True,
+        "empty": []
+    }
+    assert tracker.process_format_value(lookups, "setup", None) == []
+
+
+@pytest.mark.usefixtures("data_manager")
+def test_check_required(data_manager):
+    tracker = get_resource_tracker(data_manager, PogoAuth, "fields")
+    lookups = {
+        "required": True,
+        "has_empty": True,
+        "empty": 1
+    }
+    assert tracker.check_required(lookups, "test", "True")
+    lookups = {
+        "required": False,
+        "has_empty": True,
+        "empty": 1
+    }
+    assert tracker.check_required(lookups, "test", "True")
+    lookups = {
+        "required": True,
+        "has_empty": False,
+    }
+    assert not tracker.check_required(lookups, "test", "")
+    assert "test" in tracker.issues["missing"]
+    lookups = {
+        "required": False,
+        "has_empty": True,
+        "empty": 1
+    }
+    assert tracker.check_required(lookups, "test", None)
+
+
+@pytest.mark.usefixtures("data_manager")
+def test_check_dependencies(data_manager):
+    tracker = get_resource_tracker(data_manager, area_pokestops.AreaPokestops, "fields")
+    routecalc = {
+        "routecalc_id": 1,
+        "routefile": "[]",
+        "recalc_status": 0
+    }
+    lookups = {
+        "resource": "routecalc"
+    }
+    data_manager.dbc.autofetch_row.return_value = routecalc
+    tracker.check_dependencies(lookups, "routecalc", 1)
+    tracker.check_dependencies(lookups, "routecalc", [1, 2])
+    data_manager.dbc.autofetch_row.return_value = None
+    tracker.check_dependencies(lookups, "routecalc", 1)
+    assert tracker.issues["invalid_uri"][0] == ("routecalc", "routecalc", 1)
+    tracker = get_resource_tracker(data_manager, area_pokestops.AreaPokestops, "fields")
+    tracker.check_dependencies(lookups, "routecalc", [1, 2])
+    assert tracker.issues["invalid_uri"][0] == ("routecalc", "routecalc", 1)
+    assert tracker.issues["invalid_uri"][1] == ("routecalc", "routecalc", 2)
+
+
+@pytest.mark.usefixtures("data_manager")
+@pytest.mark.parametrize("populate_defaults", [True, False])
+def test_driver_pogoauth(data_manager, populate_defaults):
+    tracker = get_resource_tracker(data_manager, PogoAuth, "fields", populate_defaults=populate_defaults)
+    expected = sorted(PogoAuth.configuration["fields"].keys())
+    expected.remove("device_id")
+    assert expected == sorted(tracker.issues["missing"])
+    tracker["login_type"] = "ptc"
+    expected.remove("login_type")
+    assert expected == sorted(tracker.issues["missing"])
+    tracker["username"] = "ptc"
+    expected.remove("username")
+    assert expected == sorted(tracker.issues["missing"])
+    tracker["password"] = "ptc"
+    expected.remove("password")
+    assert expected == sorted(tracker.issues["missing"])
+
+
+@pytest.mark.usefixtures("data_manager")
+def test_driver(data_manager):
+    tracker = get_resource_tracker(data_manager, Walker, "fields", populate_defaults=True)
+    assert "setup" not in tracker.issues["missing"]
+    tracker["setup"] = None
+    assert "setup" not in tracker.issues["missing"]
+    assert tracker["setup"] == []
+
+
+@pytest.mark.usefixtures("data_manager")
+def test_load(data_manager):
+    routecalc = {
+        "login_type": "ptc",
+        "username": "test_user",
+        "password": "test_pwd",
+        "device_id": None,
+    }
+    tracker = get_resource_tracker(data_manager, PogoAuth, "fields", initial_data=routecalc)
+    assert len(tracker.issues["invalid"]) == 0
+    assert len(tracker.issues["missing"]) == 0
+    assert len(tracker.issues["invalid_uri"]) == 0
+    assert len(tracker.issues["unknown"]) == 0

--- a/tests/fixtures/fixture_data_manager.py
+++ b/tests/fixtures/fixture_data_manager.py
@@ -5,9 +5,17 @@ from mapadroid.patcher import install_schema, reload_instance_id
 
 
 @pytest.fixture(scope='session')
-@pytest.mark.usefixtures("db_wrapper")
-def data_manager(db_wrapper):
+@pytest.mark.usefixtures("db_wrapper_real")
+def data_manager_real(db_wrapper):
     dm = DataManager(db_wrapper, None)
     install_schema(db_wrapper)
     reload_instance_id(dm)
     yield dm
+
+
+@pytest.fixture(scope='function')
+@pytest.mark.usefixtures("db_wrapper")
+def data_manager(db_wrapper):
+    db_wrapper.identifier = 1
+    dm = DataManager(db_wrapper, db_wrapper.identifier)
+    return dm

--- a/tests/fixtures/fixture_db_wrapper.py
+++ b/tests/fixtures/fixture_db_wrapper.py
@@ -1,5 +1,6 @@
 import os
 import platform
+from unittest.mock import MagicMock
 
 import pytest
 from mysql.connector import connection
@@ -9,7 +10,9 @@ from tests.conftest import args
 
 
 @pytest.fixture(scope='session')
-def db_wrapper():
+def db_wrapper_real():
+    """Use when the actual DB is required for testing. If it is, the code should be refactored so use the mocked
+    version"""
     # Update any walker args that need to be adjusted for this instance
     update_args_testing(args)
     # Prepare the database for the tox env
@@ -19,6 +22,12 @@ def db_wrapper():
     yield db_wrapper
     # Will be executed after the last test
     db_pool_manager.shutdown()
+
+
+@pytest.fixture(scope='function')
+def db_wrapper():
+    """Use when mocking the results of the DB query"""
+    return MagicMock()
 
 
 def get_db_name(ver: str) -> str:

--- a/tox.ini
+++ b/tox.ini
@@ -24,3 +24,10 @@ env_files =
 exclude = venv,.git,mapadroid/utils/questGen.py,scripts,configs,APK,.tox
 ignore = E402,W504,W503
 max-line-length = 120
+
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38


### PR DESCRIPTION
 * Converted the ResourceTracker into pure python functions to allow ease-of-use for Unit-Testing.
 * Added mocking for the base fixtures. Using the actual connections is still available (_real)
 * Added the action, tox-gh-actions. This will be used when we migrate off travis to GH Actions