### PR TITLE
Increase Round Duration from 0.5s to 1s

### DIFF
--- a/mapadroid/worker/MITMBase.py
+++ b/mapadroid/worker/MITMBase.py
@@ -20,7 +20,7 @@ from mapadroid.worker.WorkerBase import FortSearchResultTypes, WorkerBase
 WALK_AFTER_TELEPORT_SPEED = 11
 FALLBACK_MITM_WAIT_TIMEOUT = 45
 TIMESTAMP_NEVER = 0
-WAIT_FOR_DATA_NEXT_ROUND_SLEEP = 0.5
+WAIT_FOR_DATA_NEXT_ROUND_SLEEP = 1
 # Distance in meters that are to be allowed to consider a GMO as within a valid range
 # Some modes calculate with extremely strict distances (0.0001m for example), thus not allowing
 # direct use of routemanager radius as a distance (which would allow long distances for raid scans as well)


### PR DESCRIPTION
Tested change described in issue 1102 by increasing WAIT_FOR_DATA_NEXT_ROUND_SLEEP from 0.5s to 1s. This has reduced my CPU usage by about 20%.

This worked for Dkmur's large setup and my setup of 35 devices.

I have not identified any negative impact.

Co-Authored-By: dkmur <42545952+dkmur@users.noreply.github.com>