### PR TITLE
Fix webhook wrong field for backward compatibility incidents

### DIFF
--- a/mapadroid/db/DbWebhookReader.py
+++ b/mapadroid/db/DbWebhookReader.py
@@ -139,7 +139,7 @@ class DbWebhookReader:
                     if first_incident.incident_start is not None else None
                 stop_entry["incident_expiration"] = int(first_incident.incident_expiration.timestamp()) \
                     if first_incident.incident_expiration is not None else None
-                stop_entry["incident_grunt_type"] = first_incident.incident_display_type
+                stop_entry["incident_grunt_type"] = first_incident.character_display
             stop_entry["incidents"] = incidents
 
             ret.append(stop_entry)


### PR DESCRIPTION
It should be character_display not incident_display_type