### PR TITLE
Add skip_calculate flag to RouteManager.start_routemanager

### DIFF
--- a/mapadroid/mapping_manager/MappingManager.py
+++ b/mapadroid/mapping_manager/MappingManager.py
@@ -557,7 +557,7 @@ class MappingManager(AbstractMappingManager):
             return False
         try:
             try:
-                await routemanager.start_routemanager()
+                await routemanager.start_routemanager(skip_calculate=True)
             except RoutemanagerShuttingDown as e:
                 logger.warning("Unable to start routemanager for recalc: {}", e)
                 return False

--- a/mapadroid/route/RouteManagerBase.py
+++ b/mapadroid/route/RouteManagerBase.py
@@ -268,7 +268,7 @@ class RouteManagerBase(ABC):
             return
         self._coords_to_be_ignored.add(Location(lat, lon))
 
-    async def start_routemanager(self) -> bool:
+    async def start_routemanager(self, skip_calculate: bool = False) -> bool:
         """
         Starts priority queue or whatever the implementations require
         :return:
@@ -278,7 +278,8 @@ class RouteManagerBase(ABC):
                 self._is_started.set()
                 self._coords_to_be_ignored.clear()
                 logger.info("Starting routemanager {}", self.name)
-                await self.calculate_route(dynamic=False, overwrite_persisted_route=False)
+                if not skip_calculate:
+                    await self.calculate_route(dynamic=False, overwrite_persisted_route=False)
                 await self._start_priority_queue()
                 await self._start_check_routepools()
                 self._init_route_queue()

--- a/mapadroid/route/RouteManagerLeveling.py
+++ b/mapadroid/route/RouteManagerLeveling.py
@@ -143,7 +143,7 @@ class RouteManagerLeveling(RouteManagerBase):
 
         return await self._update_routepool()
 
-    async def start_routemanager(self):
+    async def start_routemanager(self, skip_calculate: bool = False):
         async with self._manager_mutex:
             if not self._is_started.is_set():
                 self._is_started.set()

--- a/mapadroid/route/RouteManagerQuests.py
+++ b/mapadroid/route/RouteManagerQuests.py
@@ -102,7 +102,7 @@ class RouteManagerQuests(SubrouteReplacingMixin, RouteManagerBase):
                 return False
             return True
 
-    async def start_routemanager(self):
+    async def start_routemanager(self, skip_calculate: bool = False):
         if self._shutdown_route.is_set():
             logger.info('Route is shutting down already.')
             return False
@@ -114,7 +114,8 @@ class RouteManagerQuests(SubrouteReplacingMixin, RouteManagerBase):
             logger.info("Starting routemanager")
             self._is_started.set()
 
-            await self.calculate_route(dynamic=True, overwrite_persisted_route=False)
+            if not skip_calculate:
+                await self.calculate_route(dynamic=True, overwrite_persisted_route=False)
             await self._start_check_routepools()
 
             logger.info('Getting {} positions in route', len(self._route))


### PR DESCRIPTION
Allows us to skip calculating the initial route when starting, so that calculation can be started separately (fixes #1289)

Currently `start_routemanager()` will always get a new route, which for quests will fail if all stops have been finished. As we're going to start calculation ourselves, we can skip the initial route.

This has been tested with quests, spawns, and raids by clearing the existing route and starting a recalc.