### PR TITLE
(async) add unix socket connection to database and redis cache

### DIFF
--- a/configs/config.ini.example
+++ b/configs/config.ini.example
@@ -13,7 +13,7 @@
 
 # IP or hostname of MySql Server
 #dbip:
-# unix socket of MySQL server - replaces dbip
+# unix socket of MySQL server - replaces dbip. Example (MariaDB default): /run/mysqld/mysqld.sock
 #dbsocket:
 # Port of the database (Default: 3306)
 #dbport:
@@ -34,7 +34,7 @@
 ######################
 # Redis cache host (Default: localhost)
 #cache_host:
-# Redis cache unix socket - replaces cache_host
+# Redis cache unix socket - replaces cache_host. Example (disabled in redis by default!): /var/run/redis/redis-server.sock
 #cache_socket:
 # Redis cache port (Default: 6379)
 #cache_port:

--- a/configs/config.ini.example
+++ b/configs/config.ini.example
@@ -13,6 +13,8 @@
 
 # IP or hostname of MySql Server
 #dbip:
+# unix socket of MySQL server - replaces dbip
+#dbsocket:
 # Port of the database (Default: 3306)
 #dbport:
 # Username for MySQL login
@@ -32,10 +34,14 @@
 ######################
 # Redis cache host (Default: localhost)
 #cache_host:
+# Redis cache unix socket - replaces cache_host
+#cache_socket:
 # Redis cache port (Default: 6379)
 #cache_port:
 # Redis database. Use different numbers (0-15) if you are running multiple instances.
 #cache_database:
+# Redis username
+#cache_username:
 # Redis password
 #cache_password:
 

--- a/mapadroid/utils/walkerArgs.py
+++ b/mapadroid/utils/walkerArgs.py
@@ -42,6 +42,8 @@ def parse_args():
     # MySQL
     parser.add_argument('-dbip', '--dbip', required=False,
                         help='IP or hostname of MySql Server')
+    parser.add_argument('-dbsock', '--dbsocket', required=False,
+                        help='Unix socket of MySQL Server - replaces dbip')
     parser.add_argument('-dbport', '--dbport', type=int, default=3306,
                         help='Port for MySQL Server')
     parser.add_argument('-dbuser', '--dbusername', required=False,
@@ -352,8 +354,12 @@ def parse_args():
     # Redis cache
     parser.add_argument('-ch', '--cache_host', default='127.0.0.1',
                         help=('Redis host used by caching'))
+    parser.add_argument('-csock', '--cache_socket', required=False,
+                        help=('Unix Socket to connect to redis - replaces cache_host'))
     parser.add_argument('-cp', '--cache_port', default=6379,
                         help=('Redis port used by caching'))
+    parser.add_argument('-cu', '--cache_username', default=None,
+                        help=('Redis username'))
     parser.add_argument('-cpwd', '--cache_password', default=None,
                         help=('Redis password'))
     parser.add_argument('-cdb', '--cache_database', default=0,


### PR DESCRIPTION
Title mostly says it. Someone said unix sockets are less overhead than TCP/IP when on the same machine, so I tried and implemented it as optional settings for the database and redis cache connections.

Works for me.