### PR TITLE
Change IP check service to IPv4 only, PTC does not work over IPv6

### DIFF
--- a/mapadroid/utils/walkerArgs.py
+++ b/mapadroid/utils/walkerArgs.py
@@ -368,7 +368,7 @@ def parse_args():
                         dest='autoconfig_no_auth')
 
     # PTC Login tracking
-    parser.add_argument('-ips', '--ip_service', default='http://ifconfig.me',
+    parser.add_argument('-ips', '--ip_service', default='http://checkip.amazonaws.com',
                         help=('Host to use to request the external IPv4 address of the device. '
                               'MAD will search for the first IPv4 address via regex.'))
     parser.add_argument('-elt', '--enable_login_tracking', action='store_true', default=False,


### PR DESCRIPTION
We don't want to get IPv6 addresses in IP check because it's gonna break the limits/count wrong if run on IPv6 enabled (prioritized) network. https://sso.pokemon.com/ does not support IPv4