### PR TITLE
make iv_mitm encounter like mon_mitm

### DIFF
--- a/mapadroid/worker/WorkerMITM.py
+++ b/mapadroid/worker/WorkerMITM.py
@@ -114,7 +114,7 @@ class WorkerMITM(MITMBase):
             # worker has to sleep, just empty out the settings...
             ids_iv = []
             scanmode = "nothing"
-        elif routemanager_mode == "mon_mitm":
+        elif routemanager_mode == "mon_mitm" or routemanager_mode == "iv_mitm":
             scanmode = "mons"
             routemanager_settings = self._mapping_manager.routemanager_get_settings(self._routemanager_name)
             if routemanager_settings is not None:
@@ -124,9 +124,6 @@ class WorkerMITM(MITMBase):
             routemanager_settings = self._mapping_manager.routemanager_get_settings(self._routemanager_name)
             if routemanager_settings is not None:
                 ids_iv = self._mapping_manager.get_monlist(self._routemanager_name)
-        elif routemanager_mode == "iv_mitm":
-            scanmode = "ivs"
-            ids_iv = self._mapping_manager.routemanager_get_encounter_ids_left(self._routemanager_name)
         else:
             # TODO: should we throw an exception here?
             ids_iv = []


### PR DESCRIPTION
With UIV enabled in PD, it is no longer necessary that an `iv_mitm` worker only encounters its scheduled specific pokemon at the target location. Instead, it can jump to the locations and just encounter every mon there. This is accomplished by telling PD
it's in mons mode while MAD still schedules the `iv_mitm` area as usual.

Using a `iv_mitm` optimized IV List as usual, but with `all_mons` enabled, will still have the worker teleport to desirable mons on priority, but encounter every mon at the location.