### PR TITLE
Fix iv_mitm deadlocking and other issues

### DIFF
--- a/mapadroid/route/RouteManagerIV.py
+++ b/mapadroid/route/RouteManagerIV.py
@@ -68,6 +68,18 @@ class RouteManagerIV(RouteManagerBase):
     def _delete_coord_after_fetch(self) -> bool:
         return False
 
+    def _should_check_prioq(self, origin: str) -> bool:
+        # Override the base class. We only require the prioq to not be empty.
+        return self._prio_queue
+
+    def _has_normal_route(self) -> bool:
+        # Override the base class. We only use coords from prioq.
+        return False
+
+    def _can_pass_prioq_coords(self) -> bool:
+        # Override the base class. No need to pass prioq coords.
+        return False
+
     def _start_routemanager(self):
         with self._manager_mutex:
             if not self._is_started:

--- a/mapadroid/route/RouteManagerMon.py
+++ b/mapadroid/route/RouteManagerMon.py
@@ -1,3 +1,5 @@
+import time
+
 from mapadroid.route.RouteManagerBase import RouteManagerBase
 from mapadroid.utils.logging import LoggerEnums, get_logger
 
@@ -53,6 +55,17 @@ class RouteManagerMon(RouteManagerBase):
             return self.settings.get("priority_queue_clustering_timedelta", 300)
         else:
             return 300
+
+    def _should_skip_prioq_entry(self, queue_entry) -> bool:
+        # Override the base class:
+        # TODO: Consider if we want to have the following functionality for other modes, too
+        # Problem: delete_seconds_passed = 0 makes sense in _filter_priority_queue_internal,
+        # because it will remove past events only at the moment of prioQ calculation,
+        # but here it would skip ALL events, because events can only be due when they are in the past
+        if self.remove_from_queue_backlog in [None, 0]:
+            return False
+        delete_before = time.time() - self.remove_from_queue_backlog
+        return queue_entry[0] < delete_before
 
     def _start_routemanager(self):
         with self._manager_mutex:


### PR DESCRIPTION
This refactors get_next_location() for the following purposes:

1) Remove recursion as it can deadlock. (See below.)
2) Don't sleep while holding a lock (happens currently for 'iv_mitm')
3) Don't pass coords for 'iv_mitm' as they are never used/looked at.
   (See below.)
4) Remove checks on 'mode'. The base class should not have to have
different logic based on 'mode'. Mode specific logic should exist
in their respective classes!

More details:

* Issue 1 above: iv_mitm deadlocking

There are a few checks within the prioq section of get_next_location()
that can cause recursion. When this happens, a deadlock can occur.

This is due to the recursing of get_next_location() while holding
self._manager_mutex in combination with this loop that is at the top
of get_next_location() that loops until there is a queue entry for
iv_mitm:

```
    got_location = False
    while not got_location and self._is_started and not self.init:
        with self._manager_mutex:
            if self.mode == "iv_mitm":
                got_location = self._prio_queue is not None and len(self._prio_queue) > 0
                if not got_location:
                    time.sleep(1)
[...]

def _prioq_update_thread(...):
[...]
   with self._manager_mutex:
      # replace the queue
```

When recursed, self._manager_mutex is already held. Yes, it's an
RLock, so locking again is not a problem when we re-enter
get_next_location().

However, if the queue is empty... we sit in that 'while' loop forever.
When we do, the *original* get_next_location() is always holding the
_manager_mutex lock. The update thread becomes blocked forever on that lock
and cannot add any more queue entries. MAD has to be restarted.

* Issue 3 above: 'iv_mitm' passed coord being ignored/dropped:

Passed coords are not used when in 'iv_mitm' mode:

```
            elif self._routepool[origin].has_prio_event and self.mode != 'iv_mitm':
                 prioevent = self._routepool[origin].prio_coords
                 route_logger.info('getting a nearby prio event {}', prioevent)
```

Yet.. coords are tried to be passed later for EVERY mode:

```
                 if self._other_worker_closer_to_prioq(next_coord, origin):
[...]
                     # Let's recurse and find another location
                     return self.get_next_location(origin)
```