### PR TITLE
add threshold to ignore mitm data in queue

### DIFF
--- a/mapadroid/mitm_receiver/SerializedMitmDataProcessor.py
+++ b/mapadroid/mitm_receiver/SerializedMitmDataProcessor.py
@@ -49,6 +49,16 @@ class SerializedMitmDataProcessor(Process):
 
             origin_logger.debug4("Received data: {}", data)
             start_time = self.get_time_ms()
+
+            threshold_seconds = self.__application_args.mitm_ignore_proc_time_thresh
+            if threshold_seconds > 0:
+                minimum_timestamp = (start_time / 1000) - threshold_seconds
+                if received_timestamp < minimum_timestamp:
+                    origin_logger.debug(
+                        "Data received at {} is older than configured threshold of {}s ({}). Ignoring data.",
+                        processed_timestamp, threshold_seconds, datetime.fromtimestamp(minimum_timestamp))
+                    pass
+
             if data_type == 106:
                 origin_logger.info("Processing GMO. Received at {}", processed_timestamp)
 

--- a/mapadroid/mitm_receiver/SerializedMitmDataProcessor.py
+++ b/mapadroid/mitm_receiver/SerializedMitmDataProcessor.py
@@ -57,7 +57,7 @@ class SerializedMitmDataProcessor(Process):
                     origin_logger.debug(
                         "Data received at {} is older than configured threshold of {}s ({}). Ignoring data.",
                         processed_timestamp, threshold_seconds, datetime.fromtimestamp(minimum_timestamp))
-                    pass
+                    return
 
             if data_type == 106:
                 origin_logger.info("Processing GMO. Received at {}", processed_timestamp)

--- a/mapadroid/utils/walkerArgs.py
+++ b/mapadroid/utils/walkerArgs.py
@@ -70,6 +70,9 @@ def parse_args():
                         help='Port to listen on for proto data (MITM data). Default: 8000')
     parser.add_argument('-mrdw', '--mitmreceiver_data_workers', type=int, default=2,
                         help='Amount of workers to work off the data that queues up. Default: 2')
+    parser.add_argument('-miptt', '--mitm_ignore_proc_time_thresh', type=int, default=0,
+                        help='Ignore MITM data having a timestamp too far in the past.'
+                             'Specify in seconds. Default: 0 (off)')
     parser.add_argument('-mipb', '--mitm_ignore_pre_boot', default=False, type=bool,
                         help='Ignore MITM data having a timestamp pre MAD\'s startup time')
     parser.add_argument('-mspass', '--mitm_status_password', default='',


### PR DESCRIPTION
On some setups, the queue of mitm data grows for unknown reason. To compensate this issue, users started to add automatic restarts to cleanup said queue.

This PR adds a new parameter `mitm_ignore_proc_time_thresh` (`miptt`) which let's users configure a threshold in seconds to ignore these payloads within the queue. 

Payloads are still being added to the payload but once they're about to be processed the timestamp is being checked and depending on the threshold ignored. Some payloads may still have a (huge) time difference due to miscofigured date/time on the device or bad connection between device and server.