### PR TITLE
(feat)[wizard]: Supported versions from MADdev backend

### DIFF
--- a/configs/config.ini.example
+++ b/configs/config.ini.example
@@ -157,8 +157,9 @@
 ######################
 #token_dispenser:           # Path to token dispenser config (MAD-provided)
 #token_dispenser_user:      # Path to token dispenser config (User-provided)
-#gmail_user:                # Email address if not using a token dispenser
-#gmail_passwd:              # Google Mail Password for interacting with the Google Play Store.  Must be an app password or 2fa will be triggered (this should be enabled on your account anyways')
+#gmail_user:                # (Deprecated) Email address if not using a token dispenser
+#gmail_passwd:              # (Deprecated) Google Mail Password for interacting with the Google Play Store.  Must be an app password or 2fa will be triggered (this should be enabled on your account anyways')
+#maddev_api_token           # Token used by the wizard to query supported versions
 
 
 # Auto-Config

--- a/mapadroid/mad_apk/__init__.py
+++ b/mapadroid/mad_apk/__init__.py
@@ -21,7 +21,7 @@ def get_storage_obj(application_args, dbc):
         StorageSyncManager.register('APKStorageDatabase', APKStorageDatabase)
         manager = StorageSyncManager()
         manager.start()
-        storage_obj = manager.APKStorageDatabase(dbc)
+        storage_obj = manager.APKStorageDatabase(dbc, application_args.maddev_api_token)
     else:
         StorageSyncManager.register('APKStorageFilesystem', APKStorageFilesystem)
         manager = StorageSyncManager()

--- a/mapadroid/mad_apk/abstract_apk_storage.py
+++ b/mapadroid/mad_apk/abstract_apk_storage.py
@@ -2,11 +2,23 @@ from abc import ABC, abstractmethod
 from io import BytesIO
 from typing import NoReturn, Optional
 
+from mapadroid.utils.logging import LoggerEnums, get_logger
+
 from .apk_enums import APKArch, APKType
 from .custom_types import MADPackages
 
+logger = get_logger(LoggerEnums.storage)
 
-class AbstractAPKStorage(ABC):
+
+class AbstractAPKStorage(ABC, object):
+    api_token: str = None
+
+    def __init__(self, token):
+        self.api_token = token
+
+    def token(self):
+        return self.api_token
+
     @abstractmethod
     def delete_file(self, package: APKType, architecture: APKArch) -> bool:
         """ Remove the package and update the configuration

--- a/mapadroid/mad_apk/apk_storage_db.py
+++ b/mapadroid/mad_apk/apk_storage_db.py
@@ -24,8 +24,9 @@ class APKStorageDatabase(AbstractAPKStorage):
         dbc: Database wrapper
         file_lock (RLock): RLock to allow updates to be thread-safe
     """
-    def __init__(self, dbc):
+    def __init__(self, dbc, token):
         logger.debug('Initializing Database storage')
+        super(APKStorageDatabase, self).__init__(token)
         self.file_lock: RLock = RLock()
         self.dbc = dbc
 

--- a/mapadroid/mad_apk/apk_storage_fs.py
+++ b/mapadroid/mad_apk/apk_storage_fs.py
@@ -73,6 +73,7 @@ class APKStorageFilesystem(AbstractAPKStorage):
 
     def __init__(self, application_args: NamedTuple):
         logger.debug('Initializing FileSystem storage')
+        super(APKStorageFilesystem, self).__init__(application_args.maddev_api_token)
         self.file_lock: RLock = RLock()
         self.config_apk_dir: str = application_args.temp_path + '/' + APKStorageFilesystem.config_apks
         self.config_filepath: str = '{}/config.json'.format(self.config_apk_dir)

--- a/mapadroid/madmin/api/apks/ftr_mad_apks.py
+++ b/mapadroid/madmin/api/apks/ftr_mad_apks.py
@@ -87,7 +87,7 @@ class APIMadAPK(APKHandler):
         else:
             try:
                 call = self.api_req.data['call']
-                wizard = APKWizard(self.dbc, self.storage_obj)
+                wizard = APKWizard(self.dbc, self.storage_obj, self._args.maddev_api_token)
                 if call == 'import':
                     thread_args = (apk_type, apk_arch)
                     upload_thread = Thread(name='PackageWizard', target=wizard.apk_download, args=thread_args)

--- a/mapadroid/madmin/routes/apks.py
+++ b/mapadroid/madmin/routes/apks.py
@@ -71,4 +71,8 @@ class APKManager(object):
 
     @auth_required
     def mad_apks(self):
-        return render_template('madmin_apk_root.html', apks=get_apk_status(self.storage_obj))
+        return render_template(
+            'madmin_apk_root.html',
+            apks=get_apk_status(self.storage_obj),
+            has_token=self._args.maddev_api_token not in [None, ""]
+        )

--- a/mapadroid/mitm_receiver/MITMReceiver.py
+++ b/mapadroid/mitm_receiver/MITMReceiver.py
@@ -369,7 +369,11 @@ class MITMReceiver(Process):
         apk_type, apk_arch = parsed
         (msg, status_code) = lookup_package_info(self.__storage_obj, apk_type, apk_arch)
         if msg:
