### PR TITLE
Store experience in stardust column

### DIFF
--- a/mapadroid/db/DbPogoProtoSubmit.py
+++ b/mapadroid/db/DbPogoProtoSubmit.py
@@ -680,6 +680,7 @@ class DbPogoProtoSubmit:
         item_item = item.get("item", None)
         item_amount = item.get("amount", None)
         pokemon_id = encounter.get("pokemon_id", None)
+        stardust = reward.get("stardust", None)
 
         if reward_type == 4:
             item_amount = reward.get('candy', {}).get('amount', 0)
@@ -688,9 +689,8 @@ class DbPogoProtoSubmit:
             item_amount = reward.get('mega_resource', {}).get('amount', 0)
             pokemon_id = reward.get('mega_resource', {}).get('pokemon_id', 0)
         elif reward_type == 1:
-            item_amount = reward.get('exp', 0)
+            stardust = reward.get('exp', 0)
 
-        stardust = reward.get("stardust", None)
         form_id = encounter.get("pokemon_display", {}).get("form_value", 0)
         costume_id = encounter.get("pokemon_display", {}).get("costume_value", 0)
         target = goal.get("target", None)

--- a/mapadroid/utils/questGen.py
+++ b/mapadroid/utils/questGen.py
@@ -122,7 +122,7 @@ class QuestGen:
             pokemon_name = await i8ln(await self.pokemonname(str(pokemon_id)))
         elif quest_reward_type == _('Experience'):
             item_type = quest_reward_type
-            item_amount = quest.quest_item_amount
+            item_amount = quest.quest_stardust
 
         if not quest.quest_task:
             quest_task = await self.questtask(


### PR DESCRIPTION
Since the quest_item_amount column is a tinyint, it can only store values up to 127, which can't hold the current 700 XP reward (saved rewards were getting truncated to 127).

This PR saves the experience amount in the stardust column, which is a smallint, which can store values up to 32767.