### PR TITLE
Bump apksearch version to latest, fixes wizard on python3.10+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ aiohttp-session==2.12.0
 aiomysql==0.2.0
 aiounittest==1.4.2
 alembic==1.11.1
-APKMirror-Search==1.0.0
+APKMirror-Search==1.0.1
 apkutils==1.5.1
 asyncio-rlock==0.1.0
 bitstring==4.0.2


### PR DESCRIPTION
The newest version brings python3.10+ compatibility, which fixes the wizard APK search on these python versions: https://github.com/Expl0dingBanana/apksearch/pull/4