### PR TITLE
Fix a typo in patchers and more info about more info about mon migration being long

### DIFF
--- a/mapadroid/patcher/add_is_ar_scan_eligible.py
+++ b/mapadroid/patcher/add_is_ar_scan_eligible.py
@@ -12,7 +12,7 @@ class Patch(PatchBase):
         """
         try:
             if not self._schema_updater.check_column_exists("pokestop", "is_ar_scan_eligible"):
-                self._db.execute(alter_pokestop, commit=True, raise_exec=True)
+                self._db.execute(alter_pokestop, commit=True, raise_exc=True)
         except Exception as e:
             self._logger.exception("Unexpected error: {}", e)
             self.issues = True
@@ -23,7 +23,7 @@ class Patch(PatchBase):
         """
         try:
             if not self._schema_updater.check_column_exists("gym", "is_ar_scan_eligible"):
-                self._db.execute(alter_gym, commit=True, raise_exec=True)
+                self._db.execute(alter_gym, commit=True, raise_exc=True)
         except Exception as e:
             self._logger.exception("Unexpected error: {}", e)
             self.issues = True

--- a/mapadroid/patcher/dynamic_iv_list.py
+++ b/mapadroid/patcher/dynamic_iv_list.py
@@ -18,7 +18,7 @@ class Patch(PatchBase):
                     AFTER `monlist_id`;
                 """.format(table)
                 try:
-                    self._db.execute(alter, commit=True, raise_exec=True)
+                    self._db.execute(alter, commit=True, raise_exc=True)
                 except Exception as e:
                     self._logger.exception("Unexpected error: {}", e)
                     self.issues = True

--- a/mapadroid/patcher/extend_trs_quest_pogodroid_190.py
+++ b/mapadroid/patcher/extend_trs_quest_pogodroid_190.py
@@ -12,7 +12,7 @@ class Patch(PatchBase):
             COLLATE utf8mb4_unicode_ci DEFAULT NULL;
         """
         try:
-            self._db.execute(alter_sql, commit=True, raise_exec=True)
+            self._db.execute(alter_sql, commit=True, raise_exc=True)
         except Exception as e:
             self._logger.exception("Unexpected error: {}", e)
             self.issues = True

--- a/mapadroid/patcher/madrom_autoconfig.py
+++ b/mapadroid/patcher/madrom_autoconfig.py
@@ -82,22 +82,22 @@ class Patch(PatchBase):
                 sql = "ALTER TABLE `settings_device`\n"\
                       " ADD `mac_address` VARCHAR(17) CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_unicode_ci' NULL\n"\
                       " AFTER `enhanced_mode_quest_safe_items`;"
-                self._db.execute(sql, commit=True, raise_exec=True)
+                self._db.execute(sql, commit=True, raise_exc=True)
             if not self._schema_updater.check_column_exists('settings_device', 'interface_type'):
                 sql = "ALTER TABLE `settings_device`\n"\
                       " ADD `interface_type` enum('lan','wlan') COLLATE utf8mb4_unicode_ci DEFAULT 'lan'\n"\
                       " AFTER `mac_address`;"
-                self._db.execute(sql, commit=True, raise_exec=True)
+                self._db.execute(sql, commit=True, raise_exc=True)
             if not self._schema_updater.check_column_exists('settings_device', 'account_id'):
                 sql = "ALTER TABLE `settings_device`\n"\
                       "     ADD `account_id` int(10) unsigned NULL\n"\
                       "     AFTER `interface_type`;"
-                self._db.execute(sql, commit=True, raise_exec=True)
+                self._db.execute(sql, commit=True, raise_exc=True)
             sql = "ALTER TABLE `settings_device`\n"\
                   "     ADD CONSTRAINT `settings_device_ibfk_3`\n"\
                   "     FOREIGN KEY (`account_id`)\n"\
                   "           REFERENCES `settings_pogoauth` (`account_id`);"
-            self._db.execute(sql, commit=True, raise_exec=False)
+            self._db.execute(sql, commit=True, raise_exc=False)
         except Exception as e:
             self._logger.exception("Unexpected error: {}", e)
             self.issues = True

--- a/mapadroid/patcher/more_ways_to_scan_mons.py
+++ b/mapadroid/patcher/more_ways_to_scan_mons.py
@@ -25,7 +25,7 @@ class Patch(PatchBase):
                 self._db.execute(alter_pokemon, commit=True, raise_exc=True)
         except Exception as e:
             self._logger.exception("Unexpected error: {}", e)
-            self._logger.warning("Migration failed if your error is Temporary file write failure it means you run out of disk space.")
+            self._logger.warning("If your error is 'Temporary file write failure' it means you run out of hard disk space.")
             self._logger.warning("Delete/truncate old entries from pokemon table or re-created table by hand.")
             self.issues = True
 

--- a/mapadroid/patcher/more_ways_to_scan_mons.py
+++ b/mapadroid/patcher/more_ways_to_scan_mons.py
@@ -10,6 +10,7 @@ class Patch(PatchBase):
     )
 
     def _execute(self):
