### PR TITLE
Pin apkutils to 0.8.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ requests~=2.22
 s2sphere~=0.2
 websockets>=7
 numpy~=1.18.0
-apkutils>=0.8.3
+apkutils==0.8.3
 greenlet<0.4.17
 apkmirror-search
 cachetools


### PR DESCRIPTION
0.8.4 is broken, 0.9.0 is supposed to be working (Discord feedback), 0.10.0 is supposed to be broken too. Let's just stick to known-working-version.