### PR TITLE
[WIP] Early Maintenance Detection

### DIFF
--- a/configs/config.ini.example
+++ b/configs/config.ini.example
@@ -376,6 +376,12 @@
 # MAD PoGo auth is not required during autoconfiguration
 #autoconfig_no_auth:
 
+# Early Maintenance Detection
+######################
+# Don't wait for Maintenance screen to show up (we need to relog for that) - mark account as burnt after proto timeouts + RETRY screen
+# This can be inaccurate (game down/internet down(?)) so use it only if you have a lot of spare accounts.
+# enable_early_maintenance_detection: True
+
 # Report MITMReceiver queue value to Redis
 # This is only useful for split/multi start_mitmreceiver.py approach and if you have anything that going to monitor your queue value.
 # Remember to set a unique key for each start_mitmreceiver you are running. You most likely want to override it in command line rather via config.ini

--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -269,7 +269,7 @@ class WordToScreenMatching(object):
         elif screentype == ScreenType.FAILURE:
             await self.__handle_failure_screen()
         elif screentype == ScreenType.RETRY:
-            if self._worker_state.early_maintenance_detection:
+            if application_args.enable_early_maintenance_detection and self._worker_state.early_maintenance_detection:
                 logger.warning("Seen RETRY screen after multiple proto timeouts - most likely MAINTENANCE")
                 await self._account_handler.mark_burnt(self._worker_state.device_id, BurnType.MAINTENANCE)
             await self.__handle_retry_screen(diff, global_dict)

--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -269,6 +269,8 @@ class WordToScreenMatching(object):
         elif screentype == ScreenType.FAILURE:
             await self.__handle_failure_screen()
         elif screentype == ScreenType.RETRY:
+            if self._worker_state.early_maintenance_detection:
+                await self._account_handler.mark_burnt(self._worker_state.device_id, BurnType.MAINTENANCE)
             await self.__handle_retry_screen(diff, global_dict)
         elif screentype == ScreenType.WRONG:
             await self.__handle_returning_player_or_wrong_credentials()

--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -270,6 +270,7 @@ class WordToScreenMatching(object):
             await self.__handle_failure_screen()
         elif screentype == ScreenType.RETRY:
             if self._worker_state.early_maintenance_detection:
+                logger.warning("Seen RETRY screen after multiple proto timeouts - most likely MAINTENANCE")
                 await self._account_handler.mark_burnt(self._worker_state.device_id, BurnType.MAINTENANCE)
             await self.__handle_retry_screen(diff, global_dict)
         elif screentype == ScreenType.WRONG:

--- a/mapadroid/utils/walkerArgs.py
+++ b/mapadroid/utils/walkerArgs.py
@@ -398,6 +398,8 @@ def parse_args():
     parser.add_argument('-cdb', '--cache_database', default=0,
                         help='Redis database. Use different numbers (0-15) if you are running multiple instances')
 
+    parser.add_argument('-eemd', '--enable_early_maintenance_detection', action='store_true', default=False,
+                        help='Enable early maintenance screen detection - could be inaccurate, but will save on login time')
     parser.add_argument('-rrqk', '--redis_report_queue_key', default=None,
                         help='Redis key used to store reported value')
     parser.add_argument('-rrqi', '--redis_report_queue_interval', default=30, type=int,

--- a/mapadroid/worker/WorkerState.py
+++ b/mapadroid/worker/WorkerState.py
@@ -25,6 +25,7 @@ class WorkerState:
         self.active_account: Optional[SettingsPogoauth] = current_auth
         # Stores the time an account was last assigned. Avoid assigning accounts all the time
         self.active_account_last_set: int = 0
+        self.early_maintenance_detection: bool = False
         self.area_id: Optional[int] = None
 
         self.current_location: Optional[Location] = Location(0.0, 0.0)

--- a/mapadroid/worker/strategy/AbstractMitmBaseStrategy.py
+++ b/mapadroid/worker/strategy/AbstractMitmBaseStrategy.py
@@ -336,6 +336,7 @@ class AbstractMitmBaseStrategy(AbstractWorkerStrategy, ABC):
 
             # self._mitm_mapper.
             self._worker_state.restart_count = 0
+            self._worker_state.early_maintenance_detection = True
             logger.warning("Too many timeouts - Restarting game")
             await self._restart_pogo(True)
 

--- a/mapadroid/worker/strategy/AbstractMitmBaseStrategy.py
+++ b/mapadroid/worker/strategy/AbstractMitmBaseStrategy.py
@@ -353,6 +353,7 @@ class AbstractMitmBaseStrategy(AbstractWorkerStrategy, ABC):
         logger.debug('Routemanager: {}', self._area_id)
         logger.debug('Restart Counter: {}', self._worker_state.restart_count)
         logger.debug('Reboot Counter: {}', self._worker_state.reboot_count)
+        logger.debug('Early Maintenance Detection Flag: {}', self._worker_state.early_maintenance_detection)
         logger.debug('Reboot Option: {}',
                      await self.get_devicesettings_value(MappingManagerDevicemappingKey.REBOOT, True))
         if self._worker_state.current_location:
@@ -400,6 +401,7 @@ class AbstractMitmBaseStrategy(AbstractWorkerStrategy, ABC):
         logger.success('Received data')
         self._worker_state.reboot_count = 0
         self._worker_state.restart_count = 0
+        self._worker_state.early_maintenance_detection = False
         self._worker_state.last_received_data_time = DatetimeWrapper.now()
         now_ts: int = int(time.time())
         routemanager_settings = await self._mapping_manager.routemanager_get_settings(self._area_id)


### PR DESCRIPTION
Current flow with Maintenance detection forces MAD to re-log into account - so wasting time and PTC limits.

With this optional flag MAD will mark accounts as burnt ASAP after multiple proto timeouts ***and*** then seeing RETRY screen.
This could backfire if you have MAD locally and internet goes down (so no protos and retry screen) or when whole game is down so enable this only if you have a lot of spare accounts.