### PR TITLE
Fix Quest Statistics showing all stops count

### DIFF
--- a/mapadroid/db/helper/PokestopHelper.py
+++ b/mapadroid/db/helper/PokestopHelper.py
@@ -49,6 +49,7 @@ class PokestopHelper:
             where_and_clauses.append(func.ST_Contains(func.ST_GeomFromText(polygon),
                                                       func.POINT(Pokestop.latitude, Pokestop.longitude)))
 
+        stmt = stmt.where(and_(*where_and_clauses))
         result = await session.execute(stmt)
         list_of_coords: List[Location] = []
         for pokestop in result.scalars().all():


### PR DESCRIPTION
However no idea why we using POLYGON here not just re-using GeofenceHelper from `fence[1]` and using min/max_lat/lon? Only place calling this with `fence` seems to be stats `statistics/GetStopQuestStatsEndpoint.py`, that already have geofence_helper and we can just do there `stops_in_fence: List[Location] = await PokestopHelper.get_locations_in_fence(self._session, geofence_helper=fence[1]` and that whole POLYGON part is not needed at all? However probably nice to have it in long run?