### PR TITLE
iv_mitm: seen_type is stored as name, not value

### DIFF
--- a/mapadroid/db/helper/PokemonHelper.py
+++ b/mapadroid/db/helper/PokemonHelper.py
@@ -81,7 +81,7 @@ class PokemonHelper:
                                           Pokemon.individual_defense == None,
                                           Pokemon.individual_stamina == None,
                                           Pokemon.encounter_id != 0,
-                                          Pokemon.seen_type != MonSeenTypes.nearby_cell.value,
+                                          Pokemon.seen_type != MonSeenTypes.nearby_cell.name,
                                           Pokemon.disappear_time.between(DatetimeWrapper.now()
                                                                          + datetime.timedelta(
                                               seconds=min_time_left_seconds),


### PR DESCRIPTION
as seen at `db/model.py`:
https://github.com/Map-A-Droid/MAD/blob/e32da08a2c17929f0e2df6d825dc1caeadb6d97c/mapadroid/db/model.py#L128

Before fix: `iv_mitm` worker tries to encounter Pokemon that were found as `nearby_cell`
After fix: `iv_mitm` worker no longer tries to encounter Pokemon that were found as `nearby_cell`