### PR TITLE
add scale indicator

### DIFF
--- a/static/madmin/static/js/madmin.js
+++ b/static/madmin/static/js/madmin.js
@@ -2212,6 +2212,11 @@ if (route.mode === "mon_mitm" && typeof route.editableId === "number") {
                 ++zIndex;
             }
 
+	    // add scale indicator
+            L.control.scale({
+                position: "bottomright"
+            }).addTo(map);
+		
             // add custom button
             locInjectBtn.addTo(map);
 


### PR DESCRIPTION
As requested by Axi from the discord, this PR adds an scale indicator to the madmin map which makes it easier to get the scale of a geofence for example.

Example:
![image](https://user-images.githubusercontent.com/34460584/212888310-22eec769-1854-4930-8030-988ffe56904e.png)
