### PR TITLE
Fixed fence/route editor not being clickable anymore in some cases

### DIFF
--- a/static/madmin/static/js/madmin.js
+++ b/static/madmin/static/js/madmin.js
@@ -1774,11 +1774,24 @@ new Vue({
                 layer.setStyle({ opacity: 1.0 });
                 layer.pm.enable({ snappable: false, allowSelfIntersection: allowSelfIntersection });
 
+                let dragging = false
+
                 layer.on("pm:markerdragstart", function() {
+                    if (dragging) {
+                        // ignore multiple drag starts (left + right mouse buttons at the same time)
+                        return;
+                    }
+
+                    dragging = true;
                     mouseEventsIgnore.enableIgnore();
                 });
 
                 layer.on("pm:markerdragend", function() {
+                    if (!dragging) {
+                        return;
+                    }
+
+                    dragging = false;
                     mouseEventsIgnore.disableIgnore();
                 });
             }

--- a/static/madmin/templates/map.html
+++ b/static/madmin/templates/map.html
@@ -20,10 +20,10 @@ const loadingImgUrl = '{{ url_for('static', filename='loading.gif') }}';
 <script src="static/js/leaflet-sidebar.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.EasyButton/2.4.0/easy-button.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.min.js"></script>
-<script src="https://unpkg.com/@geoman-io/leaflet-geoman-free@2.7.0/dist/leaflet-geoman.min.js"></script>
-<script src="static/js/leaflet-event-forwarder.js?1599172474"></script>
+<script src="https://unpkg.com/@geoman-io/leaflet-geoman-free@2.9.0/dist/leaflet-geoman.min.js"></script>
+<script src="static/js/leaflet-event-forwarder.js?1617020349"></script>
 <script src="static/js/s2geometry.min.js"></script>
-<script src="static/js/madmin.js?1598819723"></script>
+<script src="static/js/madmin.js?1617020349"></script>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
If at anytime while dragging fence or route points both mouse buttons are pressed, leaflet sends a second drag start event but still only drag end and the map input is blocked. While waiting for the double event to be fixed, here's a simple workaround.