### PR TITLE
Check walker max device settings before assigning areas

### DIFF
--- a/mapadroid/utils/routeutil.py
+++ b/mapadroid/utils/routeutil.py
@@ -55,3 +55,13 @@ def pre_check_value(walker_settings, eventid):
             return True
         return check_walker_value_type(walkervalue)
     return True
+
+
+def check_max_walkers_reached(walker, mapping_manager, area_name):
+    walkermax = walker.get('walkermax', False)
+    if walkermax is False or (type(walkermax) is str and len(walkermax) == 0):
+        return True
+    reg_workers = mapping_manager.routemanager_get_registered_workers(area_name)
+    if len(reg_workers) > int(walkermax):
+        return False
+    return True

--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -21,7 +21,7 @@ from mapadroid.utils.madGlobals import (
     WebsocketWorkerConnectionClosedException, WebsocketWorkerRemovedException,
     WebsocketWorkerTimeoutException)
 from mapadroid.utils.resolution import Resocalculator
-from mapadroid.utils.routeutil import check_walker_value_type
+from mapadroid.utils.routeutil import check_walker_value_type, check_max_walkers_reached
 from mapadroid.websocket.AbstractCommunicator import AbstractCommunicator
 from mapadroid.worker.AbstractWorker import AbstractWorker
 
@@ -132,15 +132,6 @@ class WorkerBase(AbstractWorker):
 
         return os.path.join(
             self._applicationArgs.temp_path, screenshot_filename)
-
-    def check_max_walkers_reached(self):
-        walkermax = self._walker.get('walkermax', False)
-        if walkermax is False or (type(walkermax) is str and len(walkermax) == 0):
-            return True
-        reg_workers = self._mapping_manager.routemanager_get_registered_workers(self._routemanager_name)
-        if len(reg_workers) > int(walkermax):
-            return False
-        return True
 
     @abstractmethod
     def _pre_work_loop(self):
@@ -365,7 +356,7 @@ class WorkerBase(AbstractWorker):
             self._internal_cleanup()
             return
 
-        if not self.check_max_walkers_reached():
+        if not check_max_walkers_reached(self._walker, self._mapping_manager, self._routemanager_name):
             self.logger.warning('Max. Walkers in Area {} - closing connections',
                                 self._mapping_manager.routemanager_get_name(self._routemanager_name))
             self.set_devicesettings_value('finished', True)

--- a/mapadroid/worker/WorkerFactory.py
+++ b/mapadroid/worker/WorkerFactory.py
@@ -8,7 +8,7 @@ from mapadroid.utils.collections import Location
 from mapadroid.utils.logging import LoggerEnums, get_logger, get_origin_logger
 from mapadroid.utils.madGlobals import WrongAreaInWalker
 from mapadroid.utils.MappingManager import MappingManager
-from mapadroid.utils.routeutil import pre_check_value
+from mapadroid.utils.routeutil import pre_check_value, check_max_walkers_reached
 from mapadroid.websocket.AbstractCommunicator import AbstractCommunicator
 from mapadroid.worker.AbstractWorker import AbstractWorker
 from mapadroid.worker.WorkerConfigmode import WorkerConfigmode
@@ -80,8 +80,9 @@ class WorkerFactory:
         # preckeck walker setting
         walker_area_name = walker_area_array[walker_index]['walkerarea']
         while not pre_check_value(walker_settings, self.__event.get_current_event_id()) \
-                and walker_index < len(walker_area_array):
-            origin_logger.info('not using area {} - Walkervalue out of range',
+                and walker_index < len(walker_area_array) \
+                and check_max_walkers_reached(walker_settings, self.__mapping_manager, walker_area_name):
+            origin_logger.info('not using area {} - Walkervalue out of range or max devices reached',
                                self.__mapping_manager.routemanager_get_name(walker_area_name))
             if walker_index >= len(walker_area_array) - 1:
                 origin_logger.warning('Cannot find any active area defined for current time. Check Walker entries')


### PR DESCRIPTION
Right now, MAD will assign an area to a device, check if that area has exceeded the configured device limit and then abort the connection to that device. This caused my setup (screenshot below) to take like 30 minutes for every device to get assigned to a mon area.

This PR will not fully fix this issue, but will improve the startup time. The area assignment only takes a few minutes now.

My walker looks like this and is assigned to about 55 devices.
![](https://user-images.githubusercontent.com/42342921/115230149-3c6b1280-a114-11eb-89c1-48bbac65c850.png)