### PR TITLE
Store MITMReceiver queue value in redis for monitoring tools

### DIFF
--- a/configs/config.ini.example
+++ b/configs/config.ini.example
@@ -348,3 +348,12 @@
 ######################
 # MAD PoGo auth is not required during autoconfiguration
 #autoconfig_no_auth:
+
+# Report MITMReceiver queue value to Redis
+# This is only useful for split/multi start_mitmreceiver.py approach and if you have anything that going to monitor your queue value.
+# Remember to set a unique key for each start_mitmreceiver you are running. You most likely want to override it in command line rather via config.ini
+######################
+# Redis key used to store MITMReceiver queue value
+#redis_report_queue_key: MITMReceiver_queue_len_mitm1
+# Interval of reporting value - every 30 seconds by default
+#redis_report_queue_interval: 30

--- a/mapadroid/utils/redisReport.py
+++ b/mapadroid/utils/redisReport.py
@@ -8,13 +8,9 @@ logger = get_logger(LoggerEnums.system)
 async def report_queue_size(__db_wrapper, __queueObject):
     __cache_key = application_args.redis_report_queue_key
     __sleep_time = application_args.redis_report_queue_interval
-    logger.info("Reporting queue size to redis via key {} starting", __cache_key)
     while not terminate_mad.is_set():
-        logger.info('Reporting queue size to redis while not starting')
         __cache: Redis = await __db_wrapper.get_cache()
         __value = __queueObject.qsize()
-        logger.info('Reporting queue size to redis while not value: {}', __value)
         await __cache.set(__cache_key, __value, ex=__sleep_time*2)
-        logger.info('Reporting queue size to redis sleeping for: {}', __sleep_time)
         await asyncio.sleep(__sleep_time)
 

--- a/mapadroid/utils/redisReport.py
+++ b/mapadroid/utils/redisReport.py
@@ -1,0 +1,20 @@
+import asyncio
+
+from mapadroid.utils.logging import get_logger, LoggerEnums
+from mapadroid.utils.madGlobals import application_args, terminate_mad
+
+logger = get_logger(LoggerEnums.system)
+
+async def report_queue_size(__db_wrapper, __queueObject):
+    __cache_key = application_args.redis_report_queue_key
+    __sleep_time = application_args.redis_report_queue_interval
+    logger.info("Reporting queue size to redis via key {} starting", __cache_key)
+    while not terminate_mad.is_set():
+        logger.info('Reporting queue size to redis while not starting')
+        __cache: Redis = await __db_wrapper.get_cache()
+        __value = __queueObject.qsize()
+        logger.info('Reporting queue size to redis while not value: {}', __value)
+        await __cache.set(__cache_key, __value, ex=__sleep_time*2)
+        logger.info('Reporting queue size to redis sleeping for: {}', __sleep_time)
+        await asyncio.sleep(__sleep_time)
+

--- a/mapadroid/utils/walkerArgs.py
+++ b/mapadroid/utils/walkerArgs.py
@@ -355,6 +355,12 @@ def parse_args():
     parser.add_argument('-cdb', '--cache_database', default=0,
                         help=('Redis database. Use different numbers (0-15) if you are running multiple instances'))
 
+    parser.add_argument('-rrqk', '--redis_report_queue_key', default=None,
+                        help='Redis key used to store reported value')
+    parser.add_argument('-rrqi', '--redis_report_queue_interval', default=30, type=int,
+                        help='Report queue size from mitmreciver to redis every every N seconds (Default: 30)')
+
+
     if "MODE" in os.environ and os.environ["MODE"] == "DEV":
         args = parser.parse_known_args()[0]
     else:


### PR DESCRIPTION
This seems like the best way to approach with split/multi start_mitmreceiver.py - redis is shared and actively used across all mitmreceivers - no need to query each mitmreceiver or anything like that - they all will report to redis and you just check those redis keys in your monitoring tool :)

Just provide name of key (different for each start_mitmreceiver.py of course!) and it will start putting current MITMReceiver queue size to redis every 30 seconds. Each redis entry is stored with double TTL of reporting rate so you can even use this to detect if MITMReceivers are down :)

Setting `redis_report_queue_key` in config.ini or `--redis_report_queue_key` in command line enable this
```
python3 start_mitmreceiver.py --redis_report_queue_key=MITMReceiver_queue_len_mitm1
python3 start_mitmreceiver.py --redis_report_queue_key=MITMReceiver_queue_len_mitm2
etc
```
You can override default 30 seconds window via `--redis_report_queue_interval`

async version of monitoring dreaded `MITM data processing workers are falling behind! Queue length: XXX`