### PR TITLE
Implemented route editor. Fixes #1057

### DIFF
--- a/mapadroid/madmin/routes/map.py
+++ b/mapadroid/madmin/routes/map.py
@@ -1,10 +1,9 @@
 import json
 from typing import List, Optional
 
-from flask import jsonify, redirect, render_template, request, url_for
+from flask import jsonify, render_template, request
 from flask_caching import Cache
 
-from mapadroid.data_manager import DataManagerException
 from mapadroid.db.DbWrapper import DbWrapper
 from mapadroid.geofence.geofenceHelper import GeofenceHelper
 from mapadroid.madmin.functions import (auth_required,

--- a/mapadroid/route/RouteManagerBase.py
+++ b/mapadroid/route/RouteManagerBase.py
@@ -1074,6 +1074,9 @@ class RouteManagerBase(ABC):
     def get_calc_type(self):
         return self._calctype
 
+    def get_routecalc_id(self):
+        return self._route_resource.identifier
+
     def redo_stop(self, worker, lat, lon):
         route_logger = routelogger_set_origin(self.logger, origin=worker)
         route_logger.info('redo a unprocessed Stop ({}, {})', lat, lon)

--- a/mapadroid/utils/MappingManager.py
+++ b/mapadroid/utils/MappingManager.py
@@ -252,6 +252,10 @@ class MappingManager:
         routemanager = self.__fetch_routemanager(routemanager_name)
         return routemanager.name if routemanager is not None else None
 
+    def routemanager_get_routecalc_id(self, routemanager_name: str) -> Optional[int]:
+        routemanager = self.__fetch_routemanager(routemanager_name)
+        return routemanager.get_routecalc_id() if routemanager is not None else None
+
     def routemanager_get_encounter_ids_left(self, routemanager_name: str) -> Optional[List[int]]:
         routemanager = self.__fetch_routemanager(routemanager_name)
         if routemanager is not None and isinstance(routemanager, RouteManagerIV.RouteManagerIV):

--- a/static/madmin/static/js/madmin.js
+++ b/static/madmin/static/js/madmin.js
@@ -831,7 +831,7 @@ new Vue({
                     }
 
                     const polygon = L.polygon(area.coordinates, {
-                        color: this.getRandomColor(),
+                        color: this.getRandomBackgroundColor(),
                         weight: 2,
                         opacity: 0.5,
                         pane: layerOrders.areas.pane,
@@ -967,7 +967,7 @@ new Vue({
             }
 
             const polygon = L.polygon(geofence.coordinates, {
-                color: this.getRandomColor(),
+                color: this.getRandomBackgroundColor(),
                 weight: 2,
                 opacity: 0.5,
                 pane: layerOrders.geofences.pane
@@ -1016,14 +1016,14 @@ new Vue({
             let processedCells = {};
 
             const group = L.layerGroup();
-            const color = this.getRandomColor();
+            const color = this.getRandomForegroundColor();
             const circleOptions = {
                 radius: cradius,
                 color: color,
                 fillColor: color,
                 weight: 1,
                 opacity: 0.4,
-                fillOpacity: 0.1,
+                fillOpacity: 0.2,
                 interactive: false,
                 pane: layerOrders.routes.pane,
                 pmIgnore: true
@@ -1096,8 +1096,8 @@ new Vue({
 
             const polyline = L.polyline(route.coordinates, {
                 color: color,
-                weight: 2,
-                opacity: 0.4,
+                weight: 3,
+                opacity: 1.0,
                 pane: layerOrders.routes.pane
             });
 
@@ -1143,7 +1143,7 @@ new Vue({
 
             function onMouseOver() {
                 if (!mouseEventsIgnore.isIgnored()) {
-                    layer.setStyle({ opacity: 1.0, weight: originalWeight + 1.0 })
+                    layer.setStyle({ opacity: 1.0, weight: originalWeight + 2.0 })
                 }
             }
 
@@ -1222,28 +1222,14 @@ new Vue({
                 weight: 1
             };
         },
-        getRandomColor() {
-            // generates only dark colors for better contrast
-            var letters = '0123456789'.split('');
-            var color = '#';
-            for (var i = 0; i < 6; i++) {
-                color += letters[Math.floor(Math.random() * 10)];
-            }
-            return color;
+        getRandomForegroundColor() {
+            return this.getHslColor(Math.floor(Math.random() * 360), 80, 30);
         },
-        getPercentageColor(percentage) {
-            var r, g, b = 0;
-
-            if (percentage < 50) {
-                r = 255;
-                g = Math.round(5.1 * percentage);
-            } else {
-                g = 255;
-                r = Math.round(510 - 5.10 * percentage);
-            }
-
-            var h = r * 0x10000 + g * 0x100 + b * 0x1;
-            return "#" + ("000000" + h.toString(16)).slice(-6);
+        getRandomBackgroundColor() {
+            return this.getHslColor(Math.floor(Math.random() * 360), 30, 50);
+        },
+        getHslColor(hue, saturation, lightness) {
+            return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
         },
         build_cell_popup(marker) {
             var cell = this.cellupdates[marker.options.id];

--- a/static/madmin/static/style/madmin.css
+++ b/static/madmin/static/style/madmin.css
@@ -174,6 +174,15 @@ li.list-group-item.layer-item {
     right: 10px;
 }
 
+.leaflet-sidebar-content .list-group .badge {
+    margin-right: 0.5em;
+}
+
+.leaflet-sidebar-content li.list-group-item.layer-item.list-group-subitem {
+    padding-left: 2.5em;
+    font-size: 10pt;
+}
+
 .raidIcon {
     font-size: 12px;
     display: block;

--- a/static/madmin/templates/map.html
+++ b/static/madmin/templates/map.html
@@ -10,8 +10,9 @@
 
 {% block scripts %}
 <script>
-var setlat = {{ setlat }};
-var setlng = {{ setlng }};
+const setlat = {{ setlat }};
+const setlng = {{ setlng }};
+const loadingImgUrl = '{{ url_for('static', filename='loading.gif') }}';
 </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.10/vue.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.19.0/axios.js"></script>

--- a/static/madmin/templates/map.html
+++ b/static/madmin/templates/map.html
@@ -64,12 +64,13 @@ const loadingImgUrl = '{{ url_for('static', filename='loading.gif') }}';
         <div class="sidebar-pane-content">
           <ul class="list-group list-group-flush">
             {% raw %}
-            <li v-for="(route, index) in layers.dyn.routes" class="list-group-item layer-item justify-content-between d-flex align-items-center">
-              <div class="flex-grow-1">{{ index }}</div>
-              <span class="badge badge-secondary" style="margin-right: 5px;">{{ route.mode }}</span>
+            <li v-for="route in sortedRoutes" v-bind:key="route.id" v-bind:class="{ 'list-group-subitem': route.tag }" class="list-group-item layer-item justify-content-between d-flex align-items-center">
+              <div class="flex-grow-1">{{ route.name }}</div>
+              <span class="badge badge-secondary">{{ route.mode }}</span>
+              <span v-if="route.tag" class="badge badge-info">{{ route.tag }}</span>
               <div class="custom-control custom-switch">
-                <input :id="'layers-dyn-routes-'+index" type="checkbox" v-model="layers.dyn.routes[index].show" class="custom-control-input" />
-                <label :for="'layers-dyn-routes-'+index" class="custom-control-label"></label>
+                <input :id="'layers-dyn-routes-'+route.id" type="checkbox" v-model="route.show" class="custom-control-input" />
+                <label :for="'layers-dyn-routes-'+route.id" class="custom-control-label"></label>
               </div>
             </li>
             {% endraw %}
@@ -84,7 +85,7 @@ const loadingImgUrl = '{{ url_for('static', filename='loading.gif') }}';
             {% raw %}
             <li v-for="(route, index) in layers.dyn.prioroutes" class="list-group-item layer-item justify-content-between d-flex align-items-center">
               <div class="flex-grow-1">{{ index }}</div>
-              <span class="badge badge-secondary" style="margin-right: 5px;">{{ route.mode }}</span>
+              <span class="badge badge-secondary">{{ route.mode }}</span>
               <div class="custom-control custom-switch">
                 <input :id="'layers-dyn-prioroutes-'+index" type="checkbox" v-model="layers.dyn.prioroutes[index].show" class="custom-control-input" />
                 <label :for="'layers-dyn-prioroutes-'+index" class="custom-control-label"></label>


### PR DESCRIPTION
With this PR, `mon_mitm` routes can now be edited.

It's based on the geofence editor and works the same (click on a route, choose *edit* in the popup, drag/add/remove points, click *save* in the popup): common code for the two editors has been extracted.

Once edited, a route won't be active in memory until settings are applied. The main problem here is that refreshing the map without applying settings would get back the "old" applied/unedited route from memory. To avoid this, the map now shows an additional "unapplied" route. 

To avoid confusion, there are several special rules regarding this unapplied route:
 - It only exists if it's different from the applied route (= the route has been edited)
 - After saving, the edited/unapplied route is automatically made visible and the applied route is hidden, making it easy to continue editing the current route if needed.
 - When settings are applied or when MAD is restarted, the unapplied route ceases to exist and the normal route is shown instead (if the unapplied one was visible before).

This may seem a bit complicated while reading but from an user point of view it's mostly transparent. Unless comparing the applied and unapplied routes is needed, the user simply edits and saves a single route without having to toggle anything, as easy at is was with geofences.

To make things clearer in the sidebar, sub-routes and unapplied routes are now visually indented and tagged as such:
![image](https://user-images.githubusercontent.com/1623034/109044964-54558580-76d3-11eb-97ef-ee191396447c.png)

Other map changes:
 - Route lines are thicker to make them easier to click
 - The contrast between areas and routes has been improved (it's still not perfect but it should help with editing routes)