### PR TITLE
Fix missing settings in idle area

### DIFF
--- a/mapadroid/data_manager/modules/area_idle.py
+++ b/mapadroid/data_manager/modules/area_idle.py
@@ -37,5 +37,6 @@ class AreaIdle(Area):
                     "uri_source": "api_routecalc"
                 }
             },
-        }
+        },
+        "settings": {}
     }


### PR DESCRIPTION
area.settigs is frequently used in the templates so every area should have one.