### PR TITLE
Don't need dataclasses package anymore.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ asyncio-rlock==0.1.0
 bitstring==3.1.9
 cachetools==5.2.0
 ConfigArgParse==1.5.3
-dataclasses==0.6
 geopy==2.3.0
 gevent==21.12.0
 gpxdata==1.2.1


### PR DESCRIPTION
From what I recall, this package was only needed prior to Python 3.7.
Ran my install without the package installed with no obvious related issues.