### PR TITLE
PTC Autoconfig support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ root-shell: up
 	docker-compose -f ${COMPOSE_FILE_DEV} exec -u root $(CONTAINER_NAME) $(CMD)
 
 run: down
-	docker-compose -f ${COMPOSE_FILE_TEST} up
+	docker-compose -f ${COMPOSE_FILE_PERSISTENT} up
 
 down:
 	docker-compose -f ${COMPOSE_FILE_DEV} down
@@ -134,6 +134,9 @@ tests: up
 
 unittests: up
 	docker-compose -f ${COMPOSE_FILE_DEV} exec mapadroid-dev tox -e py37
+
+test: up
+	docker-compose -f ${COMPOSE_FILE_TEST} run mapadroid-dev
 
 # Run bash within a defined tox environment
 # Specify a valid tox environment as such:

--- a/docker/.dev.env
+++ b/docker/.dev.env
@@ -1,5 +1,6 @@
 COMPOSE_CONVERT_WINDOWS_PATHS=1
 COMPOSE_FILE_DEV=docker/docker-compose-dev.yaml
+COMPOSE_FILE_PERSISTENT=docker/docker-compose-persistent.yaml
 COMPOSE_FILE_TEST=docker/docker-compose-test.yaml
 DOCKER_USER=dockeruser
 

--- a/docker/docker-compose-persistent.yaml
+++ b/docker/docker-compose-persistent.yaml
@@ -27,10 +27,12 @@ services:
     env_file:
       - .dev.env
     tty: true
-    command: ["bash"]
+    command: ["/usr/local/bin/python3", "start.py"]
 
   mariadb:
     image: mariadb:10.3
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
+    volumes:
+      - ~/mariadb/mad:/var/lib/mysql:rw
     env_file:
       - .dev.env

--- a/docker/docker-compose-test.yaml
+++ b/docker/docker-compose-test.yaml
@@ -27,12 +27,10 @@ services:
     env_file:
       - .dev.env
     tty: true
-    command: ["/usr/local/bin/python3", "start.py"]
+    command: ["/usr/src/app/.tox/py37/bin/python", "/usr/src/app/start.py", "-ut"]
 
   mariadb:
     image: mariadb:10.3
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
-    volumes:
-      - ~/mariadb/mad:/var/lib/mysql:rw
     env_file:
       - .dev.env

--- a/mapadroid/madmin/api/autoconf/ftr_autoconf.py
+++ b/mapadroid/madmin/api/autoconf/ftr_autoconf.py
@@ -1,6 +1,7 @@
 from mapadroid.data_manager.dm_exceptions import UnknownIdentifier
 from mapadroid.utils.autoconfig import (AutoConfIssue, AutoConfIssueGenerator,
-                                        PDConfig, RGCConfig, origin_generator)
+                                        PDConfig, RGCConfig,
+                                        get_available_login, origin_generator)
 
 from .autoconfHandler import AutoConfHandler
 
@@ -99,14 +100,27 @@ class APIAutoConf(AutoConfHandler):
                 try:
                     auth_type = device['settings']['logintype']
                 except KeyError:
-                    auth_type = 'google'
-                # Find one that matches authtype
-                sql = "SELECT ag.`account_id`\n"\
-                      "FROM `settings_pogoauth` ag\n"\
-                      "WHERE ag.`device_id` IS NULL AND ag.`instance_id` = %s AND ag.`login_type` = %s"
-                account_id = self.dbc.autofetch_value(sql, (self.dbc.instance_id, auth_type))
+                    login = get_available_login(self.dbc)
+                    try:
+                        auth_type = login['login_type']
+                    except KeyError:
+                        return ('No available logins for auto-config', 400)
+                    else:
+                        account_id = login['account_id']
+                else:
+                    login = get_available_login(self.dbc, auth_type)
+                    try:
+                        account_id = login['account_id']
+                    except KeyError:
+                        return ('No available logins for {}'.format(auth_type), 400)
                 if account_id is None:
-                    return ('No configured emails', 400)
+                    if is_hopper:
+                        device = self._data_manager.get_resource('device', update['device_id'])
+                        device.delete()
+                    return ('No configured Pogoauth', 400)
+                else:
+                    device["logintype"] = auth_type
+                    device.save()
                 auth = self._data_manager.get_resource('pogoauth', account_id)
                 auth['device_id'] = device.identifier
                 if is_hopper and auth_type != 'google':

--- a/mapadroid/tests/test_autoconfig.py
+++ b/mapadroid/tests/test_autoconfig.py
@@ -93,6 +93,12 @@ class MITMAutoConf(unittest.TestCase):
     def setUp(self):
         self.api = get_connection_api()
         self.mitm = get_connection_mitm(self.api)
+        devs = self.api.get("/api/device")
+        for dev_uri in devs.json()["results"]:
+            self.api.delete(dev_uri)
+        pauth = self.api.get("/api/pogoauth")
+        for uri in pauth.json()["results"]:
+            self.api.delete(uri)
 
     def tearDown(self):
         self.api.close()
