### PR TITLE
Persistent testing env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,12 @@ shell: up
 root-shell: up
 	docker-compose -f ${COMPOSE_FILE_DEV} exec -u root $(CONTAINER_NAME) $(CMD)
 
+run: down
+	docker-compose -f ${COMPOSE_FILE_TEST} up
+
 down:
 	docker-compose -f ${COMPOSE_FILE_DEV} down
+	docker-compose -f ${COMPOSE_FILE_TEST} down
 
 tests: up
 	docker-compose -f ${COMPOSE_FILE_DEV} exec mapadroid-dev tox

--- a/docker/.dev.env
+++ b/docker/.dev.env
@@ -1,5 +1,6 @@
 COMPOSE_CONVERT_WINDOWS_PATHS=1
 COMPOSE_FILE_DEV=docker/docker-compose-dev.yaml
+COMPOSE_FILE_TEST=docker/docker-compose-test.yaml
 DOCKER_USER=dockeruser
 
 LOCAL_MAD_IMAGE=local_mad_production

--- a/docker/docker-compose-test.yaml
+++ b/docker/docker-compose-test.yaml
@@ -1,0 +1,38 @@
+version: "3.4"
+
+volumes:
+  pre-commit-cache:
+    name: pre-commit-cache
+
+services:
+  mapadroid-dev:
+    image: mapadroid-dev
+    build:
+      context: ../.
+      dockerfile: docker/Dockerfile-dev
+    # Use an empty entrypoint and mount local sources into container so that a simple
+    # `docker-compose run --service-ports python3 start.py` can be used to test current
+    # development in a defined environment.
+    # `docker-compose run bash` launch a shell inside the container.
+    entrypoint: ""
+    volumes:
+      - ../:/usr/src/app:rw
+      - pre-commit-cache:/home/${DOCKER_USER}/.cache/pre-commit
+    depends_on:
+      - mariadb
+    ports:
+      - "5000:5000"
+      - "8000:8000"
+      - "8080:8080"
+    env_file:
+      - .dev.env
+    tty: true
+    command: ["/usr/local/bin/python3", "start.py"]
+
+  mariadb:
+    image: mariadb:10.3
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
+    volumes:
+      - ~/mariadb/mad:/var/lib/mysql:rw
+    env_file:
+      - .dev.env

--- a/mapadroid/worker/WorkerQuests.py
+++ b/mapadroid/worker/WorkerQuests.py
@@ -868,8 +868,8 @@ class WorkerQuests(MITMBase):
             self.logger.debug("Considering stop {} at {} (last updated {}) for deletion",
                               fort_id, stop_location_known, last_updated)
             if last_updated and last_updated > datetime.now() - timedelta_to_consider_deletion:
-                self.logger.debug3("Stop considered for deletion was last updated recently, not gonna delete it for now.",
-                                   last_updated)
+                self.logger.debug3("Stop considered for deletion was last updated recently, not gonna delete it for"
+                                   "now.", last_updated)
                 continue
             distance_to_location = get_distance_of_two_points_in_meters(float(stop_location_known.lat),
                                                                         float(stop_location_known.lng),


### PR DESCRIPTION
This PR allows for a persistent testing environment between runs. This is helpful when you are doing testing and the containers are going offline.

* Add a command to run the test environment
 * Added a new docker-compose file, docker-compose-test, that maintains a Persistent MariaDB database