### PR TITLE
handle google's consent screen for 720p displays

### DIFF
--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -281,7 +281,7 @@ class WordToScreenMatching(object):
         elif screentype == ScreenType.MARKETING:
             self.__handle_marketing_screen(diff, global_dict)
         elif screentype == ScreenType.CONSENT:
-            self._nextscreen = ScreenType.UNDEFINED
+            self.__handle_ggl_consent_screen()
         elif screentype == ScreenType.SN:
             self._nextscreen = ScreenType.UNDEFINED
         elif screentype == ScreenType.UPDATE:
@@ -425,6 +425,14 @@ class WordToScreenMatching(object):
 
     def __handle_failure_screen(self) -> None:
         self.__handle_returning_player_or_wrong_credentials()
+
+    def __handle_ggl_consent_screen(self) -> None:
+        if self._width != 720 and self._height != 1280:
+            self._logger.warning("The google consent screen can only be handled on 720x1280 screens")
+            return ScreenType.ERROR
+
+        self._nextscreen = ScreenType.UNDEFINED
+        self._communicator.click(520, 1185)
 
     def __handle_returning_player_or_wrong_credentials(self) -> None:
         self._nextscreen = ScreenType.UNDEFINED

--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -433,6 +433,7 @@ class WordToScreenMatching(object):
 
         self._nextscreen = ScreenType.UNDEFINED
         self._communicator.click(520, 1185)
+        time.sleep(10)
 
     def __handle_returning_player_or_wrong_credentials(self) -> None:
         self._nextscreen = ScreenType.UNDEFINED

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -654,7 +654,7 @@ class WorkerBase(AbstractWorker):
                 self.logger.debug("screendetection found pogo closed, start it...")
                 self._start_pogo()
                 self._loginerrorcounter += 1
-            elif screen_type in [ScreenType.GAMEDATA, ScreenType.CONSENT]:
+            elif screen_type == ScreenType.GAMEDATA:
                 self.logger.info('Error getting Gamedata or strange ggl message appears')
                 self._loginerrorcounter += 1
                 if self._loginerrorcounter < 2:


### PR DESCRIPTION
For whatever reason, on some devices, a `ConsentActivity` screen appears after logging into a Google account. MAD was able to detect this screen, but couldn't handle it yet. 

The content is not readable via uiautomator due to it being a webview. I might've missed it, but we don't have a general OCR method that finds certain text and and its position on the screen to properly find the "Allow" button's position. On some screen resolutions we might even have to scroll down first.

For now, this should "fix" the consent screen on the x96 mini running the 64bit MAD rom.