### PR TITLE
Wizard fixes

### DIFF
--- a/mapadroid/mad_apk/wizard.py
+++ b/mapadroid/mad_apk/wizard.py
@@ -311,7 +311,8 @@ class APKWizard(object):
                         version_code = current_version_code
                         version_str = current_version_string
                     else:
-                        return None
+                        version_code = latest_supported["versionCode"]
+                        version_str = latest_supported["version"]
                 elif current_version_code and store_version_code <= current_version_code:
                     logger.info(f"Latest store version is {store_version_string} while {current_version_string} is "
                                 "already installed. Unable to find a newer version")

--- a/mapadroid/mad_apk/wizard.py
+++ b/mapadroid/mad_apk/wizard.py
@@ -292,8 +292,8 @@ class APKWizard(object):
             if type(current_version_string) is not str:
                 current_version_string = None
             if current_version_string:
-                ls: dict = {architecture: current_version_string}
-                current_version_code = self.get_version_code(latest_supported=ls, arch=architecture)
+                latest_supported_dict: dict = {architecture: current_version_string}
+                current_version_code = self.get_version_code(latest_supported=latest_supported_dict, arch=architecture)
                 version_str = current_version_string
                 version_code = current_version_code
             # do some sanity checking until this is fixed properly

--- a/mapadroid/mad_apk/wizard.py
+++ b/mapadroid/mad_apk/wizard.py
@@ -391,7 +391,7 @@ class APKWizard(object):
                 return version_code
         # match not found locally.  Try GitHub
         try:
-            data = pogo_vc_sess.get(global_variables.VERSIONCODES_GITHUB).json()
+            data = pogo_vc_sess.get(global_variables.VERSIONCODES_URL).json()
         except Exception:
             pass
         else:

--- a/mapadroid/tests/mad_apk/test_wizard.py
+++ b/mapadroid/tests/mad_apk/test_wizard.py
@@ -58,7 +58,9 @@ class WizardTests(StorageBase):
         with self.assertRaises(WizardError):
             upload_package(self.storage_elem, apk_type=APKType.pd)
 
-    def test_version_newer_avail(self):
+    @patch('mapadroid.mad_apk.wizard.supported_pogo_version')
+    def test_version_newer_avail(self, supported_pogo_version):
+        supported_pogo_version.return_value = True
         with GetStorage(get_connection_api()) as storage:
             package_downloader = APKWizard(storage.db_wrapper, storage.storage_manager)
             gplay_latest = (20201001, "0.123.4")
@@ -81,7 +83,9 @@ class WizardTests(StorageBase):
             self.assertTrue(latest_supported[APKArch.arm64_v8a]["versionCode"] == wizard_latest["version_code"])
             self.assertTrue(latest_supported[APKArch.arm64_v8a]["version"] == wizard_latest["version"])
 
-    def test_version_supported_but_not_gplay(self):
+    @patch('mapadroid.mad_apk.wizard.supported_pogo_version')
+    def test_version_supported_but_not_gplay(self, supported_pogo_version):
+        supported_pogo_version.return_value = True
         with GetStorage(get_connection_api()) as storage:
             package_downloader = APKWizard(storage.db_wrapper, storage.storage_manager)
             gplay_latest = (20200901, "0.123.3")
@@ -100,7 +104,9 @@ class WizardTests(StorageBase):
             package_downloader.get_latest = MagicMock(return_value=autosearch_latest)
             GPlayConnector.get_latest_version = MagicMock(return_value=gplay_latest)
             wizard_latest = package_downloader.find_latest_pogo(APKArch.arm64_v8a)
-            self.assertTrue(wizard_latest is None)
+            self.assertTrue(wizard_latest is not None)
+            self.assertTrue(gplay_latest[0] == wizard_latest["version_code"])
+            self.assertTrue(gplay_latest[1] == wizard_latest["version"])
 
     def test_version_newest_not_supported_but_older_supported(self):
         with GetStorage(get_connection_api()) as storage:

--- a/mapadroid/tests/mad_apk/test_wizard.py
+++ b/mapadroid/tests/mad_apk/test_wizard.py
@@ -130,3 +130,29 @@ class WizardTests(StorageBase):
             self.assertTrue(wizard_latest is not None)
             self.assertTrue(latest_supported[APKArch.arm64_v8a]["versionCode"] == wizard_latest["version_code"])
             self.assertTrue(latest_supported[APKArch.arm64_v8a]["version"] == wizard_latest["version"])
+
+    @patch('mapadroid.mad_apk.wizard.supported_pogo_version')
+    def test_gplay_between_current_and_supported(self, supported_pogo_version):
+        supported_pogo_version.return_value = True
+        with GetStorage(get_connection_api()) as storage:
+            package_downloader = APKWizard(storage.db_wrapper, storage.storage_manager)
+            gplay_latest = (20200901, "0.123.3")
+            latest_supported = {
+                APKArch.arm64_v8a: {
+                    "versionCode": 20201001,
+                    "version": "0.123.4"
+                }
+            }
+            autosearch_latest = {
+                "version": "0.123.4",
+                "url": 20201001
+            }
+            package_downloader.get_latest_version = MagicMock(return_value=latest_supported)
+            package_downloader.get_version_code = MagicMock(return_value=20200801)
+            storage.storage_manager.get_current_version = MagicMock(return_value="0.123.2")
+            package_downloader.get_latest = MagicMock(return_value=autosearch_latest)
+            GPlayConnector.get_latest_version = MagicMock(return_value=gplay_latest)
+            wizard_latest = package_downloader.find_latest_pogo(APKArch.arm64_v8a)
+            self.assertTrue(wizard_latest is not None)
+            self.assertTrue(gplay_latest[0] == wizard_latest["version_code"])
+            self.assertTrue(gplay_latest[1] == wizard_latest["version"])


### PR DESCRIPTION
1. Make the Wizard "Update Everything" do the filesize check for RGC/PD before downloading (this check is run when clicking the "Search for new version" button in the individual lines above).
2. Improve the pogo update logic to make the logging easier to understand and to enable it to download "intermediate" versions. Example: `195.0` is installed. `195.1` is available to be downloaded through gplay. `195.0`, `195.1` and `195.2` are supported via the `version_codes.json` file. Previously, downloading `195.1` in this situation was not possible while `195.2` was not yet available through the store, thus we would remain at `195.0`. This behaviour should be fixed.
3. Fix a wrong global variable reference (was `VERSIONCODES_GITHUB`, corrected to `VERSIONCODES_URL`)

@Expl0dingBanana - please review.