### PR TITLE
Fix dockerbuild CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Files and directories not required in a docker build
+APK/
+venv/
+logs/
+temp/
+files/
+upload/
+update_log.json
+docker/

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ libgl1-mesa-glx \
 && python3 -m pip install --no-cache-dir -r requirements.txt ortools redis \
 # cleanup
 && apt-get remove -y build-essential \
-&& apt-get remove -y python2.7 && rm -rf /usr/lib/python2.7 \
 && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The pipeline failed because the Dockerfile wanted to remove python2.7 which is apparently not installed in the base image anymore.
I included a .dockerignore file as well because we only had that for dev builds and not for the prod ones.