### PR TITLE
Pythonic locking

### DIFF
--- a/mapadroid/db/PooledQueryExecutor.py
+++ b/mapadroid/db/PooledQueryExecutor.py
@@ -39,11 +39,10 @@ class PooledQueryExecutor:
             "password": self.password,
             "database": self.database
         }
-        self._pool_mutex.acquire()
-        self._pool = MySQLConnectionPool(pool_name="db_wrapper_pool",
-                                         pool_size=self._poolsize,
-                                         **dbconfig)
-        self._pool_mutex.release()
+        with self._pool_mutex:
+            self._pool = MySQLConnectionPool(pool_name="db_wrapper_pool",
+                                             pool_size=self._poolsize,
+                                             **dbconfig)
 
     def close(self, conn, cursor):
         """

--- a/mapadroid/madmin/api/apiHandler.py
+++ b/mapadroid/madmin/api/apiHandler.py
@@ -96,5 +96,5 @@ class APIHandler(object):
             self._logger.debug2('Formatting error: {}', headers)
             return apiResponse.APIResponse(self._logger, self.api_req)(None, 422, headers=headers)
         except Exception:
-            self._logger.opt(exception=True).critical("An unhanded exception occurred!")
+            self._logger.opt(exception=True).critical("An unhandled exception occurred!")
             return apiResponse.APIResponse(self._logger, self.api_req)('', 500)

--- a/mapadroid/madmin/api/apks/ftr_mad_apks.py
+++ b/mapadroid/madmin/api/apks/ftr_mad_apks.py
@@ -82,7 +82,7 @@ class APIMadAPK(APKHandler):
                 self._logger.warning(err)
                 return (str(err), 406)
             except Exception:
-                self._logger.opt(exception=True).critical("An unhanded exception occurred!")
+                self._logger.opt(exception=True).critical("An unhandled exception occurred!")
                 return (None, 500)
         else:
             try:

--- a/mapadroid/madmin/madmin.py
+++ b/mapadroid/madmin/madmin.py
@@ -46,7 +46,7 @@ def after_request(response):
 
 @app.errorhandler(500)
 def internal_error(self, exception):
-    logger.opt(exception=True).critical("An unhanded exception occurred!")
+    logger.opt(exception=True).critical("An unhandled exception occurred!")
     return render_template('500.html'), 500
 
 

--- a/mapadroid/route/RouteManagerIV.py
+++ b/mapadroid/route/RouteManagerIV.py
@@ -49,10 +49,9 @@ class RouteManagerIV(RouteManagerBase):
             new_list.append(prio[2])
         self.encounter_ids_left = new_list
 
-        self._manager_mutex.acquire()
-        heapq.heapify(latest_priorities)
-        self._prio_queue = latest_priorities
-        self._manager_mutex.release()
+        with self._manager_mutex:
+            heapq.heapify(latest_priorities)
+            self._prio_queue = latest_priorities
         return None
 
     def get_encounter_ids_left(self) -> List[int]:
@@ -70,14 +69,11 @@ class RouteManagerIV(RouteManagerBase):
         return False
 
     def _start_routemanager(self):
-        self._manager_mutex.acquire()
-        try:
+        with self._manager_mutex:
             if not self._is_started:
                 self._is_started = True
                 self.logger.info("Starting routemanager")
                 self._start_priority_queue()
-        finally:
-            self._manager_mutex.release()
         return True
 
     def _quit_route(self):

--- a/mapadroid/route/RouteManagerLeveling.py
+++ b/mapadroid/route/RouteManagerLeveling.py
@@ -106,9 +106,7 @@ class RouteManagerLeveling(RouteManagerQuests):
         self._init_route_queue()
 
     def _get_coords_after_finish_route(self) -> bool:
-        self._manager_mutex.acquire()
-        try:
-
+        with self._manager_mutex:
             if self._shutdown_route:
                 self.logger.info('Other worker shutdown route - leaving it')
                 return False
@@ -135,8 +133,6 @@ class RouteManagerLeveling(RouteManagerQuests):
             self._worker_changed_update_routepools()
             self._start_calc = False
             return True
-        finally:
-            self._manager_mutex.release()
 
     def _restore_original_route(self):
         if not self._tempinit:
@@ -145,18 +141,13 @@ class RouteManagerLeveling(RouteManagerQuests):
                 self._route = self._routecopy.copy()
 
     def _check_unprocessed_stops(self):
-        self._manager_mutex.acquire()
-
-        try:
+        with self._manager_mutex:
             # We finish routes on a per walker/origin level, so the route itself is always the same as long as at
             # least one origin is connected to it.
             return self._stoplist
-        finally:
-            self._manager_mutex.release()
 
     def _start_routemanager(self):
-        self._manager_mutex.acquire()
-        try:
+        with self._manager_mutex:
             if not self._is_started:
                 self._is_started = True
                 self.logger.info("Starting routemanager")
@@ -206,10 +197,6 @@ class RouteManagerLeveling(RouteManagerQuests):
 
                 self.logger.info('Getting {} positions', len(self._route))
                 return True
-
-        finally:
-            self._manager_mutex.release()
-
         return True
 
     def _recalc_stop_route(self, stops):

--- a/mapadroid/route/RouteManagerLevelingRoutefree.py
+++ b/mapadroid/route/RouteManagerLevelingRoutefree.py
@@ -110,9 +110,7 @@ class RouteManagerLevelingRoutefree(RouteManagerQuests):
         self._init_route_queue()
 
     def _get_coords_after_finish_route(self) -> bool:
-        self._manager_mutex.acquire()
-        try:
-
+        with self._manager_mutex:
             if self._shutdown_route:
                 self.logger.info('Other worker shutdown route - leaving it')
                 return False
@@ -120,22 +118,15 @@ class RouteManagerLevelingRoutefree(RouteManagerQuests):
             self._worker_changed_update_routepools()
             self._start_calc = False
             return True
-        finally:
-            self._manager_mutex.release()
 
     def _check_unprocessed_stops(self):
-        self._manager_mutex.acquire()
-
-        try:
+        with self._manager_mutex:
             # We finish routes on a per walker/origin level, so the route itself is always the same as long as at
             # least one origin is connected to it.
             return self._stoplist
-        finally:
-            self._manager_mutex.release()
 
     def _start_routemanager(self):
-        self._manager_mutex.acquire()
-        try:
+        with self._manager_mutex:
             if not self._is_started:
                 self._is_started = True
                 self.logger.info("Starting routemanager")
@@ -150,10 +141,6 @@ class RouteManagerLevelingRoutefree(RouteManagerQuests):
                 self._start_check_routepools()
 
                 return True
-
-        finally:
-            self._manager_mutex.release()
-
         return True
 
     def _recalc_stop_route(self, stops):

--- a/mapadroid/route/RouteManagerMon.py
+++ b/mapadroid/route/RouteManagerMon.py
@@ -54,8 +54,7 @@ class RouteManagerMon(RouteManagerBase):
             return 300
 
     def _start_routemanager(self):
-        self._manager_mutex.acquire()
-        try:
+        with self._manager_mutex:
             if not self._is_started:
                 self._is_started = True
                 self.logger.info("Starting routemanager {}", self.name)
@@ -63,8 +62,6 @@ class RouteManagerMon(RouteManagerBase):
                     self._start_priority_queue()
                 self._start_check_routepools()
                 self._init_route_queue()
-        finally:
-            self._manager_mutex.release()
         return True
 
     def _delete_coord_after_fetch(self) -> bool:

--- a/mapadroid/route/RouteManagerQuests.py
+++ b/mapadroid/route/RouteManagerQuests.py
@@ -62,8 +62,7 @@ class RouteManagerQuests(RouteManagerBase):
         self._init_route_queue()
 
     def _get_coords_after_finish_route(self) -> bool:
-        self._manager_mutex.acquire()
-        try:
+        with self._manager_mutex:
             if self._shutdown_route:
                 self.logger.info('Other worker shutdown - leaving it')
                 return False
@@ -93,8 +92,6 @@ class RouteManagerQuests(RouteManagerBase):
                 self._restore_original_route()
                 return False
             return True
-        finally:
-            self._manager_mutex.release()
 
     def _restore_original_route(self):
         if not self._tempinit:
@@ -102,9 +99,7 @@ class RouteManagerQuests(RouteManagerBase):
             self._route = self._routecopy.copy()
 
     def _check_unprocessed_stops(self):
-        self._manager_mutex.acquire()
-
-        try:
+        with self._manager_mutex:
             list_of_stops_to_return: List[Location] = []
 
             if len(self._stoplist) == 0:
@@ -131,12 +126,9 @@ class RouteManagerQuests(RouteManagerBase):
             if len(list_of_stops_to_return) > 0:
                 self.logger.info("Found stops not yet processed, retrying those in the next round")
             return list_of_stops_to_return
-        finally:
-            self._manager_mutex.release()
 
     def _start_routemanager(self):
-        self._manager_mutex.acquire()
-        try:
+        with self._manager_mutex:
             if not self._is_started:
                 self._is_started = True
                 self.logger.info("Starting routemanager")
@@ -193,10 +185,6 @@ class RouteManagerQuests(RouteManagerBase):
 
                 self.logger.info('Getting {} positions in route', len(self._route))
                 return True
-
-        finally:
-            self._manager_mutex.release()
-
         return True
 
     def _recalc_stop_route(self, stops):

--- a/mapadroid/route/RouteManagerRaids.py
+++ b/mapadroid/route/RouteManagerRaids.py
@@ -55,8 +55,7 @@ class RouteManagerRaids(RouteManagerBase):
             return 600
 
     def _start_routemanager(self):
-        self._manager_mutex.acquire()
-        try:
+        with self._manager_mutex:
             if not self._is_started:
                 self._is_started = True
                 self.logger.info("Starting routemanager")
@@ -64,9 +63,6 @@ class RouteManagerRaids(RouteManagerBase):
                     self._start_priority_queue()
                     self._start_check_routepools()
                     self._init_route_queue()
-        finally:
-            self._manager_mutex.release()
-
         return True
 
     def _quit_route(self):

--- a/mapadroid/utils/logging.py
+++ b/mapadroid/utils/logging.py
@@ -3,6 +3,7 @@ import os
 import sys
 from enum import IntEnum
 from functools import wraps
+from typing import Union
 
 from loguru import logger
 
@@ -236,7 +237,7 @@ def get_bind_name(logger_type: LoggerEnums, name: str) -> str:
 
 
 @apply_custom
-def get_logger(logger_type: LoggerEnums, name: str = None, filter_func: callable = None) -> logger:
+def get_logger(logger_type: Union[LoggerEnums, int], name: str = None, filter_func: callable = None) -> logger:
     """ Creates a new logger with the MAD-required featureset """
     try:
         if isinstance(logger_type, LoggerEnums):

--- a/mapadroid/utils/updater.py
+++ b/mapadroid/utils/updater.py
@@ -175,15 +175,12 @@ class DeviceUpdater(object):
                 job_id = item
                 origin = self._log[str(job_id)]['origin']
 
-                self._update_mutex.acquire()
-                try:
+                with self._update_mutex:
                     if origin in self._current_job_device:
                         self._update_queue.put(str(job_id))
                         continue
 
                     self._current_job_device.append(origin)
-                finally:
-                    self._update_mutex.release()
 
                 file_ = self._log[str(job_id)]['file']
                 counter = self._log[str(job_id)]['counter']
@@ -432,8 +429,7 @@ class DeviceUpdater(object):
         self._update_queue.put(str(job_id))
 
     def write_status_log(self, job_id, field=None, value=None, delete=False):
-        self._update_mutex.acquire()
-        try:
+        with self._update_mutex:
             if delete:
                 if field is None:
                     del self._log[str(job_id)]
@@ -447,8 +443,6 @@ class DeviceUpdater(object):
                     self._log[str(job_id)][field] = value
                 else:
                     self._log[str(job_id)] = field
-        finally:
-            self._update_mutex.release()
 
         self.update_status_log()
 

--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -105,6 +105,8 @@ class MITMBase(WorkerBase):
             -> Tuple[LatestReceivedType, Optional[Union[dict, FortSearchResultTypes]]]:
         if timestamp is None:
             timestamp = time.time()
+        # Cut off decimal places of timestamp as PD also does that...
+        timestamp = int(timestamp)
         if timeout is None:
             timeout = self.get_devicesettings_value("mitm_wait_timeout", FALLBACK_MITM_WAIT_TIMEOUT)
 

--- a/mapadroid/worker/WorkerMITM.py
+++ b/mapadroid/worker/WorkerMITM.py
@@ -181,8 +181,6 @@ class WorkerMITM(MITMBase):
         # proto has previously been received, let's check the timestamp...
         mode = self._mapping_manager.routemanager_get_mode(self._routemanager_name)
         timestamp_of_proto: float = latest_proto_entry.get("timestamp", None)
-        # Rounding down by cutting the decimal places
-        timestamp = int(timestamp)
         self.logger.debug("Latest timestamp: {} vs. timestamp waited for: {} of proto {}",
                           datetime.fromtimestamp(timestamp_of_proto), datetime.fromtimestamp(timestamp),
                           proto_to_wait_for)

--- a/mapadroid/worker/WorkerMITM.py
+++ b/mapadroid/worker/WorkerMITM.py
@@ -181,6 +181,8 @@ class WorkerMITM(MITMBase):
         # proto has previously been received, let's check the timestamp...
         mode = self._mapping_manager.routemanager_get_mode(self._routemanager_name)
         timestamp_of_proto: float = latest_proto_entry.get("timestamp", None)
+        # Rounding down by cutting the decimal places
+        timestamp = int(timestamp)
         self.logger.debug("Latest timestamp: {} vs. timestamp waited for: {} of proto {}",
                           datetime.fromtimestamp(timestamp_of_proto), datetime.fromtimestamp(timestamp),
                           proto_to_wait_for)

--- a/mapadroid/worker/WorkerQuests.py
+++ b/mapadroid/worker/WorkerQuests.py
@@ -753,6 +753,8 @@ class WorkerQuests(MITMBase):
     def _check_for_data_content(self, latest, proto_to_wait_for: ProtoIdentifier, timestamp: float) \
             -> Tuple[LatestReceivedType, Optional[Union[dict, FortSearchResultTypes]]]:
         type_of_data_found: LatestReceivedType = LatestReceivedType.UNDEFINED
+        # Cut off decimal places of timestamp as PD also does that...
+        timestamp = int(timestamp)
         data_found: Optional[object] = None
         # Check if we have clicked a gym or mon...
         if ProtoIdentifier.GYM_INFO.value in latest \

--- a/mapadroid/worker/WorkerQuests.py
+++ b/mapadroid/worker/WorkerQuests.py
@@ -753,8 +753,6 @@ class WorkerQuests(MITMBase):
     def _check_for_data_content(self, latest, proto_to_wait_for: ProtoIdentifier, timestamp: float) \
             -> Tuple[LatestReceivedType, Optional[Union[dict, FortSearchResultTypes]]]:
         type_of_data_found: LatestReceivedType = LatestReceivedType.UNDEFINED
-        # Cut off decimal places of timestamp as PD also does that...
-        timestamp = int(timestamp)
         data_found: Optional[object] = None
         # Check if we have clicked a gym or mon...
         if ProtoIdentifier.GYM_INFO.value in latest \

--- a/mapadroid/worker/WorkerQuests.py
+++ b/mapadroid/worker/WorkerQuests.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 import time
 from datetime import datetime, timedelta
@@ -53,7 +51,7 @@ class PositionStopType(Enum):
     SPINNABLE_STOP = 8
 
     @staticmethod
-    def type_contains_stop_at_all(position_stop_type: PositionStopType) -> bool:
+    def type_contains_stop_at_all(position_stop_type) -> bool:
         return position_stop_type in (PositionStopType.SPINNABLE_STOP,
                                       PositionStopType.VISITED_STOP_IN_LEVEL_MODE_TO_IGNORE,
                                       PositionStopType.STOP_CLOSED, PositionStopType.STOP_COOLDOWN,

--- a/mapadroid/worker/WorkerQuests.py
+++ b/mapadroid/worker/WorkerQuests.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 import time
 from datetime import datetime, timedelta
@@ -37,6 +39,25 @@ class ClearThreadTasks(Enum):
     IDLE = 0
     BOX = 1
     QUEST = 2
+
+
+class PositionStopType(Enum):
+    GMO_NOT_AVAILABLE = 0,
+    GMO_EMPTY = 1,
+    GYM = 2,
+    VISITED_STOP_IN_LEVEL_MODE_TO_IGNORE = 3,
+    STOP_DISABLED = 4,
+    STOP_CLOSED = 5,
+    STOP_COOLDOWN = 6
+    NO_FORT = 7
+    SPINNABLE_STOP = 8
+
+    @staticmethod
+    def type_contains_stop_at_all(position_stop_type: PositionStopType) -> bool:
+        return position_stop_type in (PositionStopType.SPINNABLE_STOP,
+                                      PositionStopType.VISITED_STOP_IN_LEVEL_MODE_TO_IGNORE,
+                                      PositionStopType.STOP_CLOSED, PositionStopType.STOP_COOLDOWN,
+                                      PositionStopType.STOP_DISABLED)
 
 
 class WorkerQuests(MITMBase):
@@ -471,18 +492,18 @@ class WorkerQuests(MITMBase):
             self.logger.debug2("GMO cells around current position ({}) do not contain stops ", self.current_location)
         return cells_with_forts
 
-    def _current_position_has_spinnable_stop(self, timestamp: float):
+    def _current_position_has_spinnable_stop(self, timestamp: float) -> PositionStopType:
         type_received, data_received = self._wait_for_data(timestamp=timestamp, proto_to_wait_for=ProtoIdentifier.GMO)
         if type_received != LatestReceivedType.GMO or data_received is None:
             self._spinnable_data_failure()
-            return False, False
+            return PositionStopType.GMO_NOT_AVAILABLE
         latest_proto = data_received.get("payload")
         gmo_cells: list = latest_proto.get("cells", None)
 
         if not gmo_cells:
             self.logger.warning("Can't spin stop - no map info in GMO!")
             self._spinnable_data_failure()
-            return False, False
+            return PositionStopType.GMO_EMPTY
 
         cells_with_stops = self._directly_surrounding_gmo_cells_containing_stops_around_current_position(gmo_cells)
         for cell in cells_with_stops:
@@ -510,53 +531,69 @@ class WorkerQuests(MITMBase):
                     self._db_wrapper.delete_stop(latitude, longitude)
                     self.logger.warning("Tried to open a stop but found a gym instead!")
                     self._spinnable_data_failcount = 0
-                    return False, True
+                    return PositionStopType.GYM
 
                 visited: bool = fort.get("visited", False)
                 if self._level_mode and self._ignore_spinned_stops and visited:
                     self.logger.info("Level mode: Stop already visited - skipping it")
                     self._db_wrapper.submit_pokestop_visited(self._origin, latitude, longitude)
                     self._spinnable_data_failcount = 0
-                    return False, True
+                    return PositionStopType.VISITED_STOP_IN_LEVEL_MODE_TO_IGNORE
 
                 enabled: bool = fort.get("enabled", True)
                 if not enabled:
                     self.logger.info("Can't spin the stop - it is disabled")
+                    return PositionStopType.STOP_DISABLED
                 closed: bool = fort.get("closed", False)
                 if closed:
                     self.logger.info("Can't spin the stop - it is closed")
+                    return PositionStopType.STOP_CLOSED
+
                 cooldown: int = fort.get("cooldown_complete_ms", 0)
                 if not cooldown == 0:
                     self.logger.info("Can't spin the stop - it has cooldown")
+                    return PositionStopType.STOP_COOLDOWN
                 self._spinnable_data_failcount = 0
-                return fort_type == 1 and enabled and not closed and cooldown == 0, False
+                return PositionStopType.SPINNABLE_STOP
+
         # by now we should've found the stop in the GMO
         self.logger.warning("Unable to confirm the current location ({}) yielding a spinnable stop "
                             "- likely not standing exactly on top ...", str(self.current_location))
         self._check_if_stop_was_nearby_and_update_location(gmo_cells)
         self._spinnable_data_failure()
-        return False, False
+        return PositionStopType.NO_FORT
 
     def _try_to_open_pokestop(self, timestamp: float) -> LatestReceivedType:
         to = 0
         type_received: LatestReceivedType = LatestReceivedType.UNDEFINED
         proto_entry = None
         # let's first check the GMO for the stop we intend to visit and abort if it's disabled, a gym, whatsoever
-        spinnable_stop, skip_recheck = self._current_position_has_spinnable_stop(timestamp)
+        stop_type: PositionStopType = self._current_position_has_spinnable_stop(timestamp)
 
         recheck_count = 0
-        while not spinnable_stop and not skip_recheck and not recheck_count > 2:
+        while stop_type in (PositionStopType.GMO_NOT_AVAILABLE, PositionStopType.GMO_EMPTY,
+                            PositionStopType.NO_FORT) and not recheck_count > 2:
             recheck_count += 1
             self.logger.info("Wait for new data to check the stop again ... (attempt {})", recheck_count + 1)
             type_received, proto_entry = self._wait_for_data(timestamp=time.time(),
                                                              proto_to_wait_for=ProtoIdentifier.GMO,
                                                              timeout=35)
             if type_received != LatestReceivedType.UNDEFINED:
-                spinnable_stop, skip_recheck = self._current_position_has_spinnable_stop(timestamp)
+                stop_type = self._current_position_has_spinnable_stop(timestamp)
 
-        if not spinnable_stop:
-            self.logger.info("Stop {}, {} considered to be ignored in the next round due to failed "
+        if not PositionStopType.type_contains_stop_at_all(stop_type):
+            self.logger.info("Location {}, {} considered to be ignored in the next round due to failed "
                              "spinnable check", self.current_location.lat, self.current_location.lng)
+            self._mapping_manager.routemanager_add_coords_to_be_removed(self._routemanager_name,
+                                                                        self.current_location.lat,
+                                                                        self.current_location.lng)
+            return type_received
+        elif stop_type in (PositionStopType.STOP_CLOSED, PositionStopType.STOP_COOLDOWN,
+                           PositionStopType.STOP_DISABLED):
+            self.logger.info("Stop at {}, {} is not spinnable at the moment ({})")
+            return type_received
+        elif stop_type == PositionStopType.VISITED_STOP_IN_LEVEL_MODE_TO_IGNORE:
+            self.logger.info("Stop at {}, {} has been spun before and is to be ignored in the next round.")
             self._mapping_manager.routemanager_add_coords_to_be_removed(self._routemanager_name,
                                                                         self.current_location.lat,
                                                                         self.current_location.lng)


### PR DESCRIPTION
Changes in a nutshell:
- Locks (not Semaphores - which we have some still) are now used via `with` rather than try-finally
- "unhanded exception" -> "unhandled exception"
- WorkerQuests::_try_to_open_pokestop now returns an enum as we had a Tuple[bool, bool] before which imho would not properly cover the permutations of results possible
- MITMBase::_wait_for_data now cuts off the decimal places of the timestamp passed as PD uses integers (long) values thus sometimes resulting in MAD waiting for data that was received before the timestamp used by MAD internally (being float)