### PR TITLE
Sleep extra time when ProgressBar detected while trying to parse PTC page

### DIFF
--- a/mapadroid/ocr/screenPath.py
+++ b/mapadroid/ocr/screenPath.py
@@ -465,6 +465,10 @@ class WordToScreenMatching(object):
             exit_keyboard_y: int = 300
 
             for item in xmlroot.iter('node'):
+                if "android.widget.ProgressBar" in item.attrib["class"]:
+                    logger.warning("PTC page still loading, sleeping for extra 12 seconds")
+                    await asyncio.sleep(12)
+                    return ScreenType.PTC
                 if "Access denied" in item.attrib["text"]:
                     logger.warning("WAF on PTC login attempt detected")
                     # Reload the page 1-3 times


### PR DESCRIPTION
I've seen from time to time that MAD tries to parse PTC login page before it fully loads. ProgressBar seems to be part of Firefox UI for that so let's just sleep some time and try again later rather than restarting POGO/device.

@Grennith this is Firefox only, you added Chrome support too and no idea if that would work there. However that Chrome is probably on 1857815785187 times faster phones and it's not an issue there :D 