### PR TITLE
Add missing pokealarm fields in quest webhook when using poracle flavor

### DIFF
--- a/mapadroid/webhook/webhookworker.py
+++ b/mapadroid/webhook/webhookworker.py
@@ -150,7 +150,7 @@ class WebhookWorker:
         return ret
 
     def __construct_quest_payload(self, quest):
-        if self.__args.quest_webhook_flavor == "default":
+        if self.__args.quest_webhook_flavor == "default":  # used by PokeAlarm
             return {
                 "pokestop_id": quest["pokestop_id"],
                 "latitude": quest["latitude"],
@@ -306,6 +306,24 @@ class WebhookWorker:
             "target": quest["quest_target"],
             "updated": quest["timestamp"],
             "quest_task": quest["quest_task"],
+            "quest_type": quest["quest_type"],
+            "quest_type_raw": quest["quest_type_raw"],
+            "item_type": quest["item_type"],
+            "name": quest["name"].replace('"', '\\"').replace("\n", "\\n"),
+            "url": quest["url"],
+            "timestamp": quest["timestamp"],
+            "quest_reward_type": quest["quest_reward_type"],
+            "quest_reward_type_raw": quest["quest_reward_type_raw"],
+            "quest_reward_raw": quest['quest_reward_raw'].replace("'", '"').lower(),
+            "quest_target": quest["quest_target"],
+            "pokemon_id": int(quest["pokemon_id"]),
+            "pokemon_form": int(quest.get("pokemon_form", '0')),
+            "pokemon_costume": int(quest.get("pokemon_costume", '0')),
+            "item_amount": quest["item_amount"],
+            "item_id": quest["item_id"],
+            "quest_condition": quest["quest_condition"].replace("'", '"').lower(),
+            "quest_template": quest["quest_template"],
+            "is_ar_scan_eligible": quest["is_ar_scan_eligible"],
         }
 
     def __prepare_weather_data(self, weather_data):
@@ -491,10 +509,7 @@ class WebhookWorker:
 
             if mon["weather_boosted_condition"] is not None \
                and mon["weather_boosted_condition"] > 0:
-                if self.__args.quest_webhook_flavor == "default":
-                    mon_payload["boosted_weather"] = mon["weather_boosted_condition"]
-                if self.__args.quest_webhook_flavor == "poracle":
-                    mon_payload["weather"] = mon["weather_boosted_condition"]
+                mon_payload["weather"] = mon["weather_boosted_condition"]
 
             if mon["seen_type"] in ("nearby_stop", "lure_wild", "lure_encounter"):
                 mon_payload["pokestop_id"] = mon["fort_id"]


### PR DESCRIPTION
There is currently a conflict with the webhook worker when switching from `default` to `poracle` `quest_webhook_flavor` setting.

The `poracle` quest flavor removes a lot of default fields instead of adding the ones which need to be added. This causes the webhook sent to PokeAlarm to be invalid as some mandatory fields are missing.

- Default quest webhook sent: https://github.com/Map-A-Droid/MAD/blob/543c3d7f002cdb64f2b6209d450ec18adc905a85/mapadroid/webhook/webhookworker.py#L154
- Poracle quest webhook sent: https://github.com/Map-A-Droid/MAD/blob/543c3d7f002cdb64f2b6209d450ec18adc905a85/mapadroid/webhook/webhookworker.py#L296

All the quest fields added for `poracle` flavor are compatible for both PokeAlarm and PoracleJS as they don't use the same name and so, they don't overwrite any field. For each webhook tools, the fields which are for the other tool will be ignored, that's not a problem.

I also renamed the `boosted_weather` field in mon data (only sent to PokeAlarm) because the real information in this field is the `weather` ID (like named for PoracleJS). This removes the difference between the flavors and add logic by renaming the PokeAlarm field. PokeAlarm still supports a `weather` field name. It will not break anything for its side.