### PR TITLE
IPv6 support for webhooks

### DIFF
--- a/mapadroid/webhook/webhookworker.py
+++ b/mapadroid/webhook/webhookworker.py
@@ -503,7 +503,7 @@ class WebhookWorker:
             url = webhook.strip()
 
             if url.startswith("["):
-                end_index = webhook.rindex("]")
+                end_index = webhook.index("]")
                 end_index += 1
                 sub_types = webhook[:end_index]
                 url = url[end_index:]


### PR DESCRIPTION
Using index instead of rindex finds the first closing bracket and not the one of the IPv6 adress.