### PR TITLE
Simplify clearing game data on NOGGL part

### DIFF
--- a/mapadroid/worker/strategy/AbstractWorkerStrategy.py
+++ b/mapadroid/worker/strategy/AbstractWorkerStrategy.py
@@ -316,11 +316,9 @@ class AbstractWorkerStrategy(ABC):
         screen_type: ScreenType = ScreenType.UNDEFINED
         while not self._worker_state.stop_worker_event.is_set():
             if self._worker_state.login_error_count > 2:
-                logger.warning('Could not login again - (clearing game data + restarting device')
+                logger.warning('Could not login again - clearing game data and restarting device')
                 await self.stop_pogo()
-                await self._communicator.clear_app_cache("com.nianticlabs.pokemongo")
-                if await self.get_devicesettings_value(MappingManagerDevicemappingKey.CLEAR_GAME_DATA, False):
-                    await self._clear_game_data()
+                await self._clear_game_data()
                 self._worker_state.login_error_count = 0
                 await self._reboot()
                 break


### PR DESCRIPTION
First of all totally dropping check if we have that enabled in device settings - we clear_game_data in million other places without this check so it seems useless plus there is no other way to recover from wrong birthday.

Also removing `clear_app_cache` as `_clear_game_data` does it already and no point it clearing app_cache twice :)