### PR TITLE
DataTable'd pogoauth settings

### DIFF
--- a/static/madmin/templates/settings_pogoauth.html
+++ b/static/madmin/templates/settings_pogoauth.html
@@ -39,6 +39,10 @@ $(document).ready(function () {
     });
     // Toggle on boot
     toggleConfiguredElement();
+    $("#pogoauth_table").DataTable({
+         "pageLength": 50,
+         order: [[2, 'desc']]
+    });
   });
 
   function toggleConfiguredElement() {


### PR DESCRIPTION
50 results per page, sorted by device column desc (so accounts tied to devices first in results).
Plus as bonus we get searchbar :D 