### PR TITLE
Handle "<app> isn't responding" system popup

### DIFF
--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -132,6 +132,9 @@ class WordToScreenMatching(object):
             return ScreenType.CREDENTIALS, global_dict, diff
         elif "ConsentActivity" in topmost_app:
             return ScreenType.CONSENT, global_dict, diff
+        elif "/a.m" in topmost_app:
+            self._logger.error("Likely found 'not responding' popup - reboot device (topmost app: {})", topmost_app)
+            return ScreenType.NOTRESPONDING, global_dict, diff
         elif "com.nianticlabs.pokemongo" not in topmost_app:
             self._logger.warning("PoGo is not opened! Current topmost app: {}", topmost_app)
             return ScreenType.CLOSE, global_dict, diff

--- a/mapadroid/ocr/screen_type.py
+++ b/mapadroid/ocr/screen_type.py
@@ -24,6 +24,7 @@ class ScreenType(Enum):
     GPS = 21  # GPS signal not found error message (pogo)
     CREDENTIALS = 22  # new GrantCredentials dialog
     NOGGL = 23  # loginselect, but without the google button (probably failed to set a correct birthdate)
+    NOTRESPONDING = 24  # system popup about an app not responding, blocking most actions
     POGO = 99  # uhm, whatever... At least pogo is topmost, no idea where we are yet tho (in the process of switching)
     ERROR = 100  # some issue occurred while handling screentypes or not able to determine screen
     BLACK = 110  # screen is black, likely loading up game

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -682,6 +682,9 @@ class WorkerBase(AbstractWorker):
                 self.logger.warning('Getting SN Screen - restart PoGo and later PD')
                 self._restart_pogo_safe()
                 break
+            elif screen_type == ScreenType.NOTRESPONDING:
+                self._reboot()
+                break
 
             if self._loginerrorcounter > 1:
                 self.logger.warning('Could not login again - (clearing game data + restarting device')


### PR DESCRIPTION
A system popup about an app not responding blocks most if not all actions of MAD / RGC on a device. It's also usually a symptom of the affected system having severe issues. A instant reboot is therefore usually the correct and quickest solution.


![screenshot](https://user-images.githubusercontent.com/13463550/113561182-7a404500-9604-11eb-9081-0b9207546c42.png)
