### PR TITLE
Correctly blank results

### DIFF
--- a/mapadroid/utils/questGen.py
+++ b/mapadroid/utils/questGen.py
@@ -51,9 +51,9 @@ class QuestGen:
                 return
 
             if apk_locale is None:
-                self.apk_locale = {}
+                apk_locale = {}
             if remote_locale is None:
-                self.remote_locale = {}
+                remote_locale = {}
             self.locale_resources = {**apk_locale, **remote_locale}
         else: self.locale_resources = None
 


### PR DESCRIPTION
Remote fetches for quest locale might fail, this fixes the fallback to no translations.