### PR TITLE
Log exception for webhook worker

### DIFF
--- a/mapadroid/webhook/webhookworker.py
+++ b/mapadroid/webhook/webhookworker.py
@@ -120,6 +120,7 @@ class WebhookWorker:
                                        whcount_text, await mad_json_dumps(self.__payload_type_count(payload_chunk)))
                 except Exception as e:
                     logger.warning("Exception occured while sending webhook: {}", e)
+                    logger.exception(e)
 
                 current_pl_num += 1
             current_wh_num += 1


### PR DESCRIPTION
.warning sometimes shows empty message rather than actual error