### PR TITLE
Use AccountHandler when getting account data, reason for switch_account/switch_user

### DIFF
--- a/mapadroid/account_handler/AbstractAccountHandler.py
+++ b/mapadroid/account_handler/AbstractAccountHandler.py
@@ -105,3 +105,7 @@ class AbstractAccountHandler(ABC):
 
         """
         pass
+
+    @abstractmethod
+    async def get_assignment(self, device_id: int) -> Optional[SettingsPogoauth]:
+        pass

--- a/mapadroid/account_handler/AccountHandler.py
+++ b/mapadroid/account_handler/AccountHandler.py
@@ -167,6 +167,13 @@ class AccountHandler(AbstractAccountHandler):
                 session, device_entry.device_id)
             return None if not currently_assigned else currently_assigned.username
 
+    async def get_assignment(self, device_id: int) -> Optional[SettingsPogoauth]:
+        async with self._db_wrapper as session, session:
+            current_auth = await SettingsPogoauthHelper.get_assigned_to_device(session, device_id)
+            if current_auth:
+                session.expunge(current_auth)
+            return current_auth
+
     def _is_burnt(self, auth: SettingsPogoauth) -> bool:
         """
         Evaluates whether a login is considered not usable based on the last known burning

--- a/mapadroid/websocket/WebsocketServer.py
+++ b/mapadroid/websocket/WebsocketServer.py
@@ -14,7 +14,6 @@ from mapadroid.data_handler.stats.AbstractStatsHandler import \
     AbstractStatsHandler
 from mapadroid.db.DbWrapper import DbWrapper
 from mapadroid.db.helper.SettingsDeviceHelper import SettingsDeviceHelper
-from mapadroid.db.helper.SettingsPogoauthHelper import SettingsPogoauthHelper
 from mapadroid.db.model import (AuthLevel, SettingsAuth, SettingsDevice,
                                 SettingsPogoauth)
 from mapadroid.mapping_manager.MappingManager import MappingManager
@@ -56,6 +55,7 @@ class WebsocketServer(object):
         self.__pogo_window_manager: PogoWindows = pogo_window_manager
         self.__mitm_mapper: AbstractMitmMapper = mitm_mapper
         self.__stats_handler: AbstractStatsHandler = stats_handler
+        self.__account_handler: AbstractAccountHandler = account_handler
         self.__enable_configmode: bool = enable_configmode
 
         # Event to signal that the server is to be stopped. Used to not accept new connections for example
@@ -177,10 +177,7 @@ class WebsocketServer(object):
                         entry.websocket_client_connection = websocket_client_connection
                     elif not entry:
                         async with self.__db_wrapper as session, session:
-                            current_auth: Optional[SettingsPogoauth] = await SettingsPogoauthHelper\
-                                .get_assigned_to_device(session, device_id)
-                            if current_auth:
-                                session.expunge(current_auth)
+                            current_auth: Optional[SettingsPogoauth] = await self.__account_handler.get_assignment(device_id)
                         # Just create a new entry...
                         worker_state: WorkerState = WorkerState(origin=origin,
                                                                 device_id=device_id,

--- a/mapadroid/worker/strategy/AbstractWorkerStrategy.py
+++ b/mapadroid/worker/strategy/AbstractWorkerStrategy.py
@@ -6,6 +6,7 @@ from typing import Any, List, Optional
 
 from loguru import logger
 
+from mapadroid.account_handler.AbstractAccountHandler import BurnType
 from mapadroid.data_handler.stats.AbstractStatsHandler import \
     AbstractStatsHandler
 from mapadroid.db.DbWrapper import DbWrapper
@@ -365,7 +366,7 @@ class AbstractWorkerStrategy(ABC):
                 await asyncio.sleep(300)
             elif screen_type == ScreenType.MAINTENANCE:
                 logger.warning("Maintenance screen - switch account ...")
-                await self._switch_user()
+                await self._switch_user(BurnType.MAINTENANCE.value)
             elif screen_type in [ScreenType.ERROR, ScreenType.FAILURE]:
                 logger.warning('Something wrong with screendetection or pogo failure screen')
                 self._worker_state.login_error_count += 1
@@ -410,7 +411,7 @@ class AbstractWorkerStrategy(ABC):
         await asyncio.sleep(1)
         return await self.start_pogo()
 
-    async def _switch_user(self):
+    async def _switch_user(self, reason=None):
         logger.info('Switching User - please wait ...')
         await self.stop_pogo()
         await asyncio.sleep(5)


### PR DESCRIPTION
Added some missing interactions with AbstractAccountHandler, added reason to switch_user/switch_account to easier work with an external accountHandler 