### PR TITLE
Tweaked tutorial OCR to work with 0.271.2

### DIFF
--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -576,6 +576,21 @@ class WordToScreenMatching(object):
         for _ in range(3):
             await self._communicator.click(int(self._width * 0.91), int(self._height * 0.94))
             await asyncio.sleep(2)
+
+        if not await self._take_screenshot(delay_before=await self.get_devicesettings_value(
+                MappingManagerDevicemappingKey.POST_SCREENSHOT_DELAY, 1),
+                                           delay_after=2):
+            logger.error("Failed getting screenshot")
+            return None
+
+        screenshot_path = await self.get_screenshot_path()
+        coordinates: Optional[ScreenCoordinates] = await self._worker_state.pogo_windows.look_for_button(
+            screenshot_path,
+            2.20, 3.01,
+            upper=True)
+        if coordinates:
+            await self._communicator.click(coordinates.x, coordinates.y)
+            await asyncio.sleep(5)
         await self._communicator.click(int(self._width * 0.91), int(self._height * 0.06))
         await asyncio.sleep(2)
 
@@ -593,6 +608,7 @@ class WordToScreenMatching(object):
         if coordinates:
             await self._communicator.click(coordinates.x, coordinates.y)
             await asyncio.sleep(5)
+
             return ScreenType.WILLOWCATCH
         return ScreenType.NOTRESPONDING
 

--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -576,6 +576,8 @@ class WordToScreenMatching(object):
         for _ in range(3):
             await self._communicator.click(int(self._width * 0.91), int(self._height * 0.94))
             await asyncio.sleep(2)
+        await self._communicator.click(int(self._width * 0.91), int(self._height * 0.06))
+            await asyncio.sleep(2)
 
         if not await self._take_screenshot(delay_before=await self.get_devicesettings_value(
                 MappingManagerDevicemappingKey.POST_SCREENSHOT_DELAY, 1),

--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -577,7 +577,7 @@ class WordToScreenMatching(object):
             await self._communicator.click(int(self._width * 0.91), int(self._height * 0.94))
             await asyncio.sleep(2)
         await self._communicator.click(int(self._width * 0.91), int(self._height * 0.06))
-		await asyncio.sleep(2)
+        await asyncio.sleep(2)
 
         if not await self._take_screenshot(delay_before=await self.get_devicesettings_value(
                 MappingManagerDevicemappingKey.POST_SCREENSHOT_DELAY, 1),

--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -577,7 +577,7 @@ class WordToScreenMatching(object):
             await self._communicator.click(int(self._width * 0.91), int(self._height * 0.94))
             await asyncio.sleep(2)
         await self._communicator.click(int(self._width * 0.91), int(self._height * 0.06))
-            await asyncio.sleep(2)
+		await asyncio.sleep(2)
 
         if not await self._take_screenshot(delay_before=await self.get_devicesettings_value(
                 MappingManagerDevicemappingKey.POST_SCREENSHOT_DELAY, 1),


### PR DESCRIPTION
0.271.2 has introduced a new step to character creation causing the device to reboot in the current state when completing the tutorial on a new account. This simple addition fixes that.

Note has not been tested on prior versions.