### PR TITLE
Enable encounters in quest mode

### DIFF
--- a/mapadroid/data_manager/modules/area_pokestops.py
+++ b/mapadroid/data_manager/modules/area_pokestops.py
@@ -113,6 +113,33 @@ class AreaPokestops(Area):
                     "description": "Cleanup quest inventory after every stop (Default: False)",
                     "expected": bool
                 }
+            },
+            "mon_ids_iv": {
+                "settings": {
+                    "type": "lookup",
+                    "display": {
+                        "name": "monlist",
+                        "section": "monivlist"
+                    },
+                    "require": False,
+                    "description": "IV List Resource",
+                    "expected": int,
+                    "uri": True,
+                    "data_source": "monivlist",
+                    "uri_source": "api_monivlist"
+                }
+            },
+            "all_mons": {
+                "settings": {
+                    "type": "option",
+                    "require": False,
+                    "values": [False, True],
+                    "description":
+                        "Dynamically generate the areas IV list to ensure all mons are included. If a mon is not part "
+                        "of the IV list it will be appended to the end of the list. Mons will be added in ascending "
+                        "order based on their ID.",
+                    "expected": bool
+                }
             }
         }
     }

--- a/mapadroid/patcher/__init__.py
+++ b/mapadroid/patcher/__init__.py
@@ -50,7 +50,8 @@ MAD_UPDATES = OrderedDict([
     (41, 'dynamic_iv_list'),
     (42, 'add_encounter_all'),
     (43, 'remove_tap_duration'),
-    (44, 'more_ways_to_scan_mons')
+    (44, 'more_ways_to_scan_mons'),
+    (45, 'pokestop_encounters')
 ])
 
 

--- a/mapadroid/patcher/pokestop_encounters.py
+++ b/mapadroid/patcher/pokestop_encounters.py
@@ -1,0 +1,34 @@
+from ._patch_base import PatchBase
+
+
+class Patch(PatchBase):
+    name = "Pokestop Encounters"
+    descr = (
+        'Add settings to enable encounters in pokestop mode'
+    )
+
+    def _execute(self):
+        if not self._schema_updater.check_column_exists("settings_area_pokestops", "all_mons"):
+            alter = """
+                ALTER TABLE `settings_area_pokestops`
+                ADD COLUMN `all_mons` tinyint(1) NOT NULL DEFAULT '0'
+            """
+            try:
+                self._db.execute(alter, commit=True, raise_exc=True)
+            except Exception as e:
+                self._logger.exception("Unexpected error: {}", e)
+                self.issues = True
+
+        if not self._schema_updater.check_column_exists("settings_area_pokestops", "monlist_id"):
+            alter = """
+                ALTER TABLE `settings_area_pokestops`
+                ADD COLUMN `monlist_id` int(10) unsigned DEFAULT NULL,
+                ADD KEY `fk_ap_monid` (`monlist_id`),
+                ADD CONSTRAINT `fk_ap_monid` FOREIGN KEY (`monlist_id`)
+                    REFERENCES `settings_monivlist` (`monlist_id`);
+            """
+            try:
+                self._db.execute(alter, commit=True, raise_exc=True)
+            except Exception as e:
+                self._logger.exception("Unexpected error: {}", e)
+                self.issues = True


### PR DESCRIPTION
Due to PD being able to hide Pokemon on the game map, it is no longer a problem that Pokemon might be clicked instead of the Pokestop during quest scan.

Thus, checking for these clicks based on received encounter data is no longer necessary and encounters can be received without
disturbing the quest scan flow.

This PR enables the relevant settings `mon_ids_iv` and `all_mons` for pokestop areas (database change!) and changes the quest scan workflow to ignore encounter data while trying to open a pokestop.