### PR TITLE
Force greenlet to < 0.4.17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ websockets>=7
 numpy~=1.18.0
 apkutils~=0.6.6
 matlink-gpapi~=0.4.4.5
-greenlet!=0.4.17
+greenlet<0.4.17


### PR DESCRIPTION
There seems to be 1.0 release that breaks a lot of stuff and makes MAD go haywire.