### PR TITLE
Fixes/improvements for #1120

### DIFF
--- a/configs/config.ini.example
+++ b/configs/config.ini.example
@@ -56,7 +56,10 @@
 #only_routes                  # Only calculate routes, then exit the program. No scanning. Default: False
 #config_mode                  # Run in ConfigMode. Default: False
 #scan_nearby_mons             # Enable scanning of nearby mons - Please make sure you know how this works before turning it on!
-#scan_lured_mons               # Enable scanning of lured mons
+#disable_nearby_cell          # Disables nearby_cell scans if scan_nearby_mons is enabled
+#scan_lured_mons              # Enable scanning of lured mons
+#default_nearby_timeleft:     # The default despawn time left in minutes for Nearby Mons. Default: 15
+#default_unknown_timeleft:    # The default despawn time left in minutes for Mons at unknown Spawnpoints. Default: 3
 #status-name:                 # Setup name for this instance - if not set: PID of the process will be used
 #no_event_checker             # Disable event checker task
 

--- a/mapadroid/data_manager/modules/area_mon_mitm.py
+++ b/mapadroid/data_manager/modules/area_mon_mitm.py
@@ -188,15 +188,6 @@ class AreaMonMITM(Area):
                                    "Pokemon species to reach a near 100% IV-rate. This will slow down route progress!",
                     "expected": bool
                 }
-            },
-            "wait_for": {
-                "settings": {
-                    "type": "option",
-                    "require": False,
-                    "values": ["Encounter", "Nearby/GMO", "Lure Encounter"],
-                    "description": "What kind of Pokémon to wait for. (Default: Encounter)",
-                    "expected": str
-                }
             }
         }
     }

--- a/mapadroid/db/DbPogoProtoSubmit.py
+++ b/mapadroid/db/DbPogoProtoSubmit.py
@@ -79,7 +79,8 @@ class DbPogoProtoSubmit:
 
                 # get known spawn end time and feed into despawn time calculation
                 getdetspawntime = self._get_detected_endtime(str(spawnid))
-                despawn_time_unix = gen_despawn_timestamp(getdetspawntime, timestamp)
+                despawn_time_unix = gen_despawn_timestamp(getdetspawntime, timestamp,
+                                                          self._args.default_unknown_timeleft)
                 despawn_time = datetime.utcfromtimestamp(despawn_time_unix).strftime("%Y-%m-%d %H:%M:%S")
 
                 if getdetspawntime is None:
@@ -170,11 +171,11 @@ class DbPogoProtoSubmit:
                 gender = display["gender_value"]
 
                 now = datetime.utcfromtimestamp(time.time())
-                disappear_time = now + timedelta(minutes=15)  # TODO: Possible config option?
+                disappear_time = now + timedelta(minutes=self._args.default_nearby_timeleft)
                 disappear_time = disappear_time.strftime("%Y-%m-%d %H:%M:%S")
                 now = now.strftime("%Y-%m-%d %H:%M:%S")
 
-                if not stopid and cellid:
+                if (not stopid and cellid) and (not self._args.disable_nearby_cell):
                     lat, lon, _ = S2Helper.get_position_from_cell(cellid)
                     stopid = None
                     db_cell = cellid
@@ -257,7 +258,7 @@ class DbPogoProtoSubmit:
         spawnid = int(str(wild_pokemon["spawnpoint_id"]), 16)
 
         getdetspawntime = self._get_detected_endtime(str(spawnid))
-        despawn_time_unix = gen_despawn_timestamp(getdetspawntime, timestamp)
+        despawn_time_unix = gen_despawn_timestamp(getdetspawntime, timestamp, self._args.default_unknown_timeleft)
         despawn_time = datetime.utcfromtimestamp(despawn_time_unix).strftime("%Y-%m-%d %H:%M:%S")
 
         latitude = wild_pokemon.get("latitude")

--- a/mapadroid/utils/gamemechanicutil.py
+++ b/mapadroid/utils/gamemechanicutil.py
@@ -10,14 +10,14 @@ def calculate_mon_level(cp_multiplier):
     return round(pokemon_level) * 2 / 2
 
 
