### PR TITLE
Fix deleting Job logs

### DIFF
--- a/mapadroid/madmin/endpoints/routes/control/DeleteLogEndpoint.py
+++ b/mapadroid/madmin/endpoints/routes/control/DeleteLogEndpoint.py
@@ -13,5 +13,5 @@ class DeleteLogEndpoint(AbstractControlEndpoint):
     async def get(self):
         only_success: Optional[str] = self.request.query.get('only_success')
 
-        await self._get_device_updater().delete_log(onlysuccess=only_success and only_success.lower() == "true")
+        await self._get_device_updater().delete_log(only_success=only_success and only_success.lower() == "true")
         await self._redirect(self._url_for('install_status'))


### PR DESCRIPTION
wrong keyword used
Personally I would love one more brackets there so my brain could process it :D 
` await self._get_device_updater().delete_log(only_success=(only_success and only_success.lower() == "true"))`