### PR TITLE
Filter out Mighty/Strong mons from Ditto detection logic

### DIFF
--- a/mapadroid/utils/gamemechanicutil.py
+++ b/mapadroid/utils/gamemechanicutil.py
@@ -262,6 +262,9 @@ def form_mapper(mon_id, form_id):
 def is_mon_ditto_raw(pokemon_data: pogoprotos.PokemonProto):
     logger.debug3('Determining if mon is a ditto')
     logger.debug4(pokemon_data)
+    if pokemon_data.pokemon_display.is_strong_pokemon:
+        logger.debug3('Strong/Mighty mon, skipping ditto check')
+        return False
     weather_boost = pokemon_data.pokemon_display.weather_boosted_condition
     valid_atk = pokemon_data.individual_attack < 4
     valid_def = pokemon_data.individual_defense < 4


### PR DESCRIPTION
Mighty/Strong mons have crazy levels (> 30, up to 50 in local in-person events) and some of those triggered Ditto check for "too high level for no weatherboost".