+        self._logger.warning("This migration may take a while if you don't trim your pokemon table often.")
         alter_pokemon = (
             "ALTER TABLE `pokemon` "
             "ADD COLUMN `fort_id` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL, "
@@ -21,9 +22,11 @@ class Patch(PatchBase):
             if not self._schema_updater.check_column_exists("pokemon", "fort_id")\
                     or not self._schema_updater.check_column_exists("pokemon", "cell_id")\
                     or not self._schema_updater.check_column_exists("pokemon", "seen_type"):
-                self._db.execute(alter_pokemon, commit=True, raise_exec=True)
+                self._db.execute(alter_pokemon, commit=True, raise_exc=True)
         except Exception as e:
             self._logger.exception("Unexpected error: {}", e)
+            self._logger.warning("Migration failed if your error is Temporary file write failure it means you run out of disk space.")
+            self._logger.warning("Delete/truncate old entries from pokemon table or re-created table by hand.")
             self.issues = True
 
         remove_encounter_id = """
@@ -32,7 +35,7 @@ class Patch(PatchBase):
         """
         try:
             if self._schema_updater.check_column_exists("pokestop", "encounter_id"):
-                self._db.execute(remove_encounter_id, commit=True, raise_exec=True)
+                self._db.execute(remove_encounter_id, commit=True, raise_exc=True)
         except Exception as e:
             self._logger.exception("Unexpected error: {}", e)
             self.issues = True

--- a/mapadroid/patcher/more_ways_to_scan_mons.py
+++ b/mapadroid/patcher/more_ways_to_scan_mons.py
@@ -25,7 +25,7 @@ class Patch(PatchBase):
                 self._db.execute(alter_pokemon, commit=True, raise_exc=True)
         except Exception as e:
             self._logger.exception("Unexpected error: {}", e)
-            self._logger.warning("If your error is 'Temporary file write failure' it means you run out of hard disk space.")
+            self._logger.warning("If your error is 'Temporary file write failure' it means you run out of disk space.")
             self._logger.warning("Delete/truncate old entries from pokemon table or re-created table by hand.")
             self.issues = True
 

--- a/mapadroid/patcher/patch_23.py
+++ b/mapadroid/patcher/patch_23.py
@@ -13,7 +13,7 @@ class Patch(PatchBase):
             field_defs[field_name] = field
         sql = "SELECT %s FROM `trs_status`" % (','.join(field_defs.keys()),)
         try:
-            existing_data = self._db.autofetch_all(sql, raise_exec=True)
+            existing_data = self._db.autofetch_all(sql, raise_exc=True)
         except Exception:
             pass
         if not existing_data:
@@ -60,7 +60,7 @@ class Patch(PatchBase):
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
         """
         try:
-            self._db.execute(new_table, commit=True, raise_exec=True)
+            self._db.execute(new_table, commit=True, raise_exc=True)
         except Exception as e:
             self._logger.exception("Unexpected error: {}", e)
             self.issues = True
@@ -133,7 +133,7 @@ class Patch(PatchBase):
                 LEFT JOIN `settings_area` sa ON sa.`area_id` = trs.`area_id`
             """
         try:
-            self._db.execute(sql, commit=True, raise_exec=True)
+            self._db.execute(sql, commit=True, raise_exc=True)
         except Exception as e:
             self._logger.exception("Unexpected error: {}", e)
             self.issues = True

--- a/mapadroid/patcher/patch_24.py
+++ b/mapadroid/patcher/patch_24.py
@@ -24,7 +24,7 @@ class Patch(PatchBase):
                 LEFT JOIN `settings_area` sa ON sa.`area_id` = trs.`area_id`
             """
         try:
-            self._db.execute(sql, commit=True, raise_exec=True)
+            self._db.execute(sql, commit=True, raise_exc=True)
         except Exception as e:
             self._logger.exception("Unexpected error: {}", e)
             self.issues = True

--- a/mapadroid/patcher/patch_28.py
+++ b/mapadroid/patcher/patch_28.py
@@ -14,7 +14,7 @@ class Patch(PatchBase):
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
         """
         try:
-            self._db.execute(origin_sql, commit=True, raise_exec=True)
+            self._db.execute(origin_sql, commit=True, raise_exc=True)
         except Exception as e:
             self._logger.exception("Unexpected error: {}", e)
             self.issues = True

--- a/mapadroid/patcher/patch_29.py
+++ b/mapadroid/patcher/patch_29.py
@@ -13,7 +13,7 @@ class Patch(PatchBase):
             CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_unicode_ci' NULL DEFAULT NULL;
         """
         try:
-            self._db.execute(origin_sql, commit=True, raise_exec=True)
+            self._db.execute(origin_sql, commit=True, raise_exc=True)
         except Exception as e:
             self._logger.exception("Unexpected error: {}", e)
             self.issues = True

--- a/mapadroid/patcher/reset_routecalc_algo.py
+++ b/mapadroid/patcher/reset_routecalc_algo.py
@@ -13,7 +13,7 @@ class Patch(PatchBase):
         )
 
         try:
-            self._db.execute(sql, commit=True, raise_exec=True)
+            self._db.execute(sql, commit=True, raise_exc=True)
         except Exception as e:
             self._logger.exception("Unexpected error: {}", e)
             self.issues = True

--- a/mapadroid/patcher/routecalc_rename.py
+++ b/mapadroid/patcher/routecalc_rename.py
@@ -13,7 +13,7 @@ class Patch(PatchBase):
             CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_unicode_ci' NULL DEFAULT NULL ;
         """
         try:
-            self._db.execute(origin_sql, commit=True, raise_exec=True)
+            self._db.execute(origin_sql, commit=True, raise_exc=True)
         except Exception as e:
             self._logger.exception("Unexpected error: {}", e)
             self.issues = True


### PR DESCRIPTION
Looks like we failed with copy-pasting code -> s/raise_exec/raise_exc/
I think I fixed all so next time we copy-paste it will be good 🥇 

This also did not stop some migrations in past, but seems they never failed up to now :-)