### PR TITLE
Handle query string in XPathForwardedFor

### DIFF
--- a/mapadroid/utils/aiohttp/XPathForwardedFor.py
+++ b/mapadroid/utils/aiohttp/XPathForwardedFor.py
@@ -39,7 +39,7 @@ class XPathForwarded(XForwardedBase):
             prefix = get_forwarded_path(headers)
             if prefix is not None:
                 prefix = '/' + prefix.strip('/') + '/'
-                request_path = URL(request.path.lstrip('/'))
+                request_path = URL(request.path_qs.lstrip('/'))
                 overrides['rel_url'] = URL(prefix).join(request_path)
 
             request = request.clone(**overrides)


### PR DESCRIPTION
Editing and creating of settings doesn't work when enable_x_forwarded_path_madmin is set if query string is not handled