### PR TITLE
Allow devices to download packages

### DIFF
--- a/mapadroid/mad_apk/utils.py
+++ b/mapadroid/mad_apk/utils.py
@@ -247,7 +247,7 @@ async def stream_package(session: AsyncSession, storage_obj,
         filename = package.filename
         version = package.version
 
-    gen_func: AsyncGenerator = await storage_obj.get_async_generator(session, package_info, apk_type, architecture)
+    gen_func: AsyncGenerator = storage_obj.get_async_generator(session, package_info, apk_type, architecture)
     return gen_func, mimetype, filename, version
 
 


### PR DESCRIPTION
Devices couldn't download latest package.  The console gave the following error: "TypeError: object async_generator can't be used in 'await' expression"
Removing the "await" allows devices to download packages.