### PR TITLE
Fix websocket/worker races

### DIFF
--- a/mapadroid/worker/WorkerBase.py
+++ b/mapadroid/worker/WorkerBase.py
@@ -233,7 +233,7 @@ class WorkerBase(AbstractWorker):
         t_main_work.daemon = True
         t_main_work.start()
         # do some other stuff in the main process
-        while not self._stop_worker_event.isSet():
+        while not self._stop_worker_event.is_set():
             time.sleep(1)
 
         while t_main_work.is_alive():
@@ -243,8 +243,8 @@ class WorkerBase(AbstractWorker):
         return self._last_known_state
 
     def stop_worker(self):
-        if self._stop_worker_event.set():
-            self.logger.info('Worker already stopped - waiting for it')
+        if self._stop_worker_event.is_set():
+            self.logger.info('Worker stop called, but worker is already stopping...')
         else:
             self._stop_worker_event.set()
             self.logger.info("Worker stop called")
@@ -372,7 +372,7 @@ class WorkerBase(AbstractWorker):
             self._internal_cleanup()
             return
 
-        while not self._stop_worker_event.isSet():
+        while not self._stop_worker_event.is_set():
             try:
                 # TODO: consider getting results of health checks and aborting the entire worker?
                 walkercheck = self.check_walker()
@@ -561,7 +561,7 @@ class WorkerBase(AbstractWorker):
             if check_walker_value_type(sleeptime):
                 self._stop_pogo()
                 killpogo = True
-            while not self._stop_worker_event.isSet() and check_walker_value_type(sleeptime):
+            while not self._stop_worker_event.is_set() and check_walker_value_type(sleeptime):
                 time.sleep(1)
             self.logger.info('just woke up')
             if killpogo:


### PR DESCRIPTION
Often in our setup, RGC reconnects before MAD notices that the old
connection is dead. When this happens, the worker is found to still
be running and not shutting down... thus the new connection is just
replaced in the WebsocketConnectedClientEntry for the worker to use.

However, once MAD finally detects the old connection is dead, it then
stops the worker... leaving no worker running for the new RGC
connection. The new RGC connection continues to ping/pong just fine,
but it's doing nothing else.. You have to restart the device (or MAD)
to recover from this.

This fixes the issue by moving the stopping of the worker to the
connection handler and only doing it when the 'Done' connection is
still the one in the WebsocketConnectedClientEntry.

But we also need to not allow new connections while the worker is still
running on an old one because of potential races with the worker
shutting itself down.

Also modifies logs, which helped track this down and may be useful
in the future.