### PR TITLE
remove encounter_id from pokestop

### DIFF
--- a/scripts/SQL/rocketmap.sql
+++ b/scripts/SQL/rocketmap.sql
@@ -141,7 +141,6 @@ CREATE TABLE `pokestop` (
     `incident_expiration` datetime DEFAULT NULL,
     `incident_grunt_type` smallint(1) DEFAULT NULL,
     `is_ar_scan_eligible` tinyint(1) NOT NULL DEFAULT '0',
-    `encounter_id` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
     PRIMARY KEY (`pokestop_id`),
     KEY `pokestop_last_modified` (`last_modified`),
     KEY `pokestop_lure_expiration` (`lure_expiration`),


### PR DESCRIPTION
This should have been part of #1120 but for whatever reason it didn't go in. This change is already part of #1120's DB patch.

[Banana's message confirming this was an accidental copy-paste](https://discord.com/channels/465247740553592832/562515411149651983/826029130222141471)