### PR TITLE
Fix parse_resource typo in apkutils usage

### DIFF
--- a/mapadroid/mad_apk/utils.py
+++ b/mapadroid/mad_apk/utils.py
@@ -104,7 +104,7 @@ def get_apk_info(downloaded_file: io.BytesIO) -> Tuple[Optional[str], Optional[s
     package_version: Optional[str] = None
     package_name: Optional[str] = None
     try:
-        apk = apkutils.APK.from_io(downloaded_file).parse_resouce()
+        apk = apkutils.APK.from_io(downloaded_file).parse_resource()
     except Exception as e:  # noqa: E722 B001
         logger.warning('Unable to parse APK file')
         logger.exception(e)


### PR DESCRIPTION
Currently the wizard / manual uploading fails.