### PR TITLE
Simplify setting for ✅ in simpler wording

### DIFF
--- a/static/madmin/templates/status.html
+++ b/static/madmin/templates/status.html
@@ -297,8 +297,7 @@
 <br>
 <div class="row">
     <div class="col">
-        Set maximum time in seconds to display "Last update" as <i class="fas fa-check"
-                                                                   style="color: green !important;"></i> for an easier overview <input type="number" id="maxSeconds"/>
+        <i class="fas fa-check" style="color: green !important;"></i>-threshold (seconds) <input type="number" id="maxSeconds"/> <i class="fas fa-question-circle" data-toggle="tooltip" title="" data-original-title="Devices that have received data within this many seconds will display a green tick."></i>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Hide the detailed explanation behind a ?-tooltip on the status-page