### PR TITLE
Fix permission toggling on clear game data/relog

### DIFF
--- a/mapadroid/worker/strategy/AbstractWorkerStrategy.py
+++ b/mapadroid/worker/strategy/AbstractWorkerStrategy.py
@@ -617,8 +617,8 @@ class AbstractWorkerStrategy(ABC):
         command: str = "su -c 'pm grant com.nianticlabs.pokemongo android.permission.ACCESS_FINE_LOCATION " \
                        "&& pm grant com.nianticlabs.pokemongo android.permission.ACCESS_COARSE_LOCATION " \
                        "&& pm grant com.nianticlabs.pokemongo android.permission.CAMERA " \
-                       "&& pm grant com.nianticlabs.pokemongo android.permission.GET_ACCOUNTS" \
-                       "&& magiskhide --add com.nianticlabs.pokemongo' 
+                       "&& pm grant com.nianticlabs.pokemongo android.permission.GET_ACCOUNTS " \
+                       "&& magiskhide --add com.nianticlabs.pokemongo'"
         await self._communicator.passthrough(command)
 
     @abstractmethod

--- a/mapadroid/worker/strategy/AbstractWorkerStrategy.py
+++ b/mapadroid/worker/strategy/AbstractWorkerStrategy.py
@@ -387,6 +387,7 @@ class AbstractWorkerStrategy(ABC):
         await self.stop_pogo()
         await asyncio.sleep(5)
         await self._clear_game_data()
+        await asyncio.sleep(5)
         await self.turn_screen_on_and_start_pogo()
         if not await self._ensure_pogo_topmost():
             logger.error('Kill Worker...')
@@ -613,11 +614,11 @@ class AbstractWorkerStrategy(ABC):
         # self._resocalc.get_x_y_ratio(self, self._screen_x, self._screen_y, x_offset, y_offset)
 
     async def _grant_permissions_to_pogo(self) -> None:
-        command: str = "su -c 'magiskhide --add com.nianticlabs.pokemongo " \
-                       "&& pm grant com.nianticlabs.pokemongo android.permission.ACCESS_FINE_LOCATION " \
+        command: str = "su -c 'pm grant com.nianticlabs.pokemongo android.permission.ACCESS_FINE_LOCATION " \
                        "&& pm grant com.nianticlabs.pokemongo android.permission.ACCESS_COARSE_LOCATION " \
-                       "&&  pm grant com.nianticlabs.pokemongo android.permission.CAMERA " \
-                       "&& pm grant com.nianticlabs.pokemongo android.permission.GET_ACCOUNTS'"
+                       "&& pm grant com.nianticlabs.pokemongo android.permission.CAMERA " \
+                       "&& pm grant com.nianticlabs.pokemongo android.permission.GET_ACCOUNTS" \
+                       "&& magiskhide --add com.nianticlabs.pokemongo' 
         await self._communicator.passthrough(command)
 
     @abstractmethod


### PR DESCRIPTION
Move magiskhide to the end of command so it won't exit with code > 0 and break whole `&&` chain - by default it responses with something along the lines "Package already hidden" and exit code 1.

Plus there is extra sleep after clearing game data on _switch_user - just to make sure slow(er) ATVs will have time to catch up with clearing app data/cache. This still will be faster than going OCR for permission screen [~60 seconds wasted]