### PR TITLE
Fix `Win a level X or higher raid` quest

### DIFF
--- a/mapadroid/utils/questGen.py
+++ b/mapadroid/utils/questGen.py
@@ -210,9 +210,9 @@ def questtask(typeid, condition, target, quest_template):
     elif typeid == 8:
         if re.search(r'"type": 6', condition) is not None:
             text = _("Win {0} Raids")
-            if re.search(r'"raid_level": \[3, 4, 5, 6\]', condition) is not None:
+            if re.search(r'"raid_level": \[3, 4, 5(.*)\]', condition) is not None:
                 text = _('Win a level 3 or higher raid')
-            if re.search(r'"raid_level": \[2, 3, 4, 5, 6\]', condition) is not None:
+            if re.search(r'"raid_level": \[2, 3, 4, 5(.*)\]', condition) is not None:
                 text = _('Win a level 2 or higher raid')
             if re.search(r'"raid_level": \[6\]', condition) is not None:
                 text = _('Win a Mega raid')

--- a/mapadroid/utils/questGen.py
+++ b/mapadroid/utils/questGen.py
@@ -210,9 +210,9 @@ def questtask(typeid, condition, target, quest_template):
     elif typeid == 8:
         if re.search(r'"type": 6', condition) is not None:
             text = _("Win {0} Raids")
-            if re.search(r'"raid_level": \[3, 4, 5\]', condition) is not None:
+            if re.search(r'"raid_level": \[3, 4, 5, 6\]', condition) is not None:
                 text = _('Win a level 3 or higher raid')
-            if re.search(r'"raid_level": \[2, 3, 4, 5\]', condition) is not None:
+            if re.search(r'"raid_level": \[2, 3, 4, 5, 6\]', condition) is not None:
                 text = _('Win a level 2 or higher raid')
             if re.search(r'"raid_level": \[6\]', condition) is not None:
                 text = _('Win a Mega raid')


### PR DESCRIPTION
Looks like Niantic finally added megas to that.
```
'goal': {
				'condition': [{
					'type': 7,
					'with_raid_level': {
						'raid_level': [3, 4, 5, 6]
					}
				}, {
					'type': 6,
					'with_win_raid_status': {}
				}],
				'target': 1
			},
```