### PR TITLE
Fix: Reset self_screen_count before rebooting the device

### DIFF
--- a/mapadroid/worker/strategy/AbstractWorkerStrategy.py
+++ b/mapadroid/worker/strategy/AbstractWorkerStrategy.py
@@ -306,6 +306,7 @@ class AbstractWorkerStrategy(ABC):
                 if self._worker_state.same_screen_count > 3:
                     logger.warning("Screen is frozen!")
                     if self._worker_state.same_screen_count > 4 or not await self._restart_pogo():
+                        self._worker_state.same_screen_count = 0
                         logger.warning("Restarting PoGo failed - reboot device")
                         await self._reboot()
                     break


### PR DESCRIPTION
Experienced some edge case where this counter would not reset after trying to reboot the device, because the worker instance was retained - so it would be possible that another reboot is triggered quicker than intended.