-            if apk_type == APKType.pogo and not supported_pogo_version(apk_arch, msg.version):
+            if apk_type == APKType.pogo and not supported_pogo_version(
+                apk_arch,
+                msg.version,
+                self.__storage_obj.token()
+            ):
                 return Response(status=406, response='Supported version not installed')
             return Response(status=status_code, response=msg.version)
         else:

--- a/mapadroid/utils/functions.py
+++ b/mapadroid/utils/functions.py
@@ -3,12 +3,10 @@ import json
 import os
 import time
 
-import requests
 from cachetools.func import ttl_cache
 from PIL import Image
 
 import mapadroid
-from mapadroid.utils.global_variables import VERSIONCODES_URL
 from mapadroid.utils.logging import LoggerEnums, get_logger
 
 logger = get_logger(LoggerEnums.system)
@@ -65,22 +63,10 @@ def generate_phones(phonename, add_text, adb_option, screen, filename, datetimef
 
 
 @ttl_cache
-def get_version_codes(force_gh=False):
-    if not force_gh:
-        try:
-            with open('configs/version_codes.json') as fh:
-                return json.load(fh)
-        except (IOError, json.decoder.JSONDecodeError):
-            pass
+def get_version_codes():
     try:
-        raw_resp = requests.get(VERSIONCODES_URL)
-        raw_resp.raise_for_status()
-    except Exception:
-        logger.error("Unable to query GitHub")
+        with open('configs/version_codes.json') as fh:
+            return json.load(fh)
+    except (IOError, json.decoder.JSONDecodeError):
+        logger.exception("Unable to parse the JSON when getting version codes")
         return {}
-    else:
-        try:
-            return raw_resp.json()
-        except json.decoder.JSONDecodeError:
-            logger.exception("Unable to parse the JSON when getting version codes")
-            return {}

--- a/mapadroid/utils/global_variables.py
+++ b/mapadroid/utils/global_variables.py
@@ -5,5 +5,6 @@ CHUNK_MAX_SIZE = 1024 * 1024 * 8  # 8MiB
 MAD_APK_ALLOWED_EXTENSIONS = set(['apk', 'zip'])
 URL_RGC_APK = 'https://raw.githubusercontent.com/Map-A-Droid/MAD/master/APK/RemoteGpsController.apk'
 URL_PD_APK = 'https://www.maddev.eu/apk/PogoDroid.apk'
+BACKEND_SUPPORTED_VERSIONS = "https://auth.maddev.eu/thirdparty/supported_versions"
 
 VERSIONCODES_URL = 'https://raw.githubusercontent.com/Map-A-Droid/MAD/master/configs/version_codes.json'

--- a/mapadroid/utils/updater.py
+++ b/mapadroid/utils/updater.py
@@ -513,7 +513,7 @@ class DeviceUpdater(object):
                     return False
                 # Validate it is supported
                 if package == APKType.pogo:
-                    if not supported_pogo_version(architecture, mad_apk.version):
+                    if not supported_pogo_version(architecture, mad_apk.version, self._storage_obj.token()):
                         self.write_status_log(str(item), field='status', value='not supported')
                         return True
                 if not is_newer_version(mad_apk.version, package_ver):

--- a/mapadroid/utils/walkerArgs.py
+++ b/mapadroid/utils/walkerArgs.py
@@ -278,6 +278,8 @@ def parse_args():
     parser.add_argument('-gp', '--gmail_passwd', default='',
                         help='Google Mail Password for interacting with the Google Play Store.  Must be an app'
                         ' password or 2fa will be triggered (this should be enabled on your account anyways')
+    parser.add_argument('-mat', '--maddev_api_token', default=None,
+                        help='MADdev API token used for querying supported versions')
 
     # Auto-Configuration
     parser.add_argument('-acna', '--autoconfig_no_auth', action='store_true', default=False,

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 pytest
 pytest-dotenv
+pytest-mock
 flake8
 flake8-variables-names
 flake8-logging-format

--- a/static/madmin/templates/madmin_apk_root.html
+++ b/static/madmin/templates/madmin_apk_root.html
@@ -242,6 +242,11 @@
         <div class="alert alert-primary">
             This section allows you to easily manage the required APKs for running MAD.
         </div>
+        {% if not has_token %}
+        <div class="alert alert-warning">
+            The MADdev API token is not configured in config.ini. Please configure this to use the wizard.
+        </div>
+        {% endif %}
     </div>
 </div>
 {% with messages = get_flashed_messages() %}

--- a/tests/fixtures/fixture_wizard.py
+++ b/tests/fixtures/fixture_wizard.py
@@ -8,10 +8,16 @@ from mapadroid.utils.functions import get_version_codes
 @pytest.fixture(scope='function')
 def wiz_instance(db_wrapper):
     storage = mock.Mock()
-    return APKWizard(db_wrapper, storage)
+    return APKWizard(db_wrapper, storage, "CoolToken")
 
 
 @pytest.fixture(autouse=True)
 def clear_cache():
     yield
     get_version_codes.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def mock_version_codes():
+    with mock.patch("mapadroid.utils.functions.open", new_callable=mock.mock_open, read_data="{}"):
+        yield


### PR DESCRIPTION
The supported versions is now dependant on MADdevs third-party
entrypoint. This enables the wizard to download the latest
supported version without relying on version_codes.json

 * Add a new configuration option, maddev_api_token
 * Update the wizard to query the MADdev endpoint with the token