### PR TITLE
Stop synchronizing ids_encountered

### DIFF
--- a/mapadroid/mitm_receiver/MITMReceiver.py
+++ b/mapadroid/mitm_receiver/MITMReceiver.py
@@ -302,10 +302,11 @@ class MITMReceiver(Process):
         safe_items = self.__mitm_mapper.get_safe_items(origin)
         level_mode = self.__mitm_mapper.get_levelmode(origin)
 
-        ids_encountered = self.__mitm_mapper.request_latest(
-            origin, "ids_encountered")
-        if ids_encountered is not None:
-            ids_encountered = ids_encountered.get("values", None)
+        ids_encountered = None
+        #ids_encountered = self.__mitm_mapper.request_latest(
+        #    origin, "ids_encountered")
+        #if ids_encountered is not None:
+        #    ids_encountered = ids_encountered.get("values", None)
 
         unquest_stops = self.__mitm_mapper.request_latest(
             origin, "unquest_stops")

--- a/mapadroid/mitm_receiver/MITMReceiver.py
+++ b/mapadroid/mitm_receiver/MITMReceiver.py
@@ -303,9 +303,9 @@ class MITMReceiver(Process):
         level_mode = self.__mitm_mapper.get_levelmode(origin)
 
         ids_encountered = None
-        #ids_encountered = self.__mitm_mapper.request_latest(
+        # ids_encountered = self.__mitm_mapper.request_latest(
         #    origin, "ids_encountered")
-        #if ids_encountered is not None:
+        # if ids_encountered is not None:
         #    ids_encountered = ids_encountered.get("values", None)
 
         unquest_stops = self.__mitm_mapper.request_latest(


### PR DESCRIPTION
This will make other devices in the same area re-scan mons (for example Spotlight hours) everytime it sees a mon.
For same devices (like one device in area) - there is internal 'mon already scanned' list in PD (per device), getting cleaned at :30 and :00 hours. [so event mons still will be rescanned]

This will put more stress on mysql/redis. Use redis. 
This will lower your MAD<->device traffic (the bigger the area and more mons, the bigger the traffic)

This is not a proper way of doing this (as WorkerMITM will still query db), but this is master.