### PR TITLE
Fix madmin complains after clicking start/stop worker

### DIFF
--- a/mapadroid/madmin/endpoints/api/resources/DeviceEndpoint.py
+++ b/mapadroid/madmin/endpoints/api/resources/DeviceEndpoint.py
@@ -106,7 +106,7 @@ class DeviceEndpoint(AbstractResourceEndpoint):
                     # TODO:..
                     # self._get_mapping_manager().device_set_disabled(device.name)
                     await self._get_ws_server().force_cancel_worker(device.name)
-                    return await self._json_response(status=200)
+                    return await self._json_response(text='{}', status=200)
                 elif call == 'flush_level':
                     await TrsVisitedHelper.flush_all_of_origin(self._session, device.name)
                     self._commit_trigger = True

--- a/mapadroid/madmin/endpoints/api/resources/DeviceEndpoint.py
+++ b/mapadroid/madmin/endpoints/api/resources/DeviceEndpoint.py
@@ -106,7 +106,7 @@ class DeviceEndpoint(AbstractResourceEndpoint):
                     # TODO:..
                     # self._get_mapping_manager().device_set_disabled(device.name)
                     await self._get_ws_server().force_cancel_worker(device.name)
-                    return await self._json_response(text='{}', status=200)
+                    return await self._json_response(dict(), status=200)
                 elif call == 'flush_level':
                     await TrsVisitedHelper.flush_all_of_origin(self._session, device.name)
                     self._commit_trigger = True


### PR DESCRIPTION
If we want to use success callback with $ajax calls response must contain json (parseerror) or at least null (like master :D) Just forcing empty json in text