### PR TITLE
Fix route manager locking

### DIFF
--- a/mapadroid/route/RouteManagerBase.py
+++ b/mapadroid/route/RouteManagerBase.py
@@ -201,7 +201,7 @@ class RouteManagerBase(ABC):
 
     def unregister_worker(self, worker_name):
         route_logger = routelogger_set_origin(self.logger, origin=worker_name)
-        with self._workers_registered_mutex and self._manager_mutex:
+        with self._manager_mutex, self._workers_registered_mutex:
             if worker_name in self._workers_registered:
                 route_logger.info("unregistering from routemanager")
                 self._workers_registered.remove(worker_name)
@@ -812,7 +812,7 @@ class RouteManagerBase(ABC):
         if self.mode in ("iv_mitm", "idle"):
             self.logger.info('Not updating routepools in iv_mitm mode')
             return True
-        with self._manager_mutex and self._workers_registered_mutex:
+        with self._manager_mutex, self._workers_registered_mutex:
             self.logger.debug("Updating all routepools")
             workers = len(self._routepool)
             if len(self._workers_registered) == 0 or workers == 0:

--- a/mapadroid/route/RouteManagerLeveling.py
+++ b/mapadroid/route/RouteManagerLeveling.py
@@ -27,7 +27,7 @@ class RouteManagerLeveling(RouteManagerQuests):
                                     )
 
     def _worker_changed_update_routepools(self):
-        with self._manager_mutex and self._workers_registered_mutex:
+        with self._manager_mutex, self._workers_registered_mutex:
             self.logger.info("Updating all routepools in level mode for {} origins", len(self._routepool))
             if len(self._workers_registered) == 0:
                 self.logger.info("No registered workers, aborting __worker_changed_update_routepools...")

--- a/mapadroid/route/RouteManagerLevelingRoutefree.py
+++ b/mapadroid/route/RouteManagerLevelingRoutefree.py
@@ -26,7 +26,7 @@ class RouteManagerLevelingRoutefree(RouteManagerQuests):
                                     )
 
     def _worker_changed_update_routepools(self):
-        with self._manager_mutex and self._workers_registered_mutex:
+        with self._manager_mutex, self._workers_registered_mutex:
             self.logger.info("Updating all routepools in level mode for {} origins", len(self._routepool))
             if len(self._workers_registered) == 0:
                 self.logger.info("No registered workers, aborting __worker_changed_update_routepools...")


### PR DESCRIPTION
'with a and b:' does not do what one might think. The correct
syntax is 'with a, b:' or 'with a as foo, b as bar:', etc.

It seems that 'with a and b:' does require that 'a' have an
__enter__ method, but it never calls it... it just skips to 'b'
as can be seen below.

Additionally, had both locks worked, there was a lock ordering problem
in one spot.

```
class Testing:
    def __enter__(self):
        print('    enter: %s' % self.__class__)
        return 1
    def __exit__(self, a, b, c):
        print('    exit: %s' % self.__class__)

class Testing1(Testing):
    pass

class Testing2(Testing):
    pass

t1 = Testing1()
t2 = Testing2()

print('testing with "and":')
with t1 and t2:
    print('woot')

print()

print('testing with comma:')
with t1, t2:
    print('woot')

----- OUTPUT ------

testing with "and":
    enter: <class '__main__.Testing2'>
woot
    exit: <class '__main__.Testing2'>

testing with comma:
    enter: <class '__main__.Testing1'>
    enter: <class '__main__.Testing2'>
woot
    exit: <class '__main__.Testing2'>
    exit: <class '__main__.Testing1'>
```