### PR TITLE
Include redis package as optional dependency for Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ wget \
 && mkdir /usr/local/share/tessdata/ \
 && mv -v eng.traineddata /usr/local/share/tessdata/ \
 # python reqs
-&& python3 -m pip install --no-cache-dir -r requirements.txt ortools \
+&& python3 -m pip install --no-cache-dir -r requirements.txt ortools redis \
 # cleanup
 && apt-get remove -y wget \
 && apt-get remove -y build-essential \


### PR DESCRIPTION
Include the Python redis package for optional usage. As redis is only activated when the flag is set in config it will not automatically load the package. Ensuring its install allows redis usage in a dockerized environment.