### PR TITLE
Fix pokemon missing from webhook if no type specified

### DIFF
--- a/mapadroid/webhook/webhookworker.py
+++ b/mapadroid/webhook/webhookworker.py
@@ -619,7 +619,7 @@ class WebhookWorker:
                             self.__pokemon_types.add(vmtype)
             else:
                 for valid_mon_type in self.__valid_mon_types:
-                    self.__webhook_types.add(valid_mon_type.name)
+                    self.__pokemon_types.add(valid_mon_type)
                 for valid_type in self.__valid_types:
                     self.__webhook_types.add(valid_type)
 


### PR DESCRIPTION
Was not sending pokemons if you had something like `webhook_url: http://127.0.0.1/` - no `[type, type, type]` specified.