### PR TITLE
Avoid full scan of pokemon table when worker starts for IV scan

### DIFF
--- a/mapadroid/db/DbWrapper.py
+++ b/mapadroid/db/DbWrapper.py
@@ -211,6 +211,8 @@ class DbWrapper:
         if geofence_helper is None:
             logger.error("No geofence_helper! Not fetching encounters.")
             return 0, {}
+        if latest == 0:
+            latest = time.time() - 15 * 60
 
         logger.debug3("Filtering with rectangle")
         rectangle = geofence_helper.get_polygon_from_fence()


### PR DESCRIPTION
Every time a worker switches to IV scan, it wants to update PD with the encounters stored in the `pokemon` since the last scan. However, if that happens on the first connect, the last-scan timestamp is `0`. This causes a full table scan on `pokemon` which - depending on the number of mons stored, can take quite some time and could return a huge amount of data.

To avoid this condition, we simply fetch the last 15 minutes in those circumstances.