### PR TITLE
Pin Flask to 1.1.4, 2.0.0 nuked some things.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ConfigArgParse~=0.14
+Flask~=1.1.4
 Flask-Caching~=1.8.0
 ImageHash~=4.0
 bitstring~=3.1


### PR DESCRIPTION
Probally not worth to checkout 2.0.0 before Grenn rework :)