### PR TITLE
Fix `Delete all unfenced spawnpoints`

### DIFF
--- a/mapadroid/db/DbWrapper.py
+++ b/mapadroid/db/DbWrapper.py
@@ -881,7 +881,7 @@ class DbWrapper:
         res = self.execute(query)
 
         for (spawnid, ) in res:
-            spawn.append(spawnid)
+            spawn.append(str(spawnid))
 
         return spawn
 


### PR DESCRIPTION
We need str here - all other checks are against strings and delete query expects string.
Nothing else call this except mentioned function so we can just force string here :)