### PR TITLE
Restore delete button

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # Adding linting to tox
 38e69851c09c4bac7db8827091b22afcd2072bea
+# Flake8 enforcement (#932)
+3fa093fd0761f55091516e0e27cbe332d15905b0

--- a/static/madmin/templates/upload.html
+++ b/static/madmin/templates/upload.html
@@ -21,7 +21,7 @@
 <form method="post" action="{{ url_for("upload") }}" enctype="multipart/form-data">
   <dl>
     <p>
-      <input type="file" name="file" autocomplete="off" required>
+      <input type="file" name="file" autocomplete="off" required accept=".apk">
     </p>
   </dl>
   <p>

--- a/static/madmin/templates/uploaded_files.html
+++ b/static/madmin/templates/uploaded_files.html
@@ -35,7 +35,7 @@ function setGrid(tableGridHtmlId, gridData) {
                 "' title='Install on selected devices'><i class='fas fa-tasks'></i></a> <a href='install_file_all_devices?jobname=" +
                 row.jobname + "&type=" + row.type +
                 "' class='confirm' title='Do you really want to start this job on all devices?'><i class='fas fa-play-circle'></i></a>";
-              if(row.type == "jobType.INSTALLATION") {
+              if(row.type == "JobType.INSTALLATION") {
                 dellink = " <a href='delete_file?filename=" + row.jobname +
                   "' class='confirm' title='Do you really want to delete this file?'><i class='fas fa-trash-alt'></i></a>"
               }


### PR DESCRIPTION
Fixed a regression where the delete button no longer appeared for uploaded APKs. This bug was created during #932 when the name changed from "jobType" to "JobType" 

Updated the file-browser to default to *.apk files as they are the only extensions accepted (.txt is accepted too but i don't see how that is beneficial here...)