-def gen_despawn_timestamp(known_despawn, timestamp):
+def gen_despawn_timestamp(known_despawn, timestamp, default_time_left=3):
     if known_despawn is False:
         # just set despawn time to now + 3 minutes
         # after that round down to full minutes to fix
         # possible re-scan issue updating the seconds
         # causing the timestmap to change and thus causing
         # a resend via webhook. This kinde fixes that. Kinda.
-        return int(int(time.time() + 3 * 60) // 60 * 60)
+        return int(int(time.time() + default_time_left * 60) // 60 * 60)
 
     hrmi = known_despawn.split(":")
     known_despawn = datetime.now().replace(

--- a/mapadroid/utils/walkerArgs.py
+++ b/mapadroid/utils/walkerArgs.py
@@ -111,8 +111,14 @@ def parse_args():
                         help='Run in ConfigMode')
     parser.add_argument('-nm', '--scan_nearby_mons', action='store_true', default=False,
                         help='Enable scanning of nearby mons')
+    parser.add_argument('-dnc', '--disable_nearby_cell', action='store_true', default=False,
+                        help='Disables nearby_cell scans if scan_nearby_mons is enabled')
     parser.add_argument('-lm', '--scan_lured_mons', action='store_true', default=False,
                         help='Enable scanning of lured mons')
+    parser.add_argument('-dnt', '--default_nearby_timeleft', type=int, default=15,
+                        help='The default despawn time left in minutes for Nearby Mons. Default: 15')
+    parser.add_argument('-dut', '--default_unknown_timeleft', type=int, default=3,
+                        help='The default despawn time left in minutes for Mons at unknown Spawnpoints. Default: 3')
     parser.add_argument("-sn", "--status-name", default="mad",
                         help=("Enable status page database update using"
                               " STATUS_NAME as main worker name."))

--- a/mapadroid/webhook/webhookworker.py
+++ b/mapadroid/webhook/webhookworker.py
@@ -40,7 +40,6 @@ class WebhookWorker:
         ]
 
         self.__build_webhook_receivers()
-        self.__build_ivmon_list(mapping_manager)
         self.__build_excluded_areas(mapping_manager)
 
         if self.__args.webhook_start_time != 0:
@@ -579,12 +578,15 @@ class WebhookWorker:
             url = webhook.strip()
 
             if url.startswith("["):
-                raw_sub_types, url = url.split("]")
+                end_pos = url.index("]")
+                raw_sub_types = url[1:end_pos]
+                url = url[end_pos+1:]
+
                 sub_types = raw_sub_types[1:].split(" ")
                 sub_types = [t.replace(" ", "") for t in sub_types]
 
                 if "pokemon" in sub_types:
-                    sub_types += "encounter"
+                    sub_types.append("encounter")
 
                 for vtype in self.__valid_types:
                     if vtype in sub_types:
@@ -600,16 +602,6 @@ class WebhookWorker:
                 "url": url.replace(" ", ""),
                 "types": sub_types
             })
-
-    def __build_ivmon_list(self, mapping_manager: MappingManager):
-        self.__IV_MON: List[int] = []
-
-        for routemanager_name in mapping_manager.get_all_routemanager_names():
-            ids_iv_list: Optional[List[int]] = mapping_manager.routemanager_get_ids_iv(routemanager_name)
-
-            if ids_iv_list is not None:
-                # TODO check if area/routemanager is actually active before adding the IDs
-                self.__IV_MON = self.__IV_MON + list(set(ids_iv_list) - set(self.__IV_MON))
 
     def __build_excluded_areas(self, mapping_manager: MappingManager):
         self.__excluded_areas: List[GeofenceHelper] = []


### PR DESCRIPTION
This adds some more fixes to my PR #1120 as well as new config options.

config options
- disable_nearby_cell - disables nearby_cell pokemon if nearby scanning is activated
- default_nearby_timeleft - default minutes left for nearbies
- default_unknown_timeleft - default minutes left for wilds/encounters at unknown spawnpoints

webhook fixes (thanks jab):
- ipv6 support
- properly handle pokemon -> encounter backwards-compatibility 