### PR TITLE
Parse routes in legacy MAD

### DIFF
--- a/mapadroid/mitm_receiver/MITMReceiver.py
+++ b/mapadroid/mitm_receiver/MITMReceiver.py
@@ -269,7 +269,7 @@ class MITMReceiver(Process):
             origin_logger.warning("Could not read method ID. Stopping processing of proto")
             return
 
-        if proto_type not in (106, 102, 101, 104, 4, 156, 145):
+        if proto_type not in (106, 102, 101, 104, 4, 156, 145, 1405):
             # trash protos - ignoring
             return
 

--- a/mapadroid/mitm_receiver/SerializedMitmDataProcessor.py
+++ b/mapadroid/mitm_receiver/SerializedMitmDataProcessor.py
@@ -183,6 +183,11 @@ class SerializedMitmDataProcessor(Process):
                 self.__db_submit.gym(origin, data["payload"])
                 end_time = self.get_time_ms() - start_time
                 origin_logger.debug("Done processing proto 156 in {}ms", end_time)
+            elif data_type == 1405:
+                origin_logger.debug("Processing proto 1405 (GET_ROUTES)")
+                self.__db_submit.routes(origin, data['payload'], received_timestamp)
+                end_time = self.get_time_ms() - start_time
+                origin_logger.debug("Done processing proto 1405 in {}ms", end_time)
 
     @staticmethod
     def get_time_ms():


### PR DESCRIPTION
This code is backported from async. To receive Route protos, you must be running the latest legacy PD.

I did not create a DB migration for this. Just paste the table creation that you see in the code into mysql/mariadb.

I have not tested this exact code, as I run a modified version of legacy MAD. But I'm pretty confident this is fine.