### PR TITLE
Fix a missing space in an autoconfig query

### DIFF
--- a/mapadroid/utils/autoconfig.py
+++ b/mapadroid/utils/autoconfig.py
@@ -93,7 +93,7 @@ def get_available_login(db, login_type=None) -> dict:
           "WHERE ag.`instance_id` = %s AND ag.`device_id` IS NULL"
     args = [db.instance_id]
     if login_type:
-        sql += "AND ag.`login_type` = %s"
+        sql += " AND ag.`login_type` = %s"
         args.append(login_type)
     return db.autofetch_row(sql, tuple(args))
 


### PR DESCRIPTION
This should fix this error:
```
[03-28 23:27:44.25] [           system] [PooledQueryExecutor:126 ] [E] Failed executing query: SELECT *
FROM `settings_pogoauth` ag
WHERE ag.`instance_id` = %s AND ag.`device_id` IS NULLAND ag.`login_type` = %s ([1, 'ptc']), error: 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'NULLAND ag.`login_type` = 'ptc'' at line 3
```