### PR TITLE
Fix a TypeError exception in __find_latest_head in wizard.py

### DIFF
--- a/mapadroid/mad_apk/wizard.py
+++ b/mapadroid/mad_apk/wizard.py
@@ -248,15 +248,17 @@ class APKWizard(object):
         """
         update_available = False
         (packages, status) = lookup_package_info(self.storage, package)
-        curr_info = packages[architecture]
-        installed_size = None
+        curr_info = packages[architecture] if packages else None
         if curr_info:
             installed_size = curr_info.size
+            curr_info_logstring = f' (old version {curr_info.version} of size {curr_info.size})'
+        else:
+            installed_size = None
+            curr_info_logstring = ''
         head = requests.head(url, verify=False, headers=APK_HEADERS, allow_redirects=True)
         mirror_size = int(head.headers['Content-Length'])
         if not curr_info or (installed_size and installed_size != mirror_size):
-            logger.info('Newer version found on the mirror of size {} (old version {} of size {})',
-                        mirror_size, curr_info.version, curr_info.size)
+            logger.info('Newer version found on the mirror of size {}{}', mirror_size, curr_info_logstring)
             update_available = True
         else:
             logger.info('No newer version found (installed version {} of size {})', curr_info.version, curr_info.size)


### PR DESCRIPTION
The issue was brought up on discord and is caused by changes from PR #1081.

A `TypeError` exception was thrown when trying to download RGC or PD through the wizard with no pre-existing version on the MAD instance. I could reproduce the problem locally and fix it with these changes.

It was not considered that the packages variable could be `None` when no version of the requested package is currently installed to
the MAD instance. This commit/PR will introduce code to handle this situation.
