### PR TITLE
Add back OpenCV dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update \
 && apt-get install -y --no-install-recommends \
 build-essential \
 default-libmysqlclient-dev \
+# OpenCV & dependencies
 python3-opencv \
+libsm6 \
 # python reqs
 && python3 -m pip install --no-cache-dir -r requirements.txt ortools redis \
 # cleanup


### PR DESCRIPTION
At least with the current code libSM6 is a hard dependency:
```
Traceback (most recent call last):
  File "start.py", line 19, in <module>
    from mapadroid.madmin.madmin import MADmin
  File "/usr/src/app/mapadroid/madmin/madmin.py", line 14, in <module>
    from mapadroid.madmin.routes.control import MADminControl
  File "/usr/src/app/mapadroid/madmin/routes/control.py", line 24, in <module>
    from mapadroid.websocket.WebsocketServer import WebsocketServer
  File "/usr/src/app/mapadroid/websocket/WebsocketServer.py", line 14, in <module>
    from mapadroid.ocr.pogoWindows import PogoWindows
  File "/usr/src/app/mapadroid/ocr/pogoWindows.py", line 8, in <module>
    import cv2
  File "/usr/local/lib/python3.7/site-packages/cv2/__init__.py", line 5, in <module>
    from .cv2 import *
ImportError: libSM.so.6: cannot open shared object file: No such file or directory
```