### PR TITLE
handle ConnectionError on MADdev API connections

### DIFF
--- a/mapadroid/mad_apk/utils.py
+++ b/mapadroid/mad_apk/utils.py
@@ -268,6 +268,9 @@ async def supported_pogo_version(architecture: APKArch, version: str, token: Opt
     except NoMaddevApiTokenError:
         logger.warning("Maddev API token is not set, assuming a supported version being used.")
         return True
+    except ConnectionError:
+        logger.warning("Error connecting to MADdev, assuming a supported version being used.")
+        return True
     if version in supported_versions.get(bits, []):
         return True
     # If the version is not supported, check the local
@@ -309,6 +312,9 @@ async def get_supported_pogo(architecture: APKArch, token: Optional[str]) -> Dic
         supported_versions: Dict[str, List[str]] = await get_backend_versions(token)
     except NoMaddevApiTokenError:
         logger.warning("Maddev API token is not set and no local version_codes.json defined.")
+        raise
+    except ConnectionError:
+        logger.warning("Error connecting to MADdev!")
         raise
     return await translate_pogo_versions(supported_versions)
 


### PR DESCRIPTION
* fixes /apk endpoint returning 500 when MADDev API is unreachable
* the actual error is already being logged during the `get_backend_versions` call by `RestHelper`

```
[04-16 09:59:16.53] [            utils] [   w.x.y.z] [         RestHelper:51  ] [W] Connecting to https://auth.maddev.eu/thirdparty/supported_versions failed: Cannot connect to host auth.maddev.eu:443 ssl:True [SSLCertVerificationError: (1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1129)')]
[04-16 09:59:11.53] [  package_manager] [   w.x.y.z] [              utils:272 ] [W] Error connecting to MADdev, assuming a supported version being used.
```

🙃 