### PR TITLE
WIP Make Dockerfile work again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,6 @@ libxext6 \
 libxrender-dev \
 tk \
 wget \
-&& wget https://github.com/tesseract-ocr/tessdata/raw/master/eng.traineddata \
-&& mkdir /usr/local/share/tessdata/ \
-&& mv -v eng.traineddata /usr/local/share/tessdata/ \
 # python reqs
 && python3 -m pip install --no-cache-dir -r requirements.txt ortools redis \
 # cleanup

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update \
 build-essential \
 libglib2.0-0 \
 default-libmysqlclient-dev \
-libgl1 python-opencv \
+libgl1 python3-opencv \
 libsm6 \
 libxext6 \
 libxrender-dev \
@@ -34,12 +34,8 @@ wget \
 && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 && rm -rf /var/lib/apt/lists/*
 
-RUN printf "deb http://ftp.de.debian.org/debian stretch main" >> /etc/apt/sources.list \
-&& apt-get update && apt-get install libicu57
-
-# tesseract from stretch-backport
-RUN printf "deb http://httpredir.debian.org/debian stretch-backports main non-free\ndeb-src http://httpredir.debian.org/debian stretch-backports main non-free" >> /etc/apt/sources.list.d/backports.list \
-&& apt-get update && apt-get -y --allow-unauthenticated -t stretch-backports install tesseract-ocr libtesseract-dev
+# tesseract
+RUN apt-get update && apt-get -y install tesseract-ocr libtesseract-dev
 
 # Copy everything to the working directory (Python files, templates, config) in one go.
 COPY . /usr/src/app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,25 +14,18 @@ COPY requirements.txt /usr/src/app/
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update \
 && apt-get install -y --no-install-recommends \
 build-essential \
-libglib2.0-0 \
 default-libmysqlclient-dev \
-libgl1 python3-opencv \
-libsm6 \
-libxext6 \
-libxrender-dev \
-tk \
-wget \
+python3-opencv \
 # python reqs
 && python3 -m pip install --no-cache-dir -r requirements.txt ortools redis \
 # cleanup
-&& apt-get remove -y wget \
 && apt-get remove -y build-essential \
 && apt-get remove -y python2.7 && rm -rf /usr/lib/python2.7 \
 && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 && rm -rf /var/lib/apt/lists/*
 
 # tesseract
-RUN apt-get update && apt-get -y install tesseract-ocr libtesseract-dev
+RUN apt-get update && apt-get -y install tesseract-ocr
 
 # Copy everything to the working directory (Python files, templates, config) in one go.
 COPY . /usr/src/app/

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -15,7 +15,7 @@ RUN apt-get install -y --no-install-recommends \
 # pyenv
 build-essential libssl-dev zlib1g-dev libbz2-dev \
 libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-xz-utils tk-dev libffi-dev liblzma-dev python-openssl git \
+xz-utils tk-dev libffi-dev liblzma-dev python3-openssl git \
 # python build
 libffi-dev libgdbm-dev libsqlite3-dev libssl-dev zlib1g-dev && \
 # Create user


### PR DESCRIPTION
Debian 11 (bullseye) changes apt packet name for opencv to python3-opencv.
It also comes with tesseract so I'm trying to see if this can be fetched directly instead