### PR TITLE
Store MITMReceiver queue value in redis for monitoring tools

### DIFF
--- a/configs/config.ini.example
+++ b/configs/config.ini.example
@@ -348,3 +348,13 @@
 ######################
 # MAD PoGo auth is not required during autoconfiguration
 #autoconfig_no_auth:
+
+# Report MITMReceiver queue value to Redis
+# This is only useful for split/multi start_mitmreceiver.py approach and if you have anything that going to monitor your queue value.
+# Remember to set a unique key for each start_mitmreceiver you are running. You most likely want to override it in command line rather via config.ini
+# https://github.com/Map-A-Droid/MAD/pull/1283
+######################
+# Redis key used to store MITMReceiver queue value
+#redis_report_queue_key: MITMReceiver_queue_len_mitm1
+# Interval of reporting value - every 30 seconds by default
+#redis_report_queue_interval: 30

--- a/configs/config.ini.example
+++ b/configs/config.ini.example
@@ -349,6 +349,7 @@
 # MAD PoGo auth is not required during autoconfiguration
 #autoconfig_no_auth:
 
+
 # Report MITMReceiver queue value to Redis
 # This is only useful for split/multi start_mitmreceiver.py approach and if you have anything that going to monitor your queue value.
 # Remember to set a unique key for each start_mitmreceiver you are running. You most likely want to override it in command line rather via config.ini

--- a/mapadroid/utils/redisReport.py
+++ b/mapadroid/utils/redisReport.py
@@ -1,0 +1,15 @@
+import asyncio
+
+from mapadroid.utils.logging import get_logger, LoggerEnums
+from mapadroid.utils.madGlobals import application_args, terminate_mad
+
+logger = get_logger(LoggerEnums.system)
+
+async def report_queue_size(__db_wrapper, __queueObject):
+    __cache_key = application_args.redis_report_queue_key
+    __sleep_time = application_args.redis_report_queue_interval
+    while not terminate_mad.is_set():
+        __cache: Redis = await __db_wrapper.get_cache()
+        __value = __queueObject.qsize()
+        await __cache.set(__cache_key, __value, ex=__sleep_time*2)
+        await asyncio.sleep(__sleep_time)

--- a/mapadroid/utils/walkerArgs.py
+++ b/mapadroid/utils/walkerArgs.py
@@ -204,6 +204,10 @@ def parse_args():
     parser.add_argument('-wfdsd', '--wait_for_data_sleep_duration', default='1.0', type=float,
                         help=('Time in seconds (floating point) to sleep inbetween checks of data in workers. '
                               'Default: 1.0'))
+    parser.add_argument('-rrqk', '--redis_report_queue_key', default=None,
+                        help='Redis key used to store MITMReceiver queue value')
+    parser.add_argument('-rrqi', '--redis_report_queue_interval', default=30, type=int,
+                        help='Report queue size from MITMReceiver to redis every N seconds (Default: 30)')
 
     # MADmin
     parser.add_argument('-dm', '--disable_madmin', action='store_true', default=False,

--- a/start_mitmreceiver.py
+++ b/start_mitmreceiver.py
@@ -27,6 +27,7 @@ from mapadroid.mitm_receiver.MITMReceiver import MITMReceiver
 from mapadroid.utils.EnvironmentUtil import setup_loggers, setup_runtime
 from mapadroid.utils.logging import LoggerEnums, get_logger, init_logging
 from mapadroid.utils.madGlobals import application_args, terminate_mad
+from mapadroid.utils.redisReport import report_queue_size
 from mapadroid.utils.questGen import QuestGen
 from mapadroid.utils.SystemStatsUtil import get_system_infos
 
@@ -48,6 +49,7 @@ if py_version.major < 3 or (py_version.major == 3 and py_version.minor < 9):
 
 async def start():
     t_usage: Optional[Task] = None
+    t_reporting: Optional[Task] = None
     mitm_mapper_connector: Optional[MitmMapperClientConnector] = None
     setup_runtime()
     if application_args.config_mode and application_args.only_routes:
@@ -99,6 +101,12 @@ async def start():
         logger.info("Starting statistics collector")
         loop = asyncio.get_running_loop()
         t_usage = loop.create_task(get_system_infos(db_wrapper))
+
+    if application_args.redis_report_queue_key:
+        logger.info("Starting report queue size to Redis via key: {}", application_args.redis_report_queue_key)
+        loop = asyncio.get_running_loop()
+        t_reporting = loop.create_task(report_queue_size(db_wrapper, mitm_data_processor_manager.get_queue()))
+
     logger.info("MAD is now running.....")
     exit_code = 0
     try:
@@ -114,6 +122,8 @@ async def start():
             logger.success("Stop called")
             terminate_mad.set()
             # now cleanup all threads...
+            if t_reporting:
+                t_reporting.cancel()
             if t_usage:
                 t_usage.cancel()
             if mitm_mapper_connector:


### PR DESCRIPTION
This seems like the best way to approach with split/multi start_mitmreceiver.py - redis is shared and actively used across all mitmreceivers - no need to query each mitmreceiver or anything like that - they all will report to redis and you just check those redis keys in your monitoring tool :)

Just provide name of key (different for each start_mitmreceiver.py of course!) and it will start putting current MITMReceiver queue size to redis every 30 seconds. Each redis entry is stored with double TTL of reporting rate so you can even use this to detect if MITMReceivers are down :)

Setting `redis_report_queue_key` in config.ini or `--redis_report_queue_key` in command line enable this
```
python3 start_mitmreceiver.py --redis_report_queue_key=MITMReceiver_queue_len_mitm1
python3 start_mitmreceiver.py --redis_report_queue_key=MITMReceiver_queue_len_mitm2
etc
```
You can override default 30 seconds window via `--redis_report_queue_interval`

async version of monitoring dreaded `MITM data processing workers are falling behind! Queue length: XXX`