@@ -133,7 +139,7 @@ class MITMAutoConf(unittest.TestCase):
                         AutoConfIssues.rgc_not_configured.value,
                     ],
                     'X-Warnings': [
-                        AutoConfIssues.no_ggl_login.value,
+                        AutoConfIssues.no_login.value,
                         AutoConfIssues.auth_not_configured.value,
                     ]
                 }
@@ -166,7 +172,7 @@ class MITMAutoConf(unittest.TestCase):
                         AutoConfIssues.package_missing.value,
                     ],
                     'X-Warnings': [
-                        AutoConfIssues.no_ggl_login.value,
+                        AutoConfIssues.no_login.value,
                         AutoConfIssues.auth_not_configured.value,
                     ]
                 }
@@ -182,7 +188,7 @@ class MITMAutoConf(unittest.TestCase):
                         AutoConfIssues.package_missing.value,
                     ],
                     'X-Warnings': [
-                        AutoConfIssues.no_ggl_login.value,
+                        AutoConfIssues.no_login.value,
                         AutoConfIssues.auth_not_configured.value,
                     ]
                 }
@@ -198,7 +204,7 @@ class MITMAutoConf(unittest.TestCase):
                         AutoConfIssues.package_missing.value,
                     ],
                     'X-Warnings': [
-                        AutoConfIssues.no_ggl_login.value,
+                        AutoConfIssues.no_login.value,
                         AutoConfIssues.auth_not_configured.value,
                     ]
                 }
@@ -213,7 +219,7 @@ class MITMAutoConf(unittest.TestCase):
                         AutoConfIssues.rgc_not_configured.value,
                     ],
                     'X-Warnings': [
-                        AutoConfIssues.no_ggl_login.value,
+                        AutoConfIssues.no_login.value,
                         AutoConfIssues.auth_not_configured.value,
                     ]
                 }

--- a/mapadroid/utils/autoconfig.py
+++ b/mapadroid/utils/autoconfig.py
@@ -13,7 +13,7 @@ from mapadroid.mad_apk import get_apk_status
 
 
 class AutoConfIssues(IntEnum):
-    no_ggl_login: int = 1
+    no_login: int = 1
     origin_hopper_not_ready: int = 2
     auth_not_configured: int = 3
     pd_not_configured: int = 4
@@ -25,11 +25,9 @@ class AutoConfIssueGenerator(object):
     def __init__(self, db, data_manager, args, storage_obj):
         self.warnings: List[AutoConfIssues] = []
         self.critical: List[AutoConfIssues] = []
-        sql = "SELECT count(*)\n" \
-              "FROM `settings_pogoauth` ag\n" \
-              "WHERE ag.`instance_id` = %s AND ag.`device_id` IS NULL"
-        if db.autofetch_value(sql, (db.instance_id)) == 0 and not args.autoconfig_no_auth:
-            self.warnings.append(AutoConfIssues.no_ggl_login)
+        any_login = get_available_login(db)
+        if not any_login and not args.autoconfig_no_auth:
+            self.warnings.append(AutoConfIssues.no_login)
         if not validate_hopper_ready(data_manager):
             self.critical.append(AutoConfIssues.origin_hopper_not_ready)
         if not data_manager.get_root_resource('auth'):
@@ -57,10 +55,10 @@ class AutoConfIssueGenerator(object):
         issues_warning = []
         issues_critical = []
         # Warning messages
-        if AutoConfIssues.no_ggl_login in self.warnings:
+        if AutoConfIssues.no_login in self.warnings:
             link = url_for('settings_pogoauth')
             anchor = f"<a class=\"alert-link\" href=\"{link}\">PogoAuth</a>"
-            issues_warning.append("No available Google logins for auto creation of devices. Configure through "
+            issues_warning.append("No available PogoAuth logins for auto creation of devices. Configure through "
                                   f"{anchor}")
         if AutoConfIssues.auth_not_configured in self.warnings:
             link = url_for('settings_auth')
@@ -87,6 +85,17 @@ class AutoConfIssueGenerator(object):
 
     def has_blockers(self) -> bool:
         return len(self.critical) > 0
+
+
+def get_available_login(db, login_type=None) -> dict:
+    sql = "SELECT *\n" \
+          "FROM `settings_pogoauth` ag\n" \
+          "WHERE ag.`instance_id` = %s AND ag.`device_id` IS NULL"
+    args = [db.instance_id]
+    if login_type:
+        sql += "AND ag.`login_type` = %s"
+        args.append(login_type)
+    return db.autofetch_row(sql, tuple(args))
 
 
 def validate_hopper_ready(data_manager):


### PR DESCRIPTION
Enables AutoConfig / Origin Hopper to use PTC accounts if they are available during auto-config.


Fix for #1111 