### PR TITLE
fix some random issue in patch 23

### DIFF
--- a/mapadroid/patcher/patch_23.py
+++ b/mapadroid/patcher/patch_23.py
@@ -15,7 +15,7 @@ class Patch(PatchBase):
         try:
             existing_data = self._db.autofetch_all(sql, raise_exc=True)
         except Exception:
-            pass
+            existing_data = False
         if not existing_data:
             existing_data = {}
         sql = "DROP TABLE IF EXISTS `trs_status`"


### PR DESCRIPTION
if an exception occurs, `existing_data` is referenced